### PR TITLE
Adds support for managing specific files to be written for the Terraform provider

### DIFF
--- a/pkg/properties/provider_file.go
+++ b/pkg/properties/provider_file.go
@@ -1,7 +1,6 @@
 package properties
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/paloaltonetworks/pan-os-codegen/pkg/imports"


### PR DESCRIPTION
Adds support for managing specific files to be written for the Terraform provider.  I'm not sure these are the best names for this, so I'm open to suggestions.

fixes #58

The provider generator would do this:

```go
files := make(map[string] *properties.TerraformProviderFile)
```

Keys are the file name, and value is the provider file properties.

When the provider needs to add code to something:

```go
var pf *properties.TerraformProviderFile
if pf = files[filename]; pf == nil {
    pf = properties.NewTerraformProviderFile(filename)
}
```

Then after processing whatever code needs to be added at the end, save the provider file back to the map:


```go
files[filename] = pf
```

The contents of the code in the file is a `strings.Builder` which means that while the functions / sub-functions are generating the code, the generator code can just use the strings.Builder in the provider file directly.

All `NewXXX` names can be added to `pf.DataSources` or `pf.Resources` directly, and those can be sorted by `strings.Sort` before whatever template outputs the "provider.go" file if desired.

This PR does not include any validation of the functions or structs being appended to `TerraformProviderFile.Code` which I originally thought would be good to have, because I think validation of this probably belongs in whatever validation checker.