### PR TITLE
fix: generate usable pango example

### DIFF
--- a/assets/examples/go.mod
+++ b/assets/examples/go.mod
@@ -1,5 +1,0 @@
-// This file converts assets/examples/ into its own go module.
-//
-// This allows us to run commands like go get ./... in the project root
-// without getting errors about missing imports used by examples that
-// reference generated code.

--- a/assets/pango/example/main.go
+++ b/assets/pango/example/main.go
@@ -1,10 +1,12 @@
-package example
+package main
 
 import (
 	"context"
 	"encoding/xml"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"log/slog"
 
 	"github.com/PaloAltoNetworks/pango"
 	"github.com/PaloAltoNetworks/pango/device/services/dns"
@@ -36,6 +38,11 @@ func main() {
 		CheckEnvironment:      true,
 		SkipVerifyCertificate: true,
 		ApiKeyInRequest:       true,
+		Logging: &pango.LoggingInfo{
+			LogCategories: pango.LogCategoryPango,
+			SLogHandler:   slog.NewTextHandler(ioutil.Discard, nil),
+			LogLevel:      slog.LevelDebug,
+		},
 	}
 	if err = c.Setup(); err != nil {
 		log.Printf("Failed to setup client: %s", err)


### PR DESCRIPTION
## Description

1. Move pango example back under `assets/pango`.
2. Fix example code to utilize new logging framework.

## Motivation and Context

Provide code that allows to run integration tests for pango-level changes.

## How Has This Been Tested?

Run generator, run example, run tests.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
