### PR TITLE
fix: Default log level handling

### DIFF
--- a/assets/pango/client.go
+++ b/assets/pango/client.go
@@ -30,7 +30,7 @@ type LoggingInfo struct {
 	SLogHandler   slog.Handler `json:"-"`
 	LogCategories LogCategory  `json:"-"`
 	LogSymbols    []string     `json:"log_symbols"`
-	LogLevel      slog.Leveler `json:"log_level"`
+	LogLevel      slog.Level   `json:"log_level"`
 }
 
 // Client is an XML API client connection.  If provides wrapper functions
@@ -46,7 +46,7 @@ type Client struct {
 	Target          string            `json:"target"`
 	ApiKeyInRequest bool              `json:"api_key_in_request"`
 	Headers         map[string]string `json:"headers"`
-	Logging         *LoggingInfo      `json:"logging"`
+	Logging         LoggingInfo       `json:"logging"`
 
 	// Set to true if you want to check environment variables
 	// for auth and connection properties.
@@ -1003,7 +1003,7 @@ func (c *Client) GetTechSupportFile(ctx context.Context) (string, []byte, error)
 // Internal functions.
 //
 
-func (c *Client) setupLogging(logging *LoggingInfo) error {
+func (c *Client) setupLogging(logging LoggingInfo) error {
 	var logger *slog.Logger
 
 	if logging.SLogHandler == nil {
@@ -1011,7 +1011,7 @@ func (c *Client) setupLogging(logging *LoggingInfo) error {
 		logger.Info("No slog handler provided, creating default os.Stderr handler.", "LogLevel", logging.LogLevel.Level())
 	} else {
 		logger = slog.New(logging.SLogHandler)
-		if logging.LogLevel != nil {
+		if logging.LogLevel != 0 {
 			logger.Warn("LogLevel is ignored when using custom SLog handler.")
 		}
 	}

--- a/assets/pango/example/main.go
+++ b/assets/pango/example/main.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"log"
-	"log/slog"
 
 	"github.com/PaloAltoNetworks/pango"
 	"github.com/PaloAltoNetworks/pango/device/services/dns"
@@ -38,11 +36,6 @@ func main() {
 		CheckEnvironment:      true,
 		SkipVerifyCertificate: true,
 		ApiKeyInRequest:       true,
-		Logging: &pango.LoggingInfo{
-			LogCategories: pango.LogCategoryPango,
-			SLogHandler:   slog.NewTextHandler(ioutil.Discard, nil),
-			LogLevel:      slog.LevelDebug,
-		},
 	}
 	if err = c.Setup(); err != nil {
 		log.Printf("Failed to setup client: %s", err)


### PR DESCRIPTION
## Description

Handle cases when Client does not have Logging explicitly set, which right now results in "invalid memory address or nil pointer dereference" runtime error in setupLogging function.

## Motivation and Context

Bug fix.

## How Has This Been Tested?

Generate code, run pango example, run terraform sample code.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
