### PR TITLE
feat: Use full XPaths for config "set" operations

### DIFF
--- a/assets/pango/xml/utils.go
+++ b/assets/pango/xml/utils.go
@@ -1,0 +1,15 @@
+package xml
+
+import "bytes"
+
+func StripEntryElement(data []byte) []byte {
+	if !bytes.HasPrefix(data, []byte("<entry")) || !bytes.HasSuffix(data, []byte("</entry>")) {
+		return data
+	}
+
+	var startIdx, endIdx int
+	startIdx = bytes.Index(data, []byte(">"))
+	endIdx = len(data) - len("</entry>")
+
+	return data[startIdx+1 : endIdx]
+}

--- a/pkg/translate/imports.go
+++ b/pkg/translate/imports.go
@@ -30,10 +30,12 @@ func RenderImports(templateTypes ...string) (string, error) {
 			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/version", "")
 		case "service":
 			manager.AddStandardImport("context", "")
+			manager.AddStandardImport("encoding/xml", "")
 			manager.AddStandardImport("fmt", "")
 			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/errors", "")
 			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/util", "")
 			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/xmlapi", "")
+			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/xml", "pangoxml")
 		case "filtering":
 			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/filtering", "")
 		case "audit":

--- a/templates/sdk/service.tmpl
+++ b/templates/sdk/service.tmpl
@@ -56,12 +56,16 @@ return nil, err
 
 {{- if .Entry}}
     path, err := loc.XpathWithEntryName(vn, entry.Name)
+    if err != nil {
+        return nil, err
+    }
 {{- else}}
     path, err := loc.Xpath(vn)
+    if err != nil {
+        return nil, err
+    }
+    path = path[:len(path)-1]
 {{- end}}
-if err != nil {
-return nil, err
-}
 
 {{- if .Entry}}
     createSpec, err := specifier(entry)
@@ -72,10 +76,21 @@ if err != nil {
 return nil, err
 }
 
+data, err := xml.Marshal(createSpec)
+if err != nil {
+	return nil, err
+}
+
+// Optionally remove top entry element from marshalled data to fullfill
+// PAN-OS API requirements.
+// PAN-OS behaviour change: SET operations in the XML API no longer support
+// partial XPath values.
+data = pangoxml.StripEntryElement(data)
+
 cmd := &xmlapi.Config{
 Action:  "set",
-Xpath:   util.AsXpath(path[:len(path)-1]),
-Element: createSpec,
+Xpath:   util.AsXpath(path),
+Element: string(data),
 Target:  s.client.GetTarget(),
 }
 


### PR DESCRIPTION
## Description

When sending config "set" operations to PAN-OS, remove wrapping `<entry></entry>`
elements and use full XPath for the entry instead.

## Motivation and Context

Support for partial XPaths has been removed in PAN-OS 11.0.3-h3, and
full XPaths are supported across all PAN-OS versions we're targetting.
