### PR TITLE
feat: Add support for computed and optional & computed attributes

### DIFF
--- a/pkg/properties/normalized.go
+++ b/pkg/properties/normalized.go
@@ -110,19 +110,20 @@ type ConstValue struct {
 }
 
 type SpecParam struct {
-	Name        *NameVariant
-	Description string              `json:"description" yaml:"description"`
-	Type        string              `json:"type" yaml:"type"`
-	Default     string              `json:"default" yaml:"default"`
-	Required    bool                `json:"required" yaml:"required"`
-	Sensitive   bool                `json:"sensitive" yaml:"sensitive"`
-	Length      *SpecParamLength    `json:"length" yaml:"length,omitempty"`
-	Count       *SpecParamCount     `json:"count" yaml:"count,omitempty"`
-	Hashing     *SpecParamHashing   `json:"hashing" yaml:"hashing,omitempty"`
-	Items       *SpecParamItems     `json:"items" yaml:"items,omitempty"`
-	Regex       string              `json:"regex" yaml:"regex,omitempty"`
-	Profiles    []*SpecParamProfile `json:"profiles" yaml:"profiles"`
-	Spec        *Spec               `json:"spec" yaml:"spec"`
+	Name                    *NameVariant
+	Description             string                            `json:"description" yaml:"description"`
+	TerraformProviderConfig *SpecParamTerraformProviderConfig `json:"terraform_provider_config" yaml:"terraform_provider_config"`
+	Type                    string                            `json:"type" yaml:"type"`
+	Default                 string                            `json:"default" yaml:"default"`
+	Required                bool                              `json:"required" yaml:"required"`
+	Sensitive               bool                              `json:"sensitive" yaml:"sensitive"`
+	Length                  *SpecParamLength                  `json:"length" yaml:"length,omitempty"`
+	Count                   *SpecParamCount                   `json:"count" yaml:"count,omitempty"`
+	Hashing                 *SpecParamHashing                 `json:"hashing" yaml:"hashing,omitempty"`
+	Items                   *SpecParamItems                   `json:"items" yaml:"items,omitempty"`
+	Regex                   string                            `json:"regex" yaml:"regex,omitempty"`
+	Profiles                []*SpecParamProfile               `json:"profiles" yaml:"profiles"`
+	Spec                    *Spec                             `json:"spec" yaml:"spec"`
 }
 
 type SpecParamLength struct {
@@ -137,6 +138,10 @@ type SpecParamCount struct {
 
 type SpecParamHashing struct {
 	Type string `json:"type" yaml:"type"`
+}
+
+type SpecParamTerraformProviderConfig struct {
+	Computed bool `json:"computed" yaml:"computed"`
 }
 
 type SpecParamItems struct {

--- a/pkg/translate/terraform_provider/funcs.go
+++ b/pkg/translate/terraform_provider/funcs.go
@@ -776,11 +776,22 @@ func createSchemaSpecForParameter(typ schemaType, structPrefix string, packageNa
 			LowerCamelCase: naming.CamelCase("", "name", "", false),
 		}
 
+		var computed, optional bool
+		if param.TerraformProviderConfig != nil {
+			computed = param.TerraformProviderConfig.Computed
+			optional = !computed
+		} else if param.Default != "" {
+			computed = true
+			optional = true
+		}
+
 		attributes = append(attributes, attributeCtx{
 			Package:    packageName,
 			Name:       name,
 			SchemaType: "StringAttribute",
 			Required:   true,
+			Computed:   computed,
+			Optional:   optional,
 		})
 	}
 
@@ -859,6 +870,15 @@ func createSchemaAttributeForParameter(typ schemaType, packageName string, param
 		}
 	}
 
+	var optional, computed bool
+	if param.TerraformProviderConfig != nil {
+		computed = param.TerraformProviderConfig.Computed
+		optional = !computed
+	} else if param.Default != "" {
+		optional = true
+		computed = true
+	}
+
 	return attributeCtx{
 		Package:     packageName,
 		Name:        param.Name,
@@ -866,10 +886,10 @@ func createSchemaAttributeForParameter(typ schemaType, packageName string, param
 		ElementType: elementType,
 		Description: param.Description,
 		Required:    param.Required,
-		Optional:    !param.Required,
+		Optional:    optional,
 		Sensitive:   param.Sensitive,
 		Default:     defaultValue,
-		Computed:    param.Default != "",
+		Computed:    computed,
 	}
 }
 

--- a/specs/network/interface/ethernet.yaml
+++ b/specs/network/interface/ethernet.yaml
@@ -200,12 +200,6 @@ spec:
                       type: object
                       spec:
                         params:
-                          - name: name
-                            type: string
-                            profiles:
-                              - xpath: []
-                            spec:
-                              required: true
                           - name: enable-on-interface
                             type: bool
                             profiles:

--- a/specs/network/interface/loopback.yaml
+++ b/specs/network/interface/loopback.yaml
@@ -128,12 +128,6 @@ spec:
                 type: object
                 spec:
                   params:
-                    - name: name
-                      type: string
-                      profiles:
-                        - xpath: []
-                      spec:
-                        required: true
                     - name: enable-on-interface
                       type: bool
                       profiles:


### PR DESCRIPTION
Terraform has a concept of optional attributes, where optional attributes can be left null, and will use default values.
Another concept is computed attributes - attributes that are set by the provider and cannot be changed by the user.
Finally, optional attributes must be marked as computed.

This change adds a way to mark some parameters in the specification as computed (e.g. uuid parameters) and properly marks attributes with default values as optional+computed.