### PR TITLE
bug: Missing sensitive attribute

### DIFF
--- a/pkg/properties/normalized.go
+++ b/pkg/properties/normalized.go
@@ -388,8 +388,11 @@ func schemaParameterToSpecParameter(schemaSpec *parameter.Parameter) (*SpecParam
 			Type: schemaSpec.Hashing.Type,
 		}
 	}
+
+	var sensitive bool
 	var terraformProviderConfig *SpecParamTerraformProviderConfig
 	if schemaSpec.CodegenOverrides != nil {
+		sensitive = schemaSpec.CodegenOverrides.Terraform.Sensitive
 		terraformProviderConfig = &SpecParamTerraformProviderConfig{
 			Computed: schemaSpec.CodegenOverrides.Terraform.Computed,
 		}
@@ -399,6 +402,7 @@ func schemaParameterToSpecParameter(schemaSpec *parameter.Parameter) (*SpecParam
 		Type:                    specType,
 		Default:                 defaultVal,
 		Required:                schemaSpec.Required,
+		Sensitive:               sensitive,
 		TerraformProviderConfig: terraformProviderConfig,
 		Hashing:                 specHashing,
 		Profiles:                profiles,

--- a/pkg/schema/parameter/parameter.go
+++ b/pkg/schema/parameter/parameter.go
@@ -43,7 +43,8 @@ type EnumSpecValue struct {
 }
 
 type CodegenOverridesTerraform struct {
-	Computed bool `yaml:"computed"`
+	Sensitive bool `yaml:"sensitive"`
+	Computed  bool `yaml:"computed"`
 }
 
 type CodegenOverrides struct {


### PR DESCRIPTION
During merge of the PR I've dropped translation of sensitive from spec to terraform provider. Re-adding it.