### PR TITLE
fix: Make generated code compile with go 1.22

### DIFF
--- a/assets/pango/go.mod
+++ b/assets/pango/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaloAltoNetworks/pango
 
-go 1.22
+go 1.22.5
 
 require (
 	github.com/onsi/ginkgo/v2 v2.19.0

--- a/assets/terraform/go.mod
+++ b/assets/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaloAltoNetworks/terraform-provider-panos
 
-go 1.22
+go 1.22.5
 
 require (
 	github.com/PaloAltoNetworks/pango v0.10.3-0.20240408115758-216d8509e7cf


### PR DESCRIPTION
## Description

Update assets go.mod files to fix generated code build.

## Motivation and Context

Currently the generated code cannot be built, following error is returned for both pango and provider:
```
$ go build
go: downloading go1.22 (linux/amd64)
go: download go1.22 for linux/amd64: toolchain not available
```

## How Has This Been Tested?

Build/install generated code.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
