### PR TITLE
feat: Add schema validation for variants

### DIFF
--- a/pkg/properties/normalized.go
+++ b/pkg/properties/normalized.go
@@ -99,6 +99,14 @@ type Location struct {
 	Vars        map[string]*LocationVar `json:"vars" yaml:"vars"`
 }
 
+func (o Location) ValidatorType() string {
+	if len(o.Vars) == 0 {
+		return "bool"
+	} else {
+		return "object"
+	}
+}
+
 type LocationDevice struct {
 	Panorama bool `json:"panorama" yaml:"panorama"`
 	Ngfw     bool `json:"ngfw" yaml:"ngfw"`

--- a/pkg/translate/terraform_provider/terraform_provider_file.go
+++ b/pkg/translate/terraform_provider/terraform_provider_file.go
@@ -314,9 +314,11 @@ func (g *GenerateTerraformProvider) GenerateTerraformDataSource(resourceTyp prop
 func (g *GenerateTerraformProvider) GenerateCommonCode(resourceTyp properties.ResourceType, spec *properties.Normalization, terraformProvider *properties.TerraformProviderFile) error {
 	names := NewNameProvider(spec, resourceTyp)
 	funcMap := template.FuncMap{
-		"RenderLocationStructs":      func() (string, error) { return RenderLocationStructs(resourceTyp, names, spec) },
-		"RenderLocationSchemaGetter": func() (string, error) { return RenderLocationSchemaGetter(names, spec) },
-		"RenderCustomCommonCode":     func() string { return RenderCustomCommonCode(names, spec) },
+		"RenderLocationStructs": func() (string, error) { return RenderLocationStructs(resourceTyp, names, spec) },
+		"RenderLocationSchemaGetter": func() (string, error) {
+			return RenderLocationSchemaGetter(names, spec, terraformProvider.ImportManager)
+		},
+		"RenderCustomCommonCode": func() string { return RenderCustomCommonCode(names, spec) },
 	}
 	return g.generateTerraformEntityTemplate("Common", names, spec, terraformProvider, commonTemplate, funcMap)
 }
@@ -411,7 +413,7 @@ func conditionallyAddValidators(manager *imports.Manager, spec *properties.Norma
 		return hasVariantsImpl(params)
 	}
 
-	if hasVariants() {
+	if hasVariants() || len(spec.Locations) > 1 {
 		manager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/path", "")
 		manager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/schema/validator", "")
 	}


### PR DESCRIPTION
## Description

This enhance provider codegen to add validators for variants in order to ensure that only one
variant can be set at the same time. 

## Motivation and Context

There is already validation for that in the SDK, but this happens too late, during execution of the plan.
This change allows us to move validation into plan generation phase.
