### PR TITLE
chore: fix iota

### DIFF
--- a/assets/pango/logging.go
+++ b/assets/pango/logging.go
@@ -33,8 +33,8 @@ const (
 	LogCategoryCurl
 	LogCategoryAll = LogCategoryPango | LogCategoryOp | LogCategorySend |
 		LogCategoryReceive | LogCategoryCurl
-	// Make sure that LogCategorySensitive is always last, explicitly set to 1 << 32
-	LogCategorySensitive LogCategory = 1 << 32
+	// Make sure that LogCategorySensitive is always last, explicitly set to 1 << 16
+	LogCategorySensitive LogCategory = 1 << 16
 )
 
 var logCategoryToString = map[LogCategory]string{


### PR DESCRIPTION
## Description

Terraform provider build for goos `freebsd` goarch `arm`fails when untyped int constant 4294967296 is in use

```
  ⨯ release failed after 12s                 error=failed to build for freebsd_arm_6: exit status 1: # github.com/PaloAltoNetworks/pango
../pango/logging.go:37:37: cannot use 1 << 32 (untyped int constant 4294967296) as LogCategory value in constant declaration (overflows)
```

## Motivation and Context

https://github.com/PaloAltoNetworks/terraform-provider-panos/actions/runs/10835988398/job/30068711510

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
