### PR TITLE
feat: Defer retrieval of system info and plugin data

### DIFF
--- a/assets/pango/client.go
+++ b/assets/pango/client.go
@@ -61,7 +61,7 @@ type Client struct {
 	// Variables determined at runtime.
 	Version    version.Number    `json:"-"`
 	systemInfo map[string]string `json:"-"`
-	plugin     []plugin.Info     `json:"-"`
+	plugins     []plugin.Info     `json:"-"`
 
 	// Internal variables.
 	con        *http.Client

--- a/assets/pango/client.go
+++ b/assets/pango/client.go
@@ -60,8 +60,8 @@ type Client struct {
 
 	// Variables determined at runtime.
 	Version    version.Number    `json:"-"`
-	SystemInfo map[string]string `json:"-"`
-	Plugin     []plugin.Info     `json:"-"`
+	systemInfo map[string]string `json:"-"`
+	plugin     []plugin.Info     `json:"-"`
 
 	// Internal variables.
 	con        *http.Client
@@ -81,9 +81,24 @@ func (c *Client) Versioning() version.Number {
 	return c.Version
 }
 
-// Plugins returns the list of plugins.
-func (c *Client) Plugins() []plugin.Info {
-	return c.Plugin
+func (c *Client) SystemInfo(ctx context.Context) (map[string]string, error) {
+	if c.systemInfo == nil {
+		if err := c.RetrieveSystemInfo(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	return c.systemInfo, nil
+}
+
+func (c *Client) Plugins(ctx context.Context) ([]plugin.Info, error) {
+	if c.plugin == nil {
+		if err := c.RetrievePlugins(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	return c.plugin, nil
 }
 
 // GetTarget returns the Target param, used in certain API calls.
@@ -93,11 +108,11 @@ func (c *Client) GetTarget() string {
 
 // IsPanorama returns true if this is Panorama.
 func (c *Client) IsPanorama() (bool, error) {
-	if len(c.SystemInfo) == 0 {
+	if len(c.systemInfo) == 0 {
 		return false, fmt.Errorf("SystemInfo is nil")
 	}
 
-	model, ok := c.SystemInfo["model"]
+	model, ok := c.systemInfo["model"]
 	if !ok {
 		return false, fmt.Errorf("model not present in SystemInfo")
 	}
@@ -314,14 +329,6 @@ func (c *Client) Initialize(ctx context.Context) error {
 		}
 	}
 
-	if err = c.RetrieveSystemInfo(ctx); err != nil {
-		return err
-	}
-
-	if err = c.RetrievePlugins(ctx); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -352,12 +359,12 @@ func (c *Client) RetrieveSystemInfo(ctx context.Context) error {
 		return err
 	}
 
-	c.SystemInfo = make(map[string]string, len(ans.System.Tags))
+	c.systemInfo = make(map[string]string, len(ans.System.Tags))
 	for _, t := range ans.System.Tags {
 		if t.TrimmedText == nil {
 			continue
 		}
-		c.SystemInfo[t.XMLName.Local] = *t.TrimmedText
+		c.systemInfo[t.XMLName.Local] = *t.TrimmedText
 		if t.XMLName.Local == "sw-version" {
 			c.Version, err = version.New(*t.TrimmedText)
 			if err != nil {
@@ -453,7 +460,7 @@ func (c *Client) RetrievePlugins(ctx context.Context) error {
 		return err
 	}
 
-	c.Plugin = ans.Listing()
+	c.plugin = ans.Listing()
 
 	return nil
 }

--- a/assets/pango/util/pangoclient.go
+++ b/assets/pango/util/pangoclient.go
@@ -15,7 +15,7 @@ import (
 type PangoClient interface {
 	// Basics.
 	Versioning() version.Number
-	Plugins() []plugin.Info
+	Plugins(context.Context) ([]plugin.Info, error)
 	GetTarget() string
 	IsPanorama() (bool, error)
 	IsFirewall() (bool, error)


### PR DESCRIPTION
Retrieving both SystemInfo and Plugins during Initialize() call slows down client setup, which can lead to large slow down for some operations (e.g. terraform provider tests run twice as long due to that).
This commit defers initialization of both to when data is accessed by calling new SystemInfo() and Plugins() methods. The old behavior can still be done when needed by explicitly calling RetrieveSystemInfo() and RetrievePlugins() after a call to Initialize().