### PR TITLE
feat: Add resource-level description to specifications

### DIFF
--- a/pkg/properties/normalized.go
+++ b/pkg/properties/normalized.go
@@ -65,6 +65,7 @@ const (
 )
 
 type TerraformProviderConfig struct {
+	Description           string                     `json:"description" yaml:"description"`
 	SkipResource          bool                       `json:"skip_resource" yaml:"skip_resource"`
 	SkipDatasource        bool                       `json:"skip_datasource" yaml:"skip_datasource"`
 	SkipDatasourceListing bool                       `json:"skip_datasource_listing" yaml:"skip_datasource_listing"`
@@ -528,6 +529,7 @@ func schemaToSpec(object object.Object) (*Normalization, error) {
 	spec := &Normalization{
 		Name: object.DisplayName,
 		TerraformProviderConfig: TerraformProviderConfig{
+			Description:           object.TerraformConfig.Description,
 			SkipResource:          object.TerraformConfig.SkipResource,
 			SkipDatasource:        object.TerraformConfig.SkipDatasource,
 			SkipDatasourceListing: object.TerraformConfig.SkipdatasourceListing,

--- a/pkg/schema/object/object.go
+++ b/pkg/schema/object/object.go
@@ -26,6 +26,7 @@ const (
 )
 
 type TerraformConfig struct {
+	Description           string                     `yaml:"description"`
 	SkipResource          bool                       `yaml:"skip_resource"`
 	SkipDatasource        bool                       `yaml:"skip_datasource"`
 	SkipdatasourceListing bool                       `yaml:"skip_datasource_listing"`

--- a/specs/schema/object.schema.json
+++ b/specs/schema/object.schema.json
@@ -20,6 +20,7 @@
       "additionalProperties": false,
       "required": ["suffix"],
       "properties": {
+        "description": { "type": "string" },
         "resource_type": {
           "type": "string",
           "enum": ["entry", "config", "uuid", "custom"]


### PR DESCRIPTION
Add resource-level descriptions for the terraform provider. This is mainly used for documentation.

Closes: #159 