### PR TITLE
fix(specs/security-policy-rule): Drop unused locations variable

### DIFF
--- a/specs/policies/security-policy-rule.yaml
+++ b/specs/policies/security-policy-rule.yaml
@@ -61,13 +61,6 @@ locations:
                 values:
                   - value: "shared"
                     error: 'The vsys cannot be "shared". Use the "shared" path instead.'
-        - name: "rulebase"
-          description: "The rulebase."
-          default: "pre-rulebase"
-          validators:
-            - type: values
-              spec:
-                values: ["post-rulebase", "pre-rulebase"]
   - name: "from_panorama_vsys"
     description: "Located in a specific vsys in the config pushed from Panorama."
     read_only: true


### PR DESCRIPTION
## Description

Remove unused variable for `vsys` location in security policy rule spec.

## Motivation and Context

bugfix

## How Has This Been Tested?

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
