### PR TITLE
feat: Add a list/map description for list resources.

### DIFF
--- a/pkg/properties/normalized.go
+++ b/pkg/properties/normalized.go
@@ -75,6 +75,7 @@ type TerraformProviderConfig struct {
 	Suffix                string                     `json:"suffix" yaml:"suffix"`
 	PluralSuffix          string                     `json:"plural_suffix" yaml:"plural_suffix"`
 	PluralName            string                     `json:"plural_name" yaml:"plural_name"`
+	PluralDescription     string                     `json:"plural_description" yaml:"plural_description"`
 }
 
 type NameVariant struct {
@@ -555,6 +556,7 @@ func schemaToSpec(object object.Object) (*Normalization, error) {
 			Suffix:                object.TerraformConfig.Suffix,
 			PluralSuffix:          object.TerraformConfig.PluralSuffix,
 			PluralName:            object.TerraformConfig.PluralName,
+			PluralDescription:     object.TerraformConfig.PluralDescription,
 		},
 		Locations:   make(map[string]*Location),
 		GoSdkSkip:   object.GoSdkConfig.Skip,

--- a/pkg/schema/object/object.go
+++ b/pkg/schema/object/object.go
@@ -36,6 +36,7 @@ type TerraformConfig struct {
 	Suffix                string                     `yaml:"suffix"`
 	PluralSuffix          string                     `yaml:"plural_suffix"`
 	PluralName            string                     `yaml:"plural_name"`
+	PluralDescription     string                     `yaml:"plural_description"`
 }
 
 type GoSdkConfig struct {

--- a/pkg/translate/terraform_provider/funcs.go
+++ b/pkg/translate/terraform_provider/funcs.go
@@ -1181,10 +1181,11 @@ func createSchemaSpecForUuidModel(resourceTyp properties.ResourceType, schemaTyp
 	}
 
 	attributes = append(attributes, attributeCtx{
-		Package:    packageName,
-		Name:       listName,
-		Required:   true,
-		SchemaType: "ListNestedAttribute",
+		Package:     packageName,
+		Name:        listName,
+		Required:    true,
+		Description: spec.TerraformProviderConfig.PluralDescription,
+		SchemaType:  "ListNestedAttribute",
 	})
 
 	var isResource bool
@@ -1302,10 +1303,11 @@ func createSchemaSpecForEntryListModel(resourceTyp properties.ResourceType, sche
 	}
 
 	attributes = append(attributes, attributeCtx{
-		Package:    packageName,
-		Name:       listName,
-		Required:   true,
-		SchemaType: "MapNestedAttribute",
+		Package:     packageName,
+		Name:        listName,
+		Description: spec.TerraformProviderConfig.PluralDescription,
+		Required:    true,
+		SchemaType:  "MapNestedAttribute",
 	})
 
 	var isResource bool

--- a/specs/schema/object.schema.json
+++ b/specs/schema/object.schema.json
@@ -47,7 +47,8 @@
           "type": "string"
         },
         "plural_suffix": { "type": "string" },
-        "plural_name": { "type": "string" }
+        "plural_name": { "type": "string" },
+        "plural_description": { "type": "string" }
       }
     },
     "go_sdk_config": {


### PR DESCRIPTION
When creating list resources (e.g. panos_addresses, panos_security_policy), PANOS objects are nested within a list/map attribute, but this attribute has no description. This PR allows us to add descriptions to those attributes.

Closes: #144 
