### PR TITLE
fix(specs/schema): Add missing name property in terraform overrides

### DIFF
--- a/specs/schema/spec.schema.json
+++ b/specs/schema/spec.schema.json
@@ -28,6 +28,7 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
+                "name": { "type": "string" },
                 "private": { "type": "booleanf" },
                 "computed": { "type": "boolean" },
                 "sensitive": { "type": "boolean" }


### PR DESCRIPTION
## Description

Add missing `name` property for `codegen_overrides.terraform` in specs schema.

## Motivation and Context

Make valid specs pass schema check.

## How Has This Been Tested?

Run schema check.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
