### PR TITLE
feat: Add terraform acceptance tests for the handwritten specs

### DIFF
--- a/assets/terraform/test/resource_addresses_test.go
+++ b/assets/terraform/test/resource_addresses_test.go
@@ -1,0 +1,177 @@
+package provider_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	sdkErrors "github.com/PaloAltoNetworks/pango/errors"
+	"github.com/PaloAltoNetworks/pango/objects/address"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccAddresses(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccAddressesDestroy(prefix),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAddressesResourceTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+					"addresses": config.MapVariable(map[string]config.Variable{
+						fmt.Sprintf("%s-ip-netmask", prefix): config.ObjectVariable(map[string]config.Variable{
+							"tags":       config.ListVariable(config.StringVariable(fmt.Sprintf("%s-tag", prefix))),
+							"ip_netmask": config.StringVariable("172.16.0.1/32"),
+						}),
+						fmt.Sprintf("%s-ip-range", prefix): config.ObjectVariable(map[string]config.Variable{
+							"description": config.StringVariable("description"),
+							"ip_range":    config.StringVariable("172.16.0.1-172.16.0.255"),
+						}),
+						fmt.Sprintf("%s-ip-wildcard", prefix): config.ObjectVariable(map[string]config.Variable{
+							"ip_wildcard": config.StringVariable("172.16.0.0/0.0.0.255"),
+						}),
+						fmt.Sprintf("%s-fqdn", prefix): config.ObjectVariable(map[string]config.Variable{
+							"fqdn": config.StringVariable("example.com"),
+						}),
+					}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_addresses.addresses",
+						tfjsonpath.
+							New("addresses").
+							AtMapKey(fmt.Sprintf("%s-ip-netmask", prefix)).
+							AtMapKey("ip_netmask"),
+						knownvalue.StringExact("172.16.0.1/32"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_addresses.addresses",
+						tfjsonpath.
+							New("addresses").
+							AtMapKey(fmt.Sprintf("%s-ip-netmask", prefix)).
+							AtMapKey("tags"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact(fmt.Sprintf("%s-tag", prefix)),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_addresses.addresses",
+						tfjsonpath.
+							New("addresses").
+							AtMapKey(fmt.Sprintf("%s-ip-range", prefix)).
+							AtMapKey("description"),
+						knownvalue.StringExact("description"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_addresses.addresses",
+						tfjsonpath.
+							New("addresses").
+							AtMapKey(fmt.Sprintf("%s-ip-range", prefix)).
+							AtMapKey("ip_range"),
+						knownvalue.StringExact("172.16.0.1-172.16.0.255"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_addresses.addresses",
+						tfjsonpath.
+							New("addresses").
+							AtMapKey(fmt.Sprintf("%s-ip-wildcard", prefix)).
+							AtMapKey("ip_wildcard"),
+						knownvalue.StringExact("172.16.0.0/0.0.0.255"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_addresses.addresses",
+						tfjsonpath.
+							New("addresses").
+							AtMapKey(fmt.Sprintf("%s-fqdn", prefix)).
+							AtMapKey("fqdn"),
+						knownvalue.StringExact("example.com"),
+					),
+				},
+			},
+		},
+	})
+}
+
+const testAccAddressesResourceTmpl = `
+variable prefix { type = string }
+variable "addresses" {
+  type = map(object({
+    disable_override = optional(bool),
+    description = optional(string),
+    ip_netmask = optional(string),
+    ip_range = optional(string),
+    ip_wildcard = optional(string),
+    fqdn = optional(string),
+    tags = optional(list(string)),
+  }))
+}
+
+resource "panos_administrative_tag" "tag" {
+  location = { shared = true }
+
+  name = format("%s-tag", var.prefix)
+}
+
+resource "panos_addresses" "addresses" {
+  depends_on = [ resource.panos_administrative_tag.tag ]
+
+  location = { shared = true }
+
+  addresses = { for name, value in var.addresses : name => {
+    disable_override = value.disable_override,
+    description = value.description,
+    ip_netmask = value.ip_netmask,
+    ip_range = value.ip_range,
+    fqdn = value.fqdn,
+    ip_wildcard = value.ip_wildcard,
+    tags = value.tags
+  }}
+}
+`
+
+func testAccAddressesDestroy(prefix string) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		api := address.NewService(sdkClient)
+		ctx := context.TODO()
+
+		location := address.NewSharedLocation()
+
+		entries, err := api.List(ctx, *location, "get", "", "")
+		if err != nil && !sdkErrors.IsObjectNotFound(err) {
+			return fmt.Errorf("listing interface management entries via sdk: %v", err)
+		}
+
+		var leftEntries []string
+		for _, elt := range entries {
+			if strings.HasPrefix(elt.Name, prefix) {
+				leftEntries = append(leftEntries, elt.Name)
+			}
+		}
+
+		if len(leftEntries) > 0 {
+			err := fmt.Errorf("terraform failed to remove entries from the server")
+			delErr := api.Delete(ctx, *location, leftEntries...)
+			if delErr != nil {
+				return errors.Join(err, delErr)
+			}
+		}
+
+		return nil
+	}
+}

--- a/assets/terraform/test/resource_administrative_tag_test.go
+++ b/assets/terraform/test/resource_administrative_tag_test.go
@@ -1,0 +1,134 @@
+package provider_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"text/template"
+
+	sdkerrors "github.com/PaloAltoNetworks/pango/errors"
+	tag "github.com/PaloAltoNetworks/pango/objects/admintag"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccAdministrativeTag(t *testing.T) {
+	resourceName := "test_tag"
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"shared": config.BoolVariable(true),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: makeAdministrativeTagConfig(resourceName),
+				ConfigVariables: map[string]config.Variable{
+					"location": location,
+					"tag_name": config.StringVariable(fmt.Sprintf("%s-tag1-nocolor", prefix)),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						fmt.Sprintf("panos_administrative_tag.%s", resourceName),
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tag1-nocolor", prefix)),
+					),
+				},
+			},
+		},
+	})
+
+	colorValue := "color1"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: makeAdministrativeTagConfig(resourceName),
+				ConfigVariables: map[string]config.Variable{
+					"location": location,
+					"tag_name": config.StringVariable(fmt.Sprintf("%s-tag1-color", prefix)),
+					"color":    config.StringVariable(colorValue),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						fmt.Sprintf("panos_administrative_tag.%s", resourceName),
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tag1-color", prefix)),
+					),
+					statecheck.ExpectKnownValue(
+						fmt.Sprintf("panos_administrative_tag.%s", resourceName),
+						tfjsonpath.New("color"),
+						knownvalue.StringExact(colorValue)),
+				},
+			},
+		},
+	})
+}
+
+const resourceTmpl = `
+variable "location" { type = map }
+variable "tag_name" { type = string }
+variable "color" {
+  type = string
+  default = null
+}
+
+resource "panos_administrative_tag" "{{ .ResourceName }}" {
+  location = var.location
+
+  name  = var.tag_name
+  color = var.color
+}
+`
+
+func makeAdministrativeTagConfig(resourceName string) string {
+	var buf bytes.Buffer
+	tmpl := template.Must(template.New("").Parse(resourceTmpl))
+
+	context := struct {
+		ResourceName string
+	}{
+		ResourceName: resourceName,
+	}
+
+	err := tmpl.Execute(&buf, context)
+	if err != nil {
+		panic(err)
+	}
+
+	return buf.String()
+}
+
+func administrativeTagCheckDestroy(prefix string, location tag.Location) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		service := tag.NewService(sdkClient)
+		ctx := context.TODO()
+
+		tags, err := service.List(ctx, location, "get", "", "")
+		if err != nil && !sdkerrors.IsObjectNotFound(err) {
+			return err
+		}
+
+		for _, elt := range tags {
+			if strings.HasPrefix(elt.Name, prefix) {
+				return DanglingObjectsError
+			}
+		}
+
+		return nil
+	}
+}

--- a/assets/terraform/test/resource_custom_url_category_test.go
+++ b/assets/terraform/test/resource_custom_url_category_test.go
@@ -1,0 +1,134 @@
+package provider_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	sdkErrors "github.com/PaloAltoNetworks/pango/errors"
+	category "github.com/PaloAltoNetworks/pango/objects/profiles/customurlcategory"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccCustomUrlCategory(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCustomUrlCategoryDestroy(prefix),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomUrlCategoryResourceTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+					"type":   config.StringVariable("URL List"),
+					"list":   config.ListVariable(config.StringVariable("example.com")),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_custom_url_category.category",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-category", prefix)),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_custom_url_category.category",
+						tfjsonpath.New("type"),
+						knownvalue.StringExact("URL List"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_custom_url_category.category",
+						tfjsonpath.New("list"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("example.com"),
+						}),
+					),
+				},
+			},
+			{
+				Config: testAccCustomUrlCategoryResourceTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+					"type":   config.StringVariable("Category Match"),
+					"list":   config.ListVariable(config.StringVariable("unknown")),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_custom_url_category.category",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-category", prefix)),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_custom_url_category.category",
+						tfjsonpath.New("type"),
+						knownvalue.StringExact("Category Match"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_custom_url_category.category",
+						tfjsonpath.New("list"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("unknown"),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const testAccCustomUrlCategoryResourceTmpl = `
+variable prefix { type = string }
+variable type { type = string }
+variable list { type = list(string) }
+
+resource "panos_custom_url_category" "category" {
+  location = { shared = true }
+
+  name = format("%s-category", var.prefix)
+  type = var.type
+  list = var.list
+}
+`
+
+func testAccCustomUrlCategoryDestroy(prefix string) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		api := category.NewService(sdkClient)
+		ctx := context.TODO()
+
+		location := category.NewSharedLocation()
+
+		entries, err := api.List(ctx, *location, "get", "", "")
+		if err != nil && !sdkErrors.IsObjectNotFound(err) {
+			return fmt.Errorf("listing interface management entries via sdk: %v", err)
+		}
+
+		var leftEntries []string
+		for _, elt := range entries {
+			if strings.HasPrefix(elt.Name, prefix) {
+				leftEntries = append(leftEntries, elt.Name)
+			}
+		}
+
+		if len(leftEntries) > 0 {
+			err := fmt.Errorf("terraform failed to remove entries from the server")
+			delErr := api.Delete(ctx, *location, leftEntries...)
+			if delErr != nil {
+				return errors.Join(err, delErr)
+			}
+		}
+
+		return nil
+	}
+}

--- a/assets/terraform/test/resource_device_group_parent_test.go
+++ b/assets/terraform/test/resource_device_group_parent_test.go
@@ -1,0 +1,68 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccDeviceGroupParent(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceGroupResourceParentTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_device_group_parent.relationship",
+						tfjsonpath.New("device_group"),
+						knownvalue.StringExact(fmt.Sprintf("%s-dg-child", prefix)),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_device_group_parent.relationship",
+						tfjsonpath.New("parent"),
+						knownvalue.StringExact(fmt.Sprintf("%s-dg-parent", prefix)),
+					),
+				},
+			},
+		},
+	})
+}
+
+const testAccDeviceGroupResourceParentTmpl = `
+variable "prefix" { type = string }
+
+resource "panos_device_group" "parent" {
+  location = { panorama = {} }
+
+  name        = format("%s-dg-parent", var.prefix)
+}
+
+resource "panos_device_group" "child" {
+  location = { panorama = {} }
+
+  name        = format("%s-dg-child", var.prefix)
+}
+
+resource "panos_device_group_parent" "relationship" {
+  location = { panorama = {} }
+
+  device_group = resource.panos_device_group.child.name
+  parent       = resource.panos_device_group.parent.name
+}
+`

--- a/assets/terraform/test/resource_device_group_test.go
+++ b/assets/terraform/test/resource_device_group_test.go
@@ -1,0 +1,129 @@
+package provider_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	sdkErrors "github.com/PaloAltoNetworks/pango/errors"
+	"github.com/PaloAltoNetworks/pango/panorama/devicegroup"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccDeviceGroup(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccDeviceGroupDestroy(prefix),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeviceGroupResourceTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_device_group.dg",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-dg", prefix)),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_device_group.dg",
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("description"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_device_group.dg",
+						tfjsonpath.New("templates"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact(fmt.Sprintf("%s-tmpl", prefix)),
+						}),
+					),
+					// statecheck.ExpectKnownValue(
+					// 	"panos_device_group.dg",
+					// 	tfjsonpath.New("devices"),
+					// 	knownvalue.ListExact([]knownvalue.Check{
+					// 		knownvalue.MapExact(map[string]knownvalue.Check{
+					// 			"name": knownvalue.StringExact("device-1"),
+					// 			"vsys": knownvalue.StringExact("vsys1"),
+					// 		}),
+					// 	}),
+					// ),
+					statecheck.ExpectKnownValue(
+						"panos_device_group.dg",
+						tfjsonpath.New("authorization_code"),
+						knownvalue.StringExact("code"),
+					),
+				},
+			},
+		},
+	})
+}
+
+const testAccDeviceGroupResourceTmpl = `
+variable "prefix" { type = string }
+
+resource "panos_template" "template" {
+  location = { panorama = {} }
+
+  name = format("%s-tmpl", var.prefix)
+}
+
+resource "panos_device_group" "dg" {
+  location = { panorama = {} }
+
+  name        = format("%s-dg", var.prefix)
+  description = "description"
+
+  templates = [ resource.panos_template.template.name ]
+  # devices   = [{ name = "device-1", vsys = ["vsys1"] }]
+
+  authorization_code = "code"
+}
+`
+
+func testAccDeviceGroupDestroy(prefix string) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		api := devicegroup.NewService(sdkClient)
+		ctx := context.TODO()
+
+		location := devicegroup.NewPanoramaLocation()
+
+		entries, err := api.List(ctx, *location, "get", "", "")
+		if err != nil && !sdkErrors.IsObjectNotFound(err) {
+			return fmt.Errorf("listing interface management entries via sdk: %v", err)
+		}
+
+		var leftEntries []string
+		for _, elt := range entries {
+			if strings.HasPrefix(elt.Name, prefix) {
+				leftEntries = append(leftEntries, elt.Name)
+			}
+		}
+
+		if len(leftEntries) > 0 {
+			err := fmt.Errorf("terraform failed to remove entries from the server")
+			delErr := api.Delete(ctx, *location, leftEntries...)
+			if delErr != nil {
+				return errors.Join(err, delErr)
+			}
+			return err
+		}
+
+		return nil
+	}
+}

--- a/assets/terraform/test/resource_dns_settings_test.go
+++ b/assets/terraform/test/resource_dns_settings_test.go
@@ -1,0 +1,127 @@
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccDnsSettings(t *testing.T) {
+	location := config.ObjectVariable(map[string]config.Variable{
+		"system": config.ObjectVariable(map[string]config.Variable{}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dnsSettingsConfig1,
+				ConfigVariables: map[string]config.Variable{
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_dns_settings.settings",
+						tfjsonpath.New("fqdn_refresh_time"),
+						knownvalue.Int64Exact(1800),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_dns_settings.settings",
+						tfjsonpath.New("dns_setting").AtMapKey("servers").AtMapKey("primary"),
+						knownvalue.StringExact("172.16.0.1"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_dns_settings.settings",
+						tfjsonpath.New("dns_setting").AtMapKey("servers").AtMapKey("secondary"),
+						knownvalue.StringExact("172.16.0.2"),
+					),
+				},
+			},
+			{
+				Config: dnsSettingsConfig2,
+				ConfigVariables: map[string]config.Variable{
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_dns_settings.settings",
+						tfjsonpath.New("fqdn_refresh_time"),
+						knownvalue.Int64Exact(3600),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_dns_settings.settings",
+						tfjsonpath.New("dns_setting").AtMapKey("servers").AtMapKey("primary"),
+						knownvalue.StringExact("172.16.0.3"),
+					),
+				},
+			},
+			{
+				Config: dnsSettingsConfig3,
+				ConfigVariables: map[string]config.Variable{
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_dns_settings.settings",
+						tfjsonpath.New("fqdn_refresh_time"),
+						knownvalue.Int64Exact(1800),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_dns_settings.settings",
+						tfjsonpath.New("dns_setting").AtMapKey("servers").AtMapKey("secondary"),
+						knownvalue.StringExact("172.16.0.4"),
+					),
+				},
+			},
+		},
+	})
+}
+
+const dnsSettingsConfig1 = `
+variable "location" { type = map }
+
+resource "panos_dns_settings" "settings" {
+  location = var.location
+
+  dns_setting = {
+    servers = {
+      primary = "172.16.0.1"
+      secondary = "172.16.0.2"
+    }
+  }
+}
+`
+
+const dnsSettingsConfig2 = `
+variable "location" { type = map }
+
+resource "panos_dns_settings" "settings" {
+  location = var.location
+
+  fqdn_refresh_time = 3600
+  dns_setting = {
+    servers = {
+      primary = "172.16.0.3"
+    }
+  }
+}
+`
+
+const dnsSettingsConfig3 = `
+variable "location" { type = map }
+
+resource "panos_dns_settings" "settings" {
+  location = var.location
+
+  dns_setting = {
+    servers = {
+      secondary = "172.16.0.4"
+    }
+  }
+}
+`

--- a/assets/terraform/test/resource_interface_management_profile_test.go
+++ b/assets/terraform/test/resource_interface_management_profile_test.go
@@ -1,0 +1,196 @@
+package provider_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	sdkErrors "github.com/PaloAltoNetworks/pango/errors"
+	"github.com/PaloAltoNetworks/pango/network/profiles/interface_management"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccInterfaceManagementProfile(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	templateName := fmt.Sprintf("%s-tmpl", nameSuffix)
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(templateName),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccInterfaceManagementProfileDestroy(prefix, templateName),
+		Steps: []resource.TestStep{
+			{
+				Config: interfaceManagementProfileResourceTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"location":      location,
+					"template_name": config.StringVariable(templateName),
+					"name":          config.StringVariable(prefix),
+					"permitted_ips": config.ListVariable(
+						config.StringVariable("172.16.0.1"),
+						config.StringVariable("172.16.0.2"),
+					),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_interface_management_profile.profile",
+						tfjsonpath.New("http"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_interface_management_profile.profile",
+						tfjsonpath.New("https"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_interface_management_profile.profile",
+						tfjsonpath.New("ping"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_interface_management_profile.profile",
+						tfjsonpath.New("response_pages"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_interface_management_profile.profile",
+						tfjsonpath.New("userid_service"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_interface_management_profile.profile",
+						tfjsonpath.New("userid_syslog_listener_ssl"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_interface_management_profile.profile",
+						tfjsonpath.New("userid_syslog_listener_udp"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_interface_management_profile.profile",
+						tfjsonpath.New("ssh"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_interface_management_profile.profile",
+						tfjsonpath.New("telnet"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_interface_management_profile.profile",
+						tfjsonpath.New("snmp"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_interface_management_profile.profile",
+						tfjsonpath.New("http_ocsp"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_interface_management_profile.profile",
+						tfjsonpath.New("permitted_ips"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("172.16.0.1"),
+							knownvalue.StringExact("172.16.0.2"),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const interfaceManagementProfileResourceTmpl = `
+variable "location" { type = map }
+variable "template_name" { type = string }
+variable "name" { type = string }
+variable "permitted_ips" {
+  type = list(string)
+  default = []
+}
+
+resource "panos_template" "template" {
+  location = { panorama = {} }
+
+  name = var.template_name
+}
+
+resource "panos_interface_management_profile" "profile" {
+  depends_on = [ resource.panos_template.template ]
+  location = var.location
+
+  name = var.name
+
+  http  = true
+  https = true
+  ping  = true
+
+  response_pages = true
+
+  userid_service             = true
+  userid_syslog_listener_ssl = true
+  userid_syslog_listener_udp = true
+
+  ssh    = true
+  telnet = true
+  snmp   = true
+
+  http_ocsp = true
+
+  permitted_ips = var.permitted_ips
+}
+`
+
+func testAccInterfaceManagementProfileDestroy(prefix string, template string) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		api := interface_management.NewService(sdkClient)
+		ctx := context.TODO()
+
+		location := interface_management.NewTemplateLocation()
+		location.Template = &interface_management.TemplateLocation{
+			Template:       template,
+			NgfwDevice:     "localhost.localdomain",
+			PanoramaDevice: "localhost.localdomain",
+		}
+
+		entries, err := api.List(ctx, *location, "get", "", "")
+		if err != nil && !sdkErrors.IsObjectNotFound(err) {
+			return fmt.Errorf("listing interface management entries via sdk: %v", err)
+		}
+
+		var leftEntries []string
+		for _, elt := range entries {
+			if strings.HasPrefix(elt.Name, prefix) {
+				leftEntries = append(leftEntries, elt.Name)
+			}
+		}
+
+		if len(leftEntries) > 0 {
+			err := fmt.Errorf("terraform failed to remove entries from the server")
+			delErr := api.Delete(ctx, *location, leftEntries...)
+			if delErr != nil {
+				return errors.Join(err, delErr)
+			}
+		}
+
+		return nil
+	}
+}

--- a/assets/terraform/test/resource_ntp_settings_test.go
+++ b/assets/terraform/test/resource_ntp_settings_test.go
@@ -1,0 +1,172 @@
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccNtpSettings(t *testing.T) {
+	location := config.ObjectVariable(map[string]config.Variable{
+		"system": config.ObjectVariable(map[string]config.Variable{}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: ntpSettingsConfig1,
+				ConfigVariables: map[string]config.Variable{
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_ntp_settings.settings",
+						tfjsonpath.New("ntp_servers").AtMapKey("primary_ntp_server").AtMapKey("ntp_server_address"),
+						knownvalue.StringExact("172.16.0.1"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_ntp_settings.settings",
+						tfjsonpath.New("ntp_servers").AtMapKey("secondary_ntp_server").AtMapKey("ntp_server_address"),
+						knownvalue.StringExact("172.16.0.2"),
+					),
+				},
+			},
+			{
+				Config: ntpSettingsConfig2,
+				ConfigVariables: map[string]config.Variable{
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_ntp_settings.settings",
+						tfjsonpath.New("ntp_servers").AtMapKey("primary_ntp_server").AtMapKey("authentication_type").AtMapKey("autokey"),
+						knownvalue.StringExact(""),
+					),
+				},
+			},
+			{
+				Config: ntpSettingsConfig3,
+				ConfigVariables: map[string]config.Variable{
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_ntp_settings.settings",
+						tfjsonpath.New("ntp_servers").
+							AtMapKey("primary_ntp_server").
+							AtMapKey("authentication_type").
+							AtMapKey("symmetric_key").
+							AtMapKey("key_id"),
+						knownvalue.Int64Exact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_ntp_settings.settings",
+						tfjsonpath.New("ntp_servers").
+							AtMapKey("primary_ntp_server").
+							AtMapKey("authentication_type").
+							AtMapKey("symmetric_key").
+							AtMapKey("sha1").
+							AtMapKey("authentication_key"),
+						knownvalue.StringExact("da39a3ee5e6b4b0d3255bfef95601890afd80709"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_ntp_settings.settings",
+						tfjsonpath.New("ntp_servers").
+							AtMapKey("secondary_ntp_server").
+							AtMapKey("authentication_type").
+							AtMapKey("symmetric_key").
+							AtMapKey("key_id"),
+						knownvalue.Int64Exact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_ntp_settings.settings",
+						tfjsonpath.New("ntp_servers").
+							AtMapKey("secondary_ntp_server").
+							AtMapKey("authentication_type").
+							AtMapKey("symmetric_key").
+							AtMapKey("md5").
+							AtMapKey("authentication_key"),
+						knownvalue.StringExact("d41d8cd98f00b204e9800998ecf8427e"),
+					),
+				},
+			},
+		},
+	})
+}
+
+const ntpSettingsConfig1 = `
+variable "location" { type = map }
+
+resource "panos_ntp_settings" "settings" {
+  location = var.location
+
+  ntp_servers = {
+    primary_ntp_server = {
+      ntp_server_address = "172.16.0.1"
+    }
+    secondary_ntp_server = {
+      ntp_server_address = "172.16.0.2"
+    }
+  }
+}
+`
+
+const ntpSettingsConfig2 = `
+variable "location" { type = map }
+
+resource "panos_ntp_settings" "settings" {
+  location = var.location
+
+  ntp_servers = {
+    primary_ntp_server = {
+      ntp_server_address = "172.16.0.1"
+      authentication_type = {
+        autokey = ""
+      }
+    }
+    secondary_ntp_server = {
+      ntp_server_address = "172.16.0.2"
+    }
+  }
+}
+`
+
+const ntpSettingsConfig3 = `
+variable "location" { type = map }
+
+resource "panos_ntp_settings" "settings" {
+  location = var.location
+
+  ntp_servers = {
+    primary_ntp_server = {
+      ntp_server_address = "172.16.0.1"
+      authentication_type = {
+        symmetric_key = {
+          key_id = 1
+          sha1 = {
+            authentication_key = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+          }
+        }
+      }
+    }
+
+    secondary_ntp_server = {
+      ntp_server_address = "172.16.0.2"
+      authentication_type = {
+        symmetric_key = {
+          key_id = 1
+          md5 = {
+            authentication_key = "d41d8cd98f00b204e9800998ecf8427e"
+          }
+        }
+      }
+    }
+  }
+}
+`

--- a/assets/terraform/test/resource_security_policy_test.go
+++ b/assets/terraform/test/resource_security_policy_test.go
@@ -1,0 +1,667 @@
+package provider_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	sdkerrors "github.com/PaloAltoNetworks/pango/errors"
+	"github.com/PaloAltoNetworks/pango/policies/rules/security"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+type expectServerSecurityRulesOrder struct {
+	Location  security.Location
+	Prefix    string
+	RuleNames []string
+}
+
+func ExpectServerSecurityRulesOrder(prefix string, location security.Location, ruleNames []string) *expectServerSecurityRulesOrder {
+	return &expectServerSecurityRulesOrder{
+		Location:  location,
+		Prefix:    prefix,
+		RuleNames: ruleNames,
+	}
+}
+
+func (o *expectServerSecurityRulesOrder) CheckState(ctx context.Context, req statecheck.CheckStateRequest, resp *statecheck.CheckStateResponse) {
+	service := security.NewService(sdkClient)
+
+	objects, err := service.List(ctx, o.Location, "get", "", "")
+	if err != nil {
+		resp.Error = fmt.Errorf("failed to query server for rules: %w", err)
+		return
+	}
+
+	type ruleWithState struct {
+		Idx   int
+		State int
+	}
+
+	rulesWithIdx := make(map[string]ruleWithState)
+	for idx, elt := range o.RuleNames {
+		rulesWithIdx[fmt.Sprintf("%s-%s", o.Prefix, elt)] = ruleWithState{
+			Idx:   idx,
+			State: 0,
+		}
+	}
+
+	var prevActualIdx = -1
+	for actualIdx, elt := range objects {
+		if state, ok := rulesWithIdx[elt.Name]; !ok {
+			continue
+		} else {
+			state.State = 1
+			rulesWithIdx[elt.Name] = state
+
+			if state.Idx == 0 {
+				prevActualIdx = actualIdx
+				continue
+			} else if prevActualIdx == -1 {
+				resp.Error = fmt.Errorf("rules missing from the server")
+				return
+			} else if actualIdx-prevActualIdx > 1 {
+				resp.Error = fmt.Errorf("invalid rules order on the server")
+				return
+			}
+			prevActualIdx = actualIdx
+		}
+	}
+
+	var missing []string
+	for name, elt := range rulesWithIdx {
+		if elt.State != 1 {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) > 0 {
+		resp.Error = fmt.Errorf("not all rules are present on the server: %s", strings.Join(missing, ", "))
+		return
+	}
+}
+
+type expectServerSecurityRulesCount struct {
+	Prefix   string
+	Location security.Location
+	Count    int
+}
+
+func ExpectServerSecurityRulesCount(prefix string, location security.Location, count int) *expectServerSecurityRulesCount {
+	return &expectServerSecurityRulesCount{
+		Prefix:   prefix,
+		Location: location,
+		Count:    count,
+	}
+}
+
+func (o *expectServerSecurityRulesCount) CheckState(ctx context.Context, req statecheck.CheckStateRequest, resp *statecheck.CheckStateResponse) {
+	service := security.NewService(sdkClient)
+
+	objects, err := service.List(ctx, o.Location, "get", "", "")
+	if err != nil {
+		resp.Error = fmt.Errorf("failed to query server for rules: %w", err)
+		return
+	}
+
+	var count int
+	for _, elt := range objects {
+		if strings.HasPrefix(elt.Name, o.Prefix) {
+			count += 1
+		}
+	}
+
+	if count != o.Count {
+		resp.Error = UnexpectedRulesError
+		return
+	}
+}
+
+const securityPolicyExtendedResource1Tmpl = `
+variable "prefix" { type = string }
+
+resource "panos_template" "template" {
+  location = { panorama = {} }
+
+  name = format("%s-secgroup-tmpl1", var.prefix)
+}
+
+resource "panos_device_group" "dg" {
+  location = { panorama = {} }
+
+  name = format("%s-secgroup-dg1", var.prefix)
+  templates = [ resource.panos_template.template.name ]
+}
+
+
+resource "panos_security_policy" "policy" {
+  location = { device_group = { name = resource.panos_device_group.dg.name }}
+
+  rules = [{
+    name = format("%s-rule1", var.prefix)
+
+    source_zones     = ["any"]
+    source_addresses = ["any"]
+    source_users     = ["some-user"]
+    # source_hips      = ["hip-profile"]
+    negate_source    = false
+
+    destination_zones     = ["any"]
+    destination_addresses = ["any"]
+    # destination_hips = ["hip-device"]
+
+    services = ["any"]
+    applications = ["any"]
+
+    action = "drop"
+
+    profile_setting = {
+      profiles = {
+        url_filtering      = ["default"]
+        # data_filtering     = ["default"]
+        file_blocking      = ["basic file blocking"]
+        virus              = ["default"]
+        spyware            = ["strict"]
+        vulnerability      = ["strict"]
+        wildfire_analysis  = ["default"]
+      }
+    }
+
+    qos = {
+      marking = {
+        ip-dscp = "af11"
+      }
+    }
+
+    disable_server_response_inspection = true
+
+    icmp_unreachable = true
+    # schedule         = "schedule"
+    # log_setting = "log-forwarding-test-1"
+  }]
+}
+`
+
+func TestAccSecurityPolicyExtended(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: securityPolicyExtendedResource1Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-rule1", prefix)),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("source_zones"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("any"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("source_addresses"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("any"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("source_users"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("some-user"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("negate_source"),
+						knownvalue.Bool(false),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("destination_addresses"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("any"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("destination_zones"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("any"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("services"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("any"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("applications"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("any"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("action"),
+						knownvalue.StringExact("drop"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("profile_setting").
+							AtMapKey("profiles").
+							AtMapKey("url_filtering"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("default"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("profile_setting").
+							AtMapKey("profiles").
+							AtMapKey("url_filtering"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("default"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("profile_setting").
+							AtMapKey("profiles").
+							AtMapKey("file_blocking"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("basic file blocking"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("profile_setting").
+							AtMapKey("profiles").
+							AtMapKey("virus"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("default"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("profile_setting").
+							AtMapKey("profiles").
+							AtMapKey("spyware"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("strict"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("profile_setting").
+							AtMapKey("profiles").
+							AtMapKey("vulnerability"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("strict"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("profile_setting").
+							AtMapKey("profiles").
+							AtMapKey("wildfire_analysis"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("default"),
+						}),
+					),
+					// statecheck.ExpectKnownValue(
+					// 	"panos_security_policy.policy",
+					// 	tfjsonpath.New("rules").
+					// 		AtSliceIndex(0).
+					// 		AtMapKey("qos").
+					// 		AtMapKey("marking").
+					// 		AtMapKey("ip_dscp"),
+					// 	knownvalue.StringExact("af11"),
+					// ),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("disable_server_response_inspection"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_security_policy.policy",
+						tfjsonpath.New("rules").
+							AtSliceIndex(0).
+							AtMapKey("icmp_unreachable"),
+						knownvalue.Bool(true),
+					),
+				},
+			},
+		},
+	})
+}
+
+const securityPolicyOrderingTmpl = `
+variable "rule_names" { type = list(string) }
+variable "location" { type = map }
+
+resource "panos_security_policy" "policy" {
+  location = var.location
+
+  rules = [
+    for index, name in var.rule_names: {
+      name = name
+
+      source_zones     = ["any"]
+      source_addresses = ["any"]
+
+      destination_zones     = ["any"]
+      destination_addresses = ["any"]
+
+      services = ["any"]
+      applications = ["any"]
+    }
+  ]
+}
+`
+
+func TestAccSecurityPolicyOrdering(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	rulesInitial := []string{"rule-1", "rule-2", "rule-3"}
+	rulesReordered := []string{"rule-2", "rule-1", "rule-3"}
+
+	prefixed := func(name string) string {
+		return fmt.Sprintf("%s-%s", prefix, name)
+	}
+
+	withPrefix := func(rules []string) []config.Variable {
+		var result []config.Variable
+		for _, elt := range rules {
+			result = append(result, config.StringVariable(prefixed(elt)))
+		}
+
+		return result
+	}
+
+	device := devicePanorama
+
+	sdkLocation, cfgLocation := securityPolicyLocationByDeviceType(device, "pre-rulebase")
+
+	stateExpectedRuleName := func(idx int, value string) statecheck.StateCheck {
+		return statecheck.ExpectKnownValue(
+			"panos_security_policy.policy",
+			tfjsonpath.New("rules").AtSliceIndex(idx).AtMapKey("name"),
+			knownvalue.StringExact(prefixed(value)),
+		)
+	}
+
+	planExpectedRuleName := func(idx int, value string) plancheck.PlanCheck {
+		return plancheck.ExpectKnownValue(
+			"panos_security_policy.policy",
+			tfjsonpath.New("rules").AtSliceIndex(idx).AtMapKey("name"),
+			knownvalue.StringExact(prefixed(value)),
+		)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			securityPolicyPreCheck(prefix, sdkLocation)
+
+		},
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             securityPolicyCheckDestroy(prefix, sdkLocation),
+		Steps: []resource.TestStep{
+			{
+				Config: securityPolicyOrderingTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"rule_names": config.ListVariable(withPrefix(rulesInitial)...),
+					"location":   cfgLocation,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					stateExpectedRuleName(0, "rule-1"),
+					stateExpectedRuleName(1, "rule-2"),
+					stateExpectedRuleName(2, "rule-3"),
+					ExpectServerSecurityRulesCount(prefix, sdkLocation, len(rulesInitial)),
+					ExpectServerSecurityRulesOrder(prefix, sdkLocation, rulesInitial),
+				},
+			},
+			{
+				Config: securityPolicyOrderingTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"rule_names": config.ListVariable(withPrefix(rulesInitial)...),
+					"location":   cfgLocation,
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: securityPolicyOrderingTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"rule_names": config.ListVariable(withPrefix(rulesReordered)...),
+					"location":   cfgLocation,
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planExpectedRuleName(0, "rule-2"),
+						planExpectedRuleName(1, "rule-1"),
+						planExpectedRuleName(2, "rule-3"),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					stateExpectedRuleName(0, "rule-2"),
+					stateExpectedRuleName(1, "rule-1"),
+					stateExpectedRuleName(2, "rule-3"),
+					ExpectServerSecurityRulesOrder(prefix, sdkLocation, rulesReordered),
+				},
+			},
+		},
+	})
+}
+
+func securityPolicyLocationByDeviceType(typ deviceType, rulebase string) (security.Location, config.Variable) {
+	var sdkLocation security.Location
+	var cfgLocation config.Variable
+	switch typ {
+	case devicePanorama:
+		sdkLocation = security.Location{
+			Shared: &security.SharedLocation{
+				Rulebase: rulebase,
+			},
+		}
+		cfgLocation = config.ObjectVariable(map[string]config.Variable{
+			"shared": config.ObjectVariable(map[string]config.Variable{
+				"rulebase": config.StringVariable(rulebase),
+			}),
+		})
+	case deviceFirewall:
+		sdkLocation = security.Location{
+			Vsys: &security.VsysLocation{
+				NgfwDevice: "localhost.localdomain",
+				Vsys:       "vsys1",
+			},
+		}
+		cfgLocation = config.ObjectVariable(map[string]config.Variable{
+			"vsys": config.ObjectVariable(map[string]config.Variable{
+				"name": config.StringVariable("vsys1"),
+			}),
+		})
+	}
+
+	return sdkLocation, cfgLocation
+}
+
+func securityPolicyPreCheck(prefix string, location security.Location) {
+	service := security.NewService(sdkClient)
+	ctx := context.TODO()
+
+	stringPointer := func(value string) *string { return &value }
+
+	rules := []security.Entry{
+		{
+			Name:                 fmt.Sprintf("%s-rule0", prefix),
+			Description:          stringPointer("Rule 0"),
+			SourceZones:          []string{"any"},
+			DestinationZones:     []string{"any"},
+			SourceAddresses:      []string{"any"},
+			DestinationAddresses: []string{"any"},
+			Services:             []string{"any"},
+		},
+		{
+			Name:                 fmt.Sprintf("%s-rule99", prefix),
+			Description:          stringPointer("Rule 99"),
+			SourceZones:          []string{"any"},
+			DestinationZones:     []string{"any"},
+			SourceAddresses:      []string{"any"},
+			DestinationAddresses: []string{"any"},
+			Services:             []string{"any"},
+		},
+	}
+
+	for _, elt := range rules {
+		_, err := service.Create(ctx, location, &elt)
+		if err != nil {
+			panic(fmt.Sprintf("natPolicyPreCheck failed: %s", err))
+		}
+
+	}
+}
+
+func securityPolicyCheckDestroy(prefix string, location security.Location) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		service := security.NewService(sdkClient)
+		ctx := context.TODO()
+
+		rules, err := service.List(ctx, location, "get", "", "")
+		if err != nil && !sdkerrors.IsObjectNotFound(err) {
+			return err
+		}
+
+		var danglingNames []string
+		for _, elt := range rules {
+			if strings.HasPrefix(elt.Name, prefix) {
+				danglingNames = append(danglingNames, elt.Name)
+			}
+		}
+
+		if len(danglingNames) > 0 {
+			err := DanglingObjectsError
+			delErr := service.Delete(ctx, location, danglingNames...)
+			if delErr != nil {
+				err = errors.Join(err, delErr)
+			}
+
+			return err
+		}
+
+		return nil
+	}
+}
+
+func init() {
+	resource.AddTestSweepers("pango_security_policy", &resource.Sweeper{
+		Name: "pango_security_policy",
+		F: func(typ string) error {
+			service := security.NewService(sdkClient)
+
+			var deviceTyp deviceType
+			switch typ {
+			case "panorama":
+				deviceTyp = devicePanorama
+			case "firewall":
+				deviceTyp = deviceFirewall
+			default:
+				panic("invalid device type")
+			}
+
+			for _, rulebase := range []string{"pre-rulebase", "post-rulebase"} {
+				location, _ := securityPolicyLocationByDeviceType(deviceTyp, rulebase)
+				ctx := context.TODO()
+				objects, err := service.List(ctx, location, "get", "", "")
+				if err != nil && !sdkerrors.IsObjectNotFound(err) {
+					return fmt.Errorf("Failed to list Security Rules during sweep: %w", err)
+				}
+
+				var names []string
+				for _, elt := range objects {
+					if strings.HasPrefix(elt.Name, "test-acc") {
+						names = append(names, elt.Name)
+					}
+				}
+
+				if len(names) > 0 {
+					err = service.Delete(ctx, location, names...)
+					if err != nil {
+						return fmt.Errorf("Failed to delete Security Rules during sweep: %w", err)
+					}
+				}
+			}
+
+			return nil
+		},
+	})
+}

--- a/assets/terraform/test/resource_service_group_test.go
+++ b/assets/terraform/test/resource_service_group_test.go
@@ -1,0 +1,144 @@
+package provider_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	sdkerrors "github.com/PaloAltoNetworks/pango/errors"
+	servicegroup "github.com/PaloAltoNetworks/pango/objects/service/group"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccPanosServiceGroup(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccCheckPanosServiceGroupDestroy(prefix),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPanosServiceGroupTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+					"groups": config.MapVariable(map[string]config.Variable{
+						"group1": config.ObjectVariable(map[string]config.Variable{
+							"tags":    config.ListVariable(config.StringVariable(fmt.Sprintf("%s-tag", prefix))),
+							"members": config.ListVariable(config.StringVariable(fmt.Sprintf("%s-svc", prefix))),
+						}),
+						"group2": config.ObjectVariable(map[string]config.Variable{
+							"members": config.ListVariable(),
+						}),
+					}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_service_group.group1",
+						tfjsonpath.New("tags"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact(fmt.Sprintf("%s-tag", prefix)),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service_group.group1",
+						tfjsonpath.New("members"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact(fmt.Sprintf("%s-svc", prefix)),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service_group.group2",
+						tfjsonpath.New("members"),
+						knownvalue.Null(),
+					),
+				},
+			},
+		},
+	})
+}
+
+const testAccPanosServiceGroupTmpl = `
+variable "prefix" { type = string }
+variable "groups" {
+  type = map(object({
+    tags = optional(list(string)),
+    members = optional(list(string)),
+  }))
+}
+
+resource "panos_service" "svc" {
+  location = { shared = true }
+
+  name = format("%s-svc", var.prefix)
+  protocol = { tcp = { source_port = 80, destination_port = 443 }}
+}
+
+resource "panos_administrative_tag" "tag" {
+  location = { shared = true }
+
+  name = format("%s-tag", var.prefix)
+}
+
+resource "panos_service_group" "group1" {
+  depends_on = [
+    resource.panos_service.svc,
+    resource.panos_administrative_tag.tag
+  ]
+  location = { shared = true }
+
+  name = format("%s-group1", var.prefix)
+  members = var.groups["group1"].members
+  tags = var.groups["group1"].tags
+}
+
+resource "panos_service_group" "group2" {
+  location = { shared = true }
+
+  name = format("%s-group2", var.prefix)
+  members = var.groups["group2"].members
+}
+`
+
+func testAccCheckPanosServiceGroupDestroy(prefix string) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		svc := servicegroup.NewService(sdkClient)
+		ctx := context.TODO()
+		location := servicegroup.NewSharedLocation()
+
+		entries, err := svc.List(ctx, *location, "get", "", "")
+		if err != nil && !sdkerrors.IsObjectNotFound(err) {
+			return fmt.Errorf("Failed to list service group entries: %w", err)
+		}
+
+		err = nil
+		var dangling []string
+		for _, elt := range entries {
+			if strings.HasPrefix(elt.Name, prefix) {
+				dangling = append(dangling, elt.Name)
+				err = errors.Join(err, fmt.Errorf("service group entry not deleted properly: %s", elt.Name))
+			}
+		}
+
+		if len(dangling) > 0 {
+			deleteErr := svc.Delete(ctx, *location, dangling...)
+			if deleteErr != nil && !sdkerrors.IsObjectNotFound(deleteErr) {
+				err = errors.Join(err, fmt.Errorf("failed to delete service group entries: %w", deleteErr))
+			}
+		}
+
+		return err
+	}
+}

--- a/assets/terraform/test/resource_service_test.go
+++ b/assets/terraform/test/resource_service_test.go
@@ -1,0 +1,309 @@
+package provider_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	sdkErrors "github.com/PaloAltoNetworks/pango/errors"
+	"github.com/PaloAltoNetworks/pango/objects/service"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccService(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccServiceDestroy(prefix),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceResourceTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+					"services": config.MapVariable(map[string]config.Variable{
+						"svc1": config.ObjectVariable(map[string]config.Variable{
+							"description": config.StringVariable("description"),
+							"tags":        config.ListVariable(config.StringVariable(fmt.Sprintf("%s-tag", prefix))),
+							"protocol": config.ObjectVariable(map[string]config.Variable{
+								"tcp": config.ObjectVariable(map[string]config.Variable{
+									"destination_port": config.IntegerVariable(8080),
+									"source_port":      config.IntegerVariable(40000),
+								}),
+							}),
+						}),
+						"svc2": config.ObjectVariable(map[string]config.Variable{
+							"protocol": config.ObjectVariable(map[string]config.Variable{
+								"tcp": config.ObjectVariable(map[string]config.Variable{
+									"destination_port": config.IntegerVariable(443),
+									"source_port":      config.IntegerVariable(20000),
+									"override": config.ObjectVariable(map[string]config.Variable{
+										"timeout":           config.IntegerVariable(600),
+										"halfclose_timeout": config.IntegerVariable(300),
+										"timewait_timeout":  config.IntegerVariable(60),
+									}),
+								}),
+							}),
+						}),
+						"svc3": config.ObjectVariable(map[string]config.Variable{
+							"name": config.StringVariable(fmt.Sprintf("%s-svc3", prefix)),
+							"protocol": config.ObjectVariable(map[string]config.Variable{
+								"udp": config.ObjectVariable(map[string]config.Variable{
+									"destination_port": config.IntegerVariable(443),
+									"source_port":      config.IntegerVariable(20000),
+									"override": config.ObjectVariable(map[string]config.Variable{
+										"timeout": config.IntegerVariable(600),
+									}),
+								}),
+							}),
+						}),
+						"svc4": config.ObjectVariable(map[string]config.Variable{
+							"name": config.StringVariable(fmt.Sprintf("%s-svc4", prefix)),
+							"protocol": config.ObjectVariable(map[string]config.Variable{
+								"udp": config.ObjectVariable(map[string]config.Variable{
+									"destination_port": config.IntegerVariable(443),
+									"source_port":      config.IntegerVariable(20000),
+								}),
+							}),
+						}),
+					}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_service.svc1",
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("description"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service.svc1",
+						tfjsonpath.New("tags"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact(fmt.Sprintf("%s-tag", prefix)),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service.svc1",
+						tfjsonpath.New("protocol").
+							AtMapKey("tcp").
+							AtMapKey("source_port"),
+						knownvalue.Int64Exact(40000),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service.svc1",
+						tfjsonpath.New("protocol").
+							AtMapKey("tcp").
+							AtMapKey("destination_port"),
+						knownvalue.Int64Exact(8080),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service.svc2",
+						tfjsonpath.New("protocol").
+							AtMapKey("tcp").
+							AtMapKey("source_port"),
+						knownvalue.Int64Exact(20000),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service.svc2",
+						tfjsonpath.New("protocol").
+							AtMapKey("tcp").
+							AtMapKey("destination_port"),
+						knownvalue.Int64Exact(443),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service.svc2",
+						tfjsonpath.New("protocol").
+							AtMapKey("tcp").
+							AtMapKey("override").
+							AtMapKey("timeout"),
+						knownvalue.Int64Exact(600),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service.svc2",
+						tfjsonpath.New("protocol").
+							AtMapKey("tcp").
+							AtMapKey("override").
+							AtMapKey("halfclose_timeout"),
+						knownvalue.Int64Exact(300),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service.svc2",
+						tfjsonpath.New("protocol").
+							AtMapKey("tcp").
+							AtMapKey("override").
+							AtMapKey("timewait_timeout"),
+						knownvalue.Int64Exact(60),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service.svc3",
+						tfjsonpath.New("protocol").
+							AtMapKey("udp").
+							AtMapKey("source_port"),
+						knownvalue.Int64Exact(20000),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service.svc3",
+						tfjsonpath.New("protocol").
+							AtMapKey("udp").
+							AtMapKey("destination_port"),
+						knownvalue.Int64Exact(443),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service.svc3",
+						tfjsonpath.New("protocol").
+							AtMapKey("udp").
+							AtMapKey("override").
+							AtMapKey("timeout"),
+						knownvalue.Int64Exact(600),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service.svc4",
+						tfjsonpath.New("protocol").
+							AtMapKey("udp").
+							AtMapKey("source_port"),
+						knownvalue.Int64Exact(20000),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service.svc4",
+						tfjsonpath.New("protocol").
+							AtMapKey("udp").
+							AtMapKey("destination_port"),
+						knownvalue.Int64Exact(443),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_service.svc4",
+						tfjsonpath.New("protocol").
+							AtMapKey("udp").
+							AtMapKey("override"),
+						knownvalue.Null(),
+					),
+				},
+			},
+		},
+	})
+}
+
+const testAccServiceResourceTmpl = `
+variable prefix { type = string }
+variable "services" {
+  type = map(object({
+    description = optional(string),
+    tags = optional(list(string)),
+    protocol = object({
+      tcp = optional(object({
+        destination_port = optional(number),
+        source_port = optional(number),
+        override = optional(object({
+          timeout = optional(number),
+          halfclose_timeout = optional(number),
+          timewait_timeout = optional(number),
+        })),
+      })),
+      udp = optional(object({
+        destination_port = optional(number),
+        source_port = optional(number),
+        override = optional(object({
+          timeout = optional(number),
+        })),
+      })),
+    }),
+  }))
+}
+
+resource "panos_administrative_tag" "tag" {
+  location = { shared = true }
+
+  name = format("%s-tag", var.prefix)
+}
+
+resource "panos_service" "svc1" {
+  depends_on = [ resource.panos_administrative_tag.tag ]
+
+  location = { shared = true }
+
+  name        = format("%s-svc1", var.prefix)
+  description = var.services["svc1"].description
+  tags        = var.services["svc1"].tags
+
+  protocol = var.services["svc1"].protocol
+}
+
+resource "panos_service" "svc2" {
+  depends_on = [ resource.panos_administrative_tag.tag ]
+
+  location = { shared = true }
+
+  name        = format("%s-svc2", var.prefix)
+  description = var.services["svc2"].description
+  tags        = var.services["svc2"].tags
+
+  protocol = var.services["svc2"].protocol
+}
+
+resource "panos_service" "svc3" {
+  depends_on = [ resource.panos_administrative_tag.tag ]
+
+  location = { shared = true }
+
+  name        = format("%s-svc3", var.prefix)
+  description = var.services["svc3"].description
+  tags        = var.services["svc3"].tags
+
+  protocol = var.services["svc3"].protocol
+}
+
+resource "panos_service" "svc4" {
+  depends_on = [ resource.panos_administrative_tag.tag ]
+
+  location = { shared = true }
+
+  name        = format("%s-svc4", var.prefix)
+  description = var.services["svc4"].description
+  tags        = var.services["svc4"].tags
+
+  protocol = var.services["svc4"].protocol
+}
+`
+
+func testAccServiceDestroy(prefix string) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		api := service.NewService(sdkClient)
+		ctx := context.TODO()
+
+		location := service.NewSharedLocation()
+
+		entries, err := api.List(ctx, *location, "get", "", "")
+		if err != nil && !sdkErrors.IsObjectNotFound(err) {
+			return fmt.Errorf("listing interface management entries via sdk: %v", err)
+		}
+
+		var leftEntries []string
+		for _, elt := range entries {
+			if strings.HasPrefix(elt.Name, prefix) {
+				leftEntries = append(leftEntries, elt.Name)
+			}
+		}
+
+		if len(leftEntries) > 0 {
+			err := fmt.Errorf("terraform failed to remove entries from the server")
+			delErr := api.Delete(ctx, *location, leftEntries...)
+			if delErr != nil {
+				return errors.Join(err, delErr)
+			}
+		}
+
+		return nil
+	}
+}

--- a/pkg/properties/normalized.go
+++ b/pkg/properties/normalized.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/paloaltonetworks/pan-os-codegen/pkg/content"
@@ -426,6 +427,8 @@ func schemaParameterToSpecParameter(schemaSpec *parameter.Parameter) (*SpecParam
 	case *parameter.SimpleSpec:
 		if typed, ok := spec.Default.(string); ok {
 			defaultVal = typed
+		} else if typed, ok := spec.Default.(int); ok {
+			defaultVal = strconv.Itoa(typed)
 		}
 	}
 

--- a/pkg/translate/terraform_provider/funcs.go
+++ b/pkg/translate/terraform_provider/funcs.go
@@ -456,8 +456,6 @@ var {{ .TerraformName.LowerCamelCase }}_list types.List
 		(*encrypted)["{{ .Encryption.EncryptedPath }}"] = types.StringValue(*obj.{{ .TerraformName.CamelCase }})
 		if value, ok := (*encrypted)["{{ .Encryption.PlaintextPath }}"]; ok {
 			{{ .TerraformName.LowerCamelCase }}_value = value
-		} else {
-			panic("{{ .Encryption.PlaintextPath }}")
 		}
 {{- else }}
 		{{ .TerraformName.LowerCamelCase }}_value = types.{{ .Type | PascalCase }}Value(*obj.{{ .PangoName.CamelCase }})

--- a/specs/objects/service.yaml
+++ b/specs/objects/service.yaml
@@ -220,21 +220,11 @@ spec:
                   type: object
                   description: "Override session timeout."
                   profiles:
-                    - xpath: ["override"]
+                    - xpath: ["override", "yes"]
                   spec:
-                    variants:
-                      - name: yes
-                        type: object
+                    params:
+                      - name: "timeout"
+                        type: int64
+                        description: "UDP session timeout value (in second)"
                         profiles:
-                          - xpath: ["yes"]
-                        spec:
-                          params:
-                            - name: "timeout"
-                              type: int64
-                              description: "UDP session timeout value (in second)"
-                              profiles:
-                                - xpath: ["timeout"]
-                      - name: no
-                        type: nil
-                        profiles:
-                          - xpath: ["no"]
+                          - xpath: ["timeout"]

--- a/specs/panorama/device-group.yaml
+++ b/specs/panorama/device-group.yaml
@@ -4,7 +4,7 @@ terraform_provider_config:
 go_sdk_config:
   package:
     - "panorama"
-    - "device_group"
+    - "devicegroup"
 xpath_suffix:
   - "device-group"
 locations:

--- a/specs/policies/network-address-translation.yaml
+++ b/specs/policies/network-address-translation.yaml
@@ -268,18 +268,9 @@ spec:
                   spec:
                     params:
                       - name: interface
-                        type: list
+                        type: string
                         profiles:
-                          - type: member
-                            xpath: [interface]
-                        validators:
-                          - type: count
-                            spec:
-                              min: 1
-                              max: 1
-                        spec:
-                          items:
-                            type: string
+                          - xpath: [interface]
                     variants:
                       - name: ip
                         description: IP


### PR DESCRIPTION
## Description

This PR introduces basic acceptance tests for all existing terraform resources (generated from handwritten specs)

## Motivation

This will be used as a smoke testing for codegen specs autogenerated from XML schema