### PR TITLE
feat(specs): Add missing enum values to panos_external_dynamic_list

### DIFF
--- a/specs/objects/external-dynamic-list.yaml
+++ b/specs/objects/external-dynamic-list.yaml
@@ -79,10 +79,12 @@ spec:
     - type: values
       spec:
         values:
+        - 'yes'
         - 'no'
     spec:
       default: 'no'
       values:
+      - value: 'yes'
       - value: 'no'
     description: disable object override in child device groups
     required: false


### PR DESCRIPTION
Most of the initial spec has already been pushed as part of #186 so this only fixes missing enum values.