### PR TITLE
fix(tests): Fix panos_ipsec_crypto_profile acceptance tests

### DIFF
--- a/assets/terraform/test/resource_ipsec_crypto_profile_test.go
+++ b/assets/terraform/test/resource_ipsec_crypto_profile_test.go
@@ -189,7 +189,7 @@ resource "panos_ipsec_crypto_profile" "profile2" {
 
   esp = {
     authentication = ["sha256"]
-    ecryption = ["3des", "null"]
+    encryption = ["3des", "null"]
   }
   lifesize = {
     kb = 5


### PR DESCRIPTION
When creating panos_ipsec_crypto_profile resource, one of arguments was not named correctly and the created object was missing data, failing the test.