### PR TITLE
fix: Properly handle empty plural resources

### DIFF
--- a/assets/terraform/internal/manager/entry.go
+++ b/assets/terraform/internal/manager/entry.go
@@ -383,7 +383,7 @@ func (o *EntryObjectManager[E, L, S]) UpdateMany(ctx context.Context, location L
 	}
 
 	existing, err = o.service.List(ctx, location, "get", "", "")
-	if err != nil {
+	if err != nil && !sdkerrors.IsObjectNotFound(err) {
 		return nil, fmt.Errorf("Failed to list remote entries: %w", err)
 	}
 

--- a/assets/terraform/internal/manager/uuid.go
+++ b/assets/terraform/internal/manager/uuid.go
@@ -353,7 +353,7 @@ func (o *UuidObjectManager[E, L, S]) CreateMany(ctx context.Context, location L,
 	}
 
 	existing, err = o.service.List(ctx, location, "get", "", "")
-	if err != nil {
+	if err != nil && !sdkerrors.IsObjectNotFound(err) {
 		return nil, fmt.Errorf("Failed to list remote entries: %w", err)
 	}
 
@@ -602,7 +602,7 @@ func (o *UuidObjectManager[E, L, S]) UpdateMany(ctx context.Context, location L,
 	}
 
 	existing, err = o.service.List(ctx, location, "get", "", "")
-	if err != nil {
+	if err != nil && !sdkerrors.IsObjectNotFound(err) {
 		return nil, fmt.Errorf("Failed to list remote entries: %w", err)
 	}
 

--- a/assets/terraform/test/resource_addresses_test.go
+++ b/assets/terraform/test/resource_addresses_test.go
@@ -33,6 +33,20 @@ func TestAccAddresses(t *testing.T) {
 			{
 				Config: testAccAddressesResourceTmpl,
 				ConfigVariables: map[string]config.Variable{
+					"prefix":    config.StringVariable(prefix),
+					"addresses": config.MapVariable(map[string]config.Variable{})},
+			},
+			{
+				Config: testAccAddressesResourceTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":    config.StringVariable(prefix),
+					"addresses": config.MapVariable(map[string]config.Variable{})},
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: testAccAddressesResourceTmpl,
+				ConfigVariables: map[string]config.Variable{
 					"prefix": config.StringVariable(prefix),
 					"addresses": config.MapVariable(map[string]config.Variable{
 						fmt.Sprintf("%s-ip-netmask", prefix): config.ObjectVariable(map[string]config.Variable{
@@ -140,6 +154,20 @@ func TestAccAddresses(t *testing.T) {
 						}),
 					),
 				},
+			},
+			{
+				Config: testAccAddressesResourceTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":    config.StringVariable(prefix),
+					"addresses": config.MapVariable(map[string]config.Variable{})},
+			},
+			{
+				Config: testAccAddressesResourceTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":    config.StringVariable(prefix),
+					"addresses": config.MapVariable(map[string]config.Variable{})},
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})

--- a/assets/terraform/test/resource_security_policy_test.go
+++ b/assets/terraform/test/resource_security_policy_test.go
@@ -474,6 +474,22 @@ func TestAccSecurityPolicyOrdering(t *testing.T) {
 			{
 				Config: securityPolicyOrderingTmpl,
 				ConfigVariables: map[string]config.Variable{
+					"rule_names": config.ListVariable([]config.Variable{}...),
+					"location":   cfgLocation,
+				},
+			},
+			{
+				Config: securityPolicyOrderingTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"rule_names": config.ListVariable([]config.Variable{}...),
+					"location":   cfgLocation,
+				},
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: securityPolicyOrderingTmpl,
+				ConfigVariables: map[string]config.Variable{
 					"rule_names": config.ListVariable(withPrefix(rulesInitial)...),
 					"location":   cfgLocation,
 				},
@@ -522,6 +538,22 @@ func TestAccSecurityPolicyOrdering(t *testing.T) {
 					stateExpectedRuleName(4, "rule-5"),
 					ExpectServerSecurityRulesOrder(prefix, sdkLocation, rulesReordered),
 				},
+			},
+			{
+				Config: securityPolicyOrderingTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"rule_names": config.ListVariable([]config.Variable{}...),
+					"location":   cfgLocation,
+				},
+			},
+			{
+				Config: securityPolicyOrderingTmpl,
+				ConfigVariables: map[string]config.Variable{
+					"rule_names": config.ListVariable([]config.Variable{}...),
+					"location":   cfgLocation,
+				},
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})

--- a/pkg/translate/terraform_provider/template.go
+++ b/pkg/translate/terraform_provider/template.go
@@ -694,7 +694,7 @@ if resp.Diagnostics.HasError() {
 
 elements := make(map[string]{{ $resourceTFStructName }})
 resp.Diagnostics.Append(state.{{ .ListAttribute.CamelCase }}.ElementsAs(ctx, &elements, false)...)
-if resp.Diagnostics.HasError() {
+if len(elements) == 0 || resp.Diagnostics.HasError() {
 	return
 }
 
@@ -786,6 +786,10 @@ if resp.Diagnostics.HasError() {
 
 var elements []{{ $resourceTFStructName }}
 state.{{ .ListAttribute.CamelCase }}.ElementsAs(ctx, &elements, false)
+if len(elements) == 0 {
+	return
+}
+
 entries := make([]*{{ $resourceSDKStructName }}, 0, len(elements))
 for _, elt := range elements {
 	var entry *{{ $resourceSDKStructName }}
@@ -949,7 +953,7 @@ for name, elt := range elements {
 }
 
 existing, err := r.manager.ReadMany(ctx, location, stateEntries)
-if err != nil && !sdkerrors.IsObjectNotFound(err) {
+if err != nil && !errors.Is(err, sdkmanager.ErrObjectNotFound) {
 	resp.Diagnostics.AddError("Error while reading entries from the server", err.Error())
 	return
 }
@@ -1044,7 +1048,7 @@ position := state.Position.CopyToPango()
 {{- end }}
 
 existing, err := r.manager.ReadMany(ctx, location, stateEntries, {{ $exhaustive }})
-if err != nil && !sdkerrors.IsObjectNotFound(err) {
+if err != nil && !errors.Is(err, sdkmanager.ErrObjectNotFound) {
 	resp.Diagnostics.AddError("Error while reading entries from the server", err.Error())
 	return
 }

--- a/pkg/translate/terraform_provider/terraform_provider_file.go
+++ b/pkg/translate/terraform_provider/terraform_provider_file.go
@@ -199,12 +199,9 @@ func (g *GenerateTerraformProvider) GenerateTerraformResource(resourceTyp proper
 			switch resourceTyp {
 			case properties.ResourceUuid:
 				terraformProvider.ImportManager.AddSdkImport("github.com/PaloAltoNetworks/pango/rule", "")
-				terraformProvider.ImportManager.AddSdkImport("github.com/PaloAltoNetworks/pango/errors", "sdkerrors")
 			case properties.ResourceEntry:
 			case properties.ResourceUuidPlural:
-				terraformProvider.ImportManager.AddSdkImport("github.com/PaloAltoNetworks/pango/errors", "sdkerrors")
 			case properties.ResourceEntryPlural:
-				terraformProvider.ImportManager.AddSdkImport("github.com/PaloAltoNetworks/pango/errors", "sdkerrors")
 			case properties.ResourceCustom, properties.ResourceConfig:
 			}
 


### PR DESCRIPTION
Plural resources (like panos_addresses or panos_security_policy) can have an empty set of entries, and this should be properly handled during updates.