### PR TITLE
fix(specs): Make security policy destination zones a list

### DIFF
--- a/assets/terraform/examples/resources/panos_security_policy/resource.tf
+++ b/assets/terraform/examples/resources/panos_security_policy/resource.tf
@@ -13,7 +13,7 @@ resource "panos_security_policy" "name" {
       source_zones          = ["any"],
       source_addresses      = ["1.1.1.1"],
       destination_zones     = ["any"],
-      destination_addresses = ["172.16.0.0/8"],
+      destination_addresses = ["172.10.0.0/8"],
       services              = ["any"],
       applications          = ["any"],
     }

--- a/assets/terraform/examples/resources/panos_security_policy/resource.tf
+++ b/assets/terraform/examples/resources/panos_security_policy/resource.tf
@@ -13,7 +13,7 @@ resource "panos_security_policy" "name" {
       source_zones          = ["any"],
       source_addresses      = ["1.1.1.1"],
       destination_zones     = ["any"],
-      destination_addresses = ["172.10.0.0/8"],
+      destination_addresses = ["172.0.0.0/8"],
       services              = ["any"],
       applications          = ["any"],
     }

--- a/assets/terraform/examples/resources/panos_security_policy_rules/resource.tf
+++ b/assets/terraform/examples/resources/panos_security_policy_rules/resource.tf
@@ -17,7 +17,7 @@ resource "panos_security_policy_rules" "name" {
       source_zones          = ["any"],
       source_addresses      = ["1.1.1.1"],
       destination_zones     = ["any"],
-      destination_addresses = ["172.16.0.0/8"],
+      destination_addresses = ["172.0.0.0/8"],
       services              = ["any"],
       applications          = ["any"],
     }

--- a/assets/terraform/test/resource_security_policy_test.go
+++ b/assets/terraform/test/resource_security_policy_test.go
@@ -156,7 +156,7 @@ resource "panos_security_policy" "policy" {
     # source_hips      = ["hip-profile"]
     negate_source    = false
 
-    destination_zone      = "any"
+    destination_zones     = ["any"]
     destination_addresses = ["any"]
     # destination_hips = ["hip-device"]
 
@@ -262,8 +262,10 @@ func TestAccSecurityPolicyExtended(t *testing.T) {
 						"panos_security_policy.policy",
 						tfjsonpath.New("rules").
 							AtSliceIndex(0).
-							AtMapKey("destination_zone"),
-						knownvalue.StringExact("any"),
+							AtMapKey("destination_zones"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("any"),
+						}),
 					),
 					statecheck.ExpectKnownValue(
 						"panos_security_policy.policy",
@@ -410,7 +412,7 @@ resource "panos_security_policy" "policy" {
       source_zones     = ["any"]
       source_addresses = ["any"]
 
-      destination_zone      = "any"
+      destination_zones     = ["any"]
       destination_addresses = ["any"]
 
       services = ["any"]

--- a/specs/policies/security-policy-rule.yaml
+++ b/specs/policies/security-policy-rule.yaml
@@ -752,8 +752,7 @@ spec:
     required: false
     codegen_overrides:
       terraform:
-        name: destination_zone
-        type: string
+        name: destination_zones
   - name: uuid
     type: string
     profiles:


### PR DESCRIPTION
This was erroneously changed into a simple string attribute