### PR TITLE
fix(specs): Remove default value from url_filtering_sec_profile variants

### DIFF
--- a/specs/objects/profiles/url-filtering.yaml
+++ b/specs/objects/profiles/url-filtering.yaml
@@ -242,8 +242,7 @@ spec:
             - type: length
               spec:
                 max: 31
-            spec:
-              default: any
+            spec: {}
             description: Use Group Mapping
             required: false
           - name: ip-user


### PR DESCRIPTION
XML schema provides default values for some variants (mostly strings) and that gets translated into a terraform attribute that always have a value, breaking server-side validation.