### PR TITLE
feat(specs): Generate singular variant for panos_address resource

### DIFF
--- a/specs/objects/address.yaml
+++ b/specs/objects/address.yaml
@@ -5,6 +5,7 @@ terraform_provider_config:
   skip_datasource: false
   resource_type: entry
   resource_variants:
+  - singular
   - plural
   suffix: address
   plural_suffix: addresses


### PR DESCRIPTION
Generate singular `panos_address` resourve variant to better support usecase when address objects are referenced from other resources (e.g. `panos_security_policy`) and list of address objects is modified.