### PR TITLE
feat(specs): Mark policy resource uuid attributes as private

### DIFF
--- a/specs/policies/decryption-policy.yaml
+++ b/specs/policies/decryption-policy.yaml
@@ -539,5 +539,5 @@ spec:
     required: false
     codegen_overrides:
       terraform:
-        computed: true
+        private: true
   variants: []

--- a/specs/policies/network-address-translation.yaml
+++ b/specs/policies/network-address-translation.yaml
@@ -589,7 +589,7 @@ spec:
     required: false
     codegen_overrides:
       terraform:
-        computed: true
+        private: true
   variants:
   - name: destination-translation
     type: object


### PR DESCRIPTION
Mark uuid attributes in policy resources (i.e. nat policies, decryption policies) as private, removing them from terraform state. This decreases the verbosity of the diff on policy changes.