### PR TITLE
fix: Properly initialize an expected order of entries when generating movement actions

### DIFF
--- a/assets/pango/movement/movement.go
+++ b/assets/pango/movement/movement.go
@@ -263,6 +263,7 @@ func getPivotMovement(entries []Movable, existing []Movable, pivot string, direc
 			filteredLen := len(filtered)
 			for i := filteredPivotIdx + 1; i < filteredLen; i++ {
 				expected[expectedIdx] = filtered[i]
+				expectedIdx++
 			}
 		} else {
 			filteredLen := len(filtered)

--- a/assets/pango/movement/movement_test.go
+++ b/assets/pango/movement/movement_test.go
@@ -168,6 +168,25 @@ var _ = Describe("MoveGroup()", func() {
 				Expect(moves[1].Where).To(Equal(movement.ActionWhereAfter))
 				Expect(moves[1].Destination.EntryName()).To(Equal("A"))
 			})
+			It("should not create a list with null entries", func() {
+				// '(A B C D E) -> '(A C D B E)
+				entries := asMovable([]string{"C", "D"})
+				moves, err := movement.MoveGroup(
+					movement.PositionAfter{Directly: true, Pivot: "A"},
+					entries, existing,
+				)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(moves).To(HaveLen(2))
+
+				Expect(moves[0].Movable.EntryName()).To(Equal("C"))
+				Expect(moves[0].Where).To(Equal(movement.ActionWhereAfter))
+				Expect(moves[0].Destination.EntryName()).To(Equal("A"))
+
+				Expect(moves[1].Movable.EntryName()).To(Equal("D"))
+				Expect(moves[1].Where).To(Equal(movement.ActionWhereAfter))
+				Expect(moves[1].Destination.EntryName()).To(Equal("C"))
+			})
 		})
 		Context("when direct position relative to the pivot is required, and order changes", func() {
 			It("should generate required move actions when after is used", func() {

--- a/assets/terraform/test/resource_security_policy_test.go
+++ b/assets/terraform/test/resource_security_policy_test.go
@@ -60,6 +60,11 @@ func (o *expectServerSecurityRulesOrder) CheckState(ctx context.Context, req sta
 		}
 	}
 
+	var serverRules []string
+	for _, elt := range objects {
+		serverRules = append(serverRules, elt.EntryName())
+	}
+
 	var prevActualIdx = -1
 	for actualIdx, elt := range objects {
 		if state, ok := rulesWithIdx[elt.Name]; !ok {
@@ -72,10 +77,10 @@ func (o *expectServerSecurityRulesOrder) CheckState(ctx context.Context, req sta
 				prevActualIdx = actualIdx
 				continue
 			} else if prevActualIdx == -1 {
-				resp.Error = fmt.Errorf("rules missing from the server")
+				resp.Error = fmt.Errorf("rules missing from the server: %s", strings.Join(serverRules, ", "))
 				return
 			} else if actualIdx-prevActualIdx > 1 {
-				resp.Error = fmt.Errorf("invalid rules order on the server")
+				resp.Error = fmt.Errorf("invalid rules order on the server: %s", strings.Join(serverRules, ", "))
 				return
 			}
 			prevActualIdx = actualIdx

--- a/pkg/translate/terraform_provider/terraform_provider_file.go
+++ b/pkg/translate/terraform_provider/terraform_provider_file.go
@@ -141,11 +141,11 @@ func (g *GenerateTerraformProvider) GenerateTerraformResource(resourceTyp proper
 		"IsEntry":      func() bool { return spec.HasEntryName() && !spec.HasEntryUuid() },
 		"HasImports":   func() bool { return len(spec.Imports) > 0 },
 
-		"IsCustom":     func() bool { return spec.TerraformProviderConfig.ResourceType == properties.TerraformResourceCustom },
-		"IsUuid":       func() bool { return spec.HasEntryUuid() },
-		"IsConfig":     func() bool { return !spec.HasEntryName() && !spec.HasEntryUuid() },
-		"IsEphemeral":  func() bool { return spec.TerraformProviderConfig.Ephemeral },
-    "ListAttribute": func() *properties.NameVariant {
+		"IsCustom":    func() bool { return spec.TerraformProviderConfig.ResourceType == properties.TerraformResourceCustom },
+		"IsUuid":      func() bool { return spec.HasEntryUuid() },
+		"IsConfig":    func() bool { return !spec.HasEntryName() && !spec.HasEntryUuid() },
+		"IsEphemeral": func() bool { return spec.TerraformProviderConfig.Ephemeral },
+		"ListAttribute": func() *properties.NameVariant {
 			return properties.NewNameVariant(spec.TerraformProviderConfig.PluralName)
 		},
 		"HasLocations": func() bool { return len(spec.Locations) > 0 },


### PR DESCRIPTION
The logic used to generate an expected list of items did not properly handle some cases for a "direct" PositionAfter case, resulting in a crash.

Closes: #447
