### PR TITLE
ci: Pin GitHub Actions

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -21,17 +21,17 @@ jobs:
         with:
           go-version: "1.23"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           version: v1.60
   ci:
     name: Continuous integration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
         with:
           go-version: "1.23"
 

--- a/pkg/translate/terraform_provider/terraform_provider_file.go
+++ b/pkg/translate/terraform_provider/terraform_provider_file.go
@@ -141,11 +141,11 @@ func (g *GenerateTerraformProvider) GenerateTerraformResource(resourceTyp proper
 		"IsEntry":      func() bool { return spec.HasEntryName() && !spec.HasEntryUuid() },
 		"HasImports":   func() bool { return len(spec.Imports) > 0 },
 
-		"IsCustom":     func() bool { return spec.TerraformProviderConfig.ResourceType == properties.TerraformResourceCustom },
-		"IsUuid":       func() bool { return spec.HasEntryUuid() },
-		"IsConfig":     func() bool { return !spec.HasEntryName() && !spec.HasEntryUuid() },
-		"IsEphemeral":  func() bool { return spec.TerraformProviderConfig.Ephemeral },
-    "ListAttribute": func() *properties.NameVariant {
+		"IsCustom":    func() bool { return spec.TerraformProviderConfig.ResourceType == properties.TerraformResourceCustom },
+		"IsUuid":      func() bool { return spec.HasEntryUuid() },
+		"IsConfig":    func() bool { return !spec.HasEntryName() && !spec.HasEntryUuid() },
+		"IsEphemeral": func() bool { return spec.TerraformProviderConfig.Ephemeral },
+		"ListAttribute": func() *properties.NameVariant {
 			return properties.NewNameVariant(spec.TerraformProviderConfig.PluralName)
 		},
 		"HasLocations": func() bool { return len(spec.Locations) > 0 },


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions