### PR TITLE
fix: Drop XMLName struct field where not needed

### DIFF
--- a/assets/terraform/test/ephemeral_api_key_test.go
+++ b/assets/terraform/test/ephemeral_api_key_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestEphemeralApiKey(t *testing.T) {
 	t.Parallel()
+	t.Skip("Disabled until user management is part of terraform and GO SDK")
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/assets/terraform/test/resource_addresses_test.go
+++ b/assets/terraform/test/resource_addresses_test.go
@@ -62,8 +62,7 @@ func TestAccAddresses(t *testing.T) {
 							"disable_override": config.StringVariable("no"),
 						}),
 						fmt.Sprintf("%s-fqdn", prefix): config.ObjectVariable(map[string]config.Variable{
-							"fqdn":             config.StringVariable("example.com"),
-							"disable_override": config.StringVariable("yes"),
+							"fqdn": config.StringVariable("example.com"),
 						}),
 					}),
 				},
@@ -105,7 +104,7 @@ func TestAccAddresses(t *testing.T) {
 							fmt.Sprintf("%s-fqdn", prefix): knownvalue.ObjectExact(map[string]knownvalue.Check{
 								"tags":             knownvalue.Null(),
 								"description":      knownvalue.Null(),
-								"disable_override": knownvalue.StringExact("yes"),
+								"disable_override": knownvalue.Null(),
 								"ip_netmask":       knownvalue.Null(),
 								"ip_range":         knownvalue.Null(),
 								"ip_wildcard":      knownvalue.Null(),

--- a/templates/sdk/config.tmpl
+++ b/templates/sdk/config.tmpl
@@ -117,12 +117,12 @@ return configList, nil
     Misc map[string][]generic.Xml
     }
 
-    {{- range $name, $spec := nestedSpecs $.Spec }}
+    {{- range $name, $nested := nestedSpecs $.Spec }}
         type {{$name}}{{createGoSuffixFromVersion nil}} struct {
-        {{- range $_, $param := $spec.SortedParams}}
+        {{- range $_, $param := $nested.Spec.SortedParams}}
             {{$param.Name.CamelCase}} {{specParamType $name $param}}
         {{- end}}
-        {{- range $_, $param := $spec.SortedOneOf}}
+        {{- range $_, $param := $nested.Spec.SortedOneOf}}
             {{$param.Name.CamelCase}} {{specParamType $name $param}}
         {{- end}}
         }
@@ -139,13 +139,13 @@ return configList, nil
       {{- template "configXmlStructTmpl" Map "Version" $version.Minimum }}
     {{- end}}
 
-    {{- range $name, $spec := nestedSpecs $.Spec }}
-      {{- template "configXmlChildStructTmpl" Map "Name" $name "Spec" $spec "Version" nil }}
+    {{- range $name, $nested := nestedSpecs $.Spec }}
+      {{- template "configXmlChildStructTmpl" Map "Name" $name "ParentIsList" $nested.ParentIsList "Spec" $nested.Spec "Version" nil }}
     {{- end }}
 
     {{- range $version := .SupportedVersionRanges }}
-      {{- range $name, $spec := nestedSpecs $.Spec }}
-        {{- template "configXmlChildStructTmpl" Map "Name" $name "Spec" $spec "Version" $version.Minimum }}
+      {{- range $name, $nested := nestedSpecs $.Spec }}
+        {{- template "configXmlChildStructTmpl" Map "Name" $name "ParentIsList" $nested.ParentIsList "Spec" $nested.Spec "Version" $version.Minimum }}
       {{- end}}
     {{- end}}
 

--- a/templates/sdk/entry.tmpl
+++ b/templates/sdk/entry.tmpl
@@ -29,7 +29,7 @@ type entryXml{{createGoSuffixFromVersion $.Version}} struct {
 {{- define "entryXmlChildStructTmpl" }}
 type {{ .Name }}Xml{{createGoSuffixFromVersion $.Version}} struct {
   {{- range $_, $param := $.Spec.Params}}
-    {{- if eq $param.Name.CamelCase "Name"}}
+    {{- if and ($.ParentIsList) (eq $param.Name.CamelCase "Name") }}
 	XMLName xml.Name `xml:"entry"`
     {{- end}}
     {{- if paramSupportedInVersion $param $.Version}}
@@ -129,12 +129,12 @@ return entryList, nil
     Misc map[string][]generic.Xml
     }
 
-    {{ range $name, $spec := nestedSpecs $.Spec }}
+    {{ range $name, $nested := nestedSpecs $.Spec }}
         type {{$name}}{{createGoSuffixFromVersion nil}} struct {
-        {{- range $param := $spec.SortedParams}}
+        {{- range $param := $nested.Spec.SortedParams}}
             {{$param.Name.CamelCase}} {{specParamType $name $param}}
         {{- end}}
-        {{- range $param := $spec.SortedOneOf}}
+        {{- range $param := $nested.Spec.SortedOneOf}}
             {{$param.Name.CamelCase}} {{specParamType $name $param}}
         {{- end}}
         }
@@ -155,13 +155,13 @@ return entryList, nil
         {{- template "entryXmlStructTmpl" Map "Spec" $.Spec "Version" $version.Minimum }}
     {{- end}}
 
-    {{- range $name, $spec := nestedSpecs $.Spec }}
-      {{- template "entryXmlChildStructTmpl" Map "Name" $name "Spec" $spec "Version" nil }}
+    {{- range $name, $nested := nestedSpecs $.Spec }}
+      {{- template "entryXmlChildStructTmpl" Map "Name" $name "ParentIsList" $nested.ParentIsList "Spec" $nested.Spec "Version" nil }}
     {{- end }}
 
     {{- range $version := .SupportedVersionRanges }}
-      {{- range $name, $spec := nestedSpecs $.Spec }}
-        {{- template "entryXmlChildStructTmpl" Map "Name" $name "Spec" $spec "Version" $version.Minimum }}
+      {{- range $name, $nested := nestedSpecs $.Spec }}
+        {{- template "entryXmlChildStructTmpl" Map "Name" $name "ParentIsList" $nested.ParentIsList "Spec" $nested.Spec "Version" $version.Minimum }}
       {{- end }}
     {{- end}}
 


### PR DESCRIPTION
In some circumstances (non-list parameter with explicit "name" attribute)
it was possible to generate XML struct that cannot be marshaled into an XML
document due to XMLName being different from the name tag in a parent structure.