### PR TITLE
feat: Unify location types, making a shared location an (optionally) empty object

### DIFF
--- a/assets/pango/example/main.go
+++ b/assets/pango/example/main.go
@@ -159,20 +159,18 @@ func checkSharedObjects(c *pango.Client, ctx context.Context) {
 			IpNetmask:   util.String("1.2.3.4"),
 		}
 
-		addressLocation := address.Location{
-			Shared: true,
-		}
+		addressLocation := address.NewSharedLocation()
 
 		addressApi := address.NewService(c)
 
-		addressReply, err := addressApi.Create(ctx, addressLocation, addressObject)
+		addressReply, err := addressApi.Create(ctx, *addressLocation, addressObject)
 		if err != nil {
 			log.Printf("Failed to create object: %s", err)
 			return
 		}
 		log.Printf("Address '%s=%s' created", addressReply.Name, *addressReply.IpNetmask)
 
-		err = addressApi.Delete(ctx, addressLocation, addressReply.Name)
+		err = addressApi.Delete(ctx, *addressLocation, addressReply.Name)
 		if err != nil {
 			log.Printf("Failed to delete object: %s", err)
 			return

--- a/assets/terraform/test/resource_address_group_test.go
+++ b/assets/terraform/test/resource_address_group_test.go
@@ -103,7 +103,7 @@ func makeAddressGroupConfig(label string) string {
 
     resource "panos_addresses" "google_dns_servers" {
       location = {
-        shared = true
+        shared = {}
       }
 
       addresses = {
@@ -116,7 +116,7 @@ func makeAddressGroupConfig(label string) string {
     resource "panos_address_group" "%s_base" {
       count = var.from_address_group ? 1 : 0
       location = {
-        shared = true
+        shared = {}
       }
 
       name   = "${var.address_group_name}-base-${var.name_suffix}"
@@ -126,7 +126,7 @@ func makeAddressGroupConfig(label string) string {
     resource "panos_address_group" "%s" {
 
       location = {
-        shared = true
+        shared = {}
       }
 
       name = "${var.address_group_name}-${var.name_suffix}"

--- a/assets/terraform/test/resource_addresses_test.go
+++ b/assets/terraform/test/resource_addresses_test.go
@@ -189,7 +189,7 @@ variable "addresses" {
 }
 
 resource "panos_administrative_tag" "tag" {
-  location = { shared = true }
+  location = { shared = {} }
 
   name = format("%s-tag", var.prefix)
 }
@@ -197,7 +197,7 @@ resource "panos_administrative_tag" "tag" {
 resource "panos_addresses" "addresses" {
   depends_on = [ resource.panos_administrative_tag.tag ]
 
-  location = { shared = true }
+  location = { shared = {} }
 
   addresses = { for name, value in var.addresses : name => {
     disable_override = value.disable_override,

--- a/assets/terraform/test/resource_administrative_tag_test.go
+++ b/assets/terraform/test/resource_administrative_tag_test.go
@@ -27,7 +27,7 @@ func TestAccAdministrativeTag(t *testing.T) {
 	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
 
 	location := config.ObjectVariable(map[string]config.Variable{
-		"shared": config.BoolVariable(true),
+		"shared": config.ObjectVariable(map[string]config.Variable{}),
 	})
 
 	resource.Test(t, resource.TestCase{

--- a/assets/terraform/test/resource_custom_url_category_test.go
+++ b/assets/terraform/test/resource_custom_url_category_test.go
@@ -94,7 +94,7 @@ variable type { type = string }
 variable list { type = list(string) }
 
 resource "panos_custom_url_category" "category" {
-  location = { shared = true }
+  location = { shared = {} }
 
   name = format("%s-category", var.prefix)
   type = var.type

--- a/assets/terraform/test/resource_service_group_test.go
+++ b/assets/terraform/test/resource_service_group_test.go
@@ -80,14 +80,14 @@ variable "groups" {
 }
 
 resource "panos_service" "svc" {
-  location = { shared = true }
+  location = { shared = {} }
 
   name = format("%s-svc", var.prefix)
   protocol = { tcp = { source_port = 80, destination_port = 443 }}
 }
 
 resource "panos_administrative_tag" "tag" {
-  location = { shared = true }
+  location = { shared = {} }
 
   name = format("%s-tag", var.prefix)
 }
@@ -97,7 +97,7 @@ resource "panos_service_group" "group1" {
     resource.panos_service.svc,
     resource.panos_administrative_tag.tag
   ]
-  location = { shared = true }
+  location = { shared = {} }
 
   name = format("%s-group1", var.prefix)
   members = var.groups["group1"].members
@@ -105,7 +105,7 @@ resource "panos_service_group" "group1" {
 }
 
 resource "panos_service_group" "group2" {
-  location = { shared = true }
+  location = { shared = {} }
 
   name = format("%s-group2", var.prefix)
   members = var.groups["group2"].members

--- a/assets/terraform/test/resource_service_test.go
+++ b/assets/terraform/test/resource_service_test.go
@@ -223,7 +223,7 @@ variable "services" {
 }
 
 resource "panos_administrative_tag" "tag" {
-  location = { shared = true }
+  location = { shared = {} }
 
   name = format("%s-tag", var.prefix)
 }
@@ -231,7 +231,7 @@ resource "panos_administrative_tag" "tag" {
 resource "panos_service" "svc1" {
   depends_on = [ resource.panos_administrative_tag.tag ]
 
-  location = { shared = true }
+  location = { shared = {} }
 
   name        = format("%s-svc1", var.prefix)
   description = var.services["svc1"].description
@@ -243,7 +243,7 @@ resource "panos_service" "svc1" {
 resource "panos_service" "svc2" {
   depends_on = [ resource.panos_administrative_tag.tag ]
 
-  location = { shared = true }
+  location = { shared = {} }
 
   name        = format("%s-svc2", var.prefix)
   description = var.services["svc2"].description
@@ -255,7 +255,7 @@ resource "panos_service" "svc2" {
 resource "panos_service" "svc3" {
   depends_on = [ resource.panos_administrative_tag.tag ]
 
-  location = { shared = true }
+  location = { shared = {} }
 
   name        = format("%s-svc3", var.prefix)
   description = var.services["svc3"].description
@@ -267,7 +267,7 @@ resource "panos_service" "svc3" {
 resource "panos_service" "svc4" {
   depends_on = [ resource.panos_administrative_tag.tag ]
 
-  location = { shared = true }
+  location = { shared = {} }
 
   name        = format("%s-svc4", var.prefix)
   description = var.services["svc4"].description

--- a/pkg/properties/normalized.go
+++ b/pkg/properties/normalized.go
@@ -112,11 +112,7 @@ type Location struct {
 }
 
 func (o Location) ValidatorType() string {
-	if len(o.Vars) == 0 {
-		return "bool"
-	} else {
-		return "object"
-	}
+	return "object"
 }
 
 func (o *Location) OrderedVars() []*LocationVar {

--- a/pkg/translate/structs.go
+++ b/pkg/translate/structs.go
@@ -18,11 +18,7 @@ func LocationType(location *properties.Location, pointer bool) string {
 	if pointer {
 		prefix = "*"
 	}
-	if location.Vars != nil {
-		return fmt.Sprintf("%s%sLocation", prefix, location.Name.CamelCase)
-	} else {
-		return "bool"
-	}
+	return fmt.Sprintf("%s%sLocation", prefix, location.Name.CamelCase)
 }
 
 // NestedSpecs goes through all params and one ofs (recursively) and returns map of all nested specs.

--- a/pkg/translate/structs_test.go
+++ b/pkg/translate/structs_test.go
@@ -30,7 +30,7 @@ func TestLocationType(t *testing.T) {
 	// then
 	assert.NotEmpty(t, locationTypes)
 	assert.Contains(t, locationTypes, "*DeviceGroupLocation")
-	assert.Contains(t, locationTypes, "bool")
+	assert.Contains(t, locationTypes, "*SharedLocation")
 }
 
 func TestSpecParamType(t *testing.T) {

--- a/pkg/translate/terraform_provider/terraform_provider_file.go
+++ b/pkg/translate/terraform_provider/terraform_provider_file.go
@@ -536,10 +536,8 @@ func conditionallyAddModifiers(manager *imports.Manager, spec *properties.Normal
 	}
 
 	for _, loc := range spec.Locations {
-		if len(loc.Vars) == 0 {
-			manager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier", "")
-		} else {
-			manager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier", "")
+		manager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier", "")
+		if len(loc.Vars) > 0 {
 			manager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier", "")
 		}
 	}

--- a/templates/sdk/location.tmpl
+++ b/templates/sdk/location.tmpl
@@ -14,17 +14,14 @@ type Location struct {
 {{end}}
 }
 {{range $location := .OrderedLocations}}
-    {{- if $location.Vars}}
         type {{locationType $location false}} struct {
         {{- range $key, $var := $location.Vars}}
             {{$var.Name.CamelCase}} string `json:"{{$var.Name.Underscore}}"`
         {{- end}}
         }
-    {{end}}
 {{- end}}
 
 {{range $location := .OrderedLocations}}
-    {{- if $location.Vars}}
         func New{{locationType $location false}}() *Location {
             return &Location{
                 {{- $location.Name.CamelCase}}: &{{locationType $location false}}{
@@ -34,15 +31,6 @@ type Location struct {
                 },
             }
         }
-    {{- else}}
-        {{- if eq $location.Name.CamelCase "Shared"}}
-        func NewSharedLocation() *Location {
-            return &Location{
-                Shared: true,
-            }
-        }
-        {{- end}}
-    {{- end}}
 {{- end}}
 
 func (o Location) IsValid() error {


### PR DESCRIPTION
Before, most shared locations were rendered as boolean types. This
however was not always the case, for some shared locations additional
attributes were needed and so those were rendered as objects, possibly
leading to confusion.

Make it so all shared locations are always objects (and structures in Go SDK),
some of which have no attributes/fields.