### PR TITLE
feat(codegen): Add support for multiple variant groups within single spec

### DIFF
--- a/pkg/properties/normalized.go
+++ b/pkg/properties/normalized.go
@@ -193,6 +193,7 @@ type SpecParam struct {
 	Items                   *SpecParamItems                   `json:"items" yaml:"items,omitempty"`
 	Regex                   string                            `json:"regex" yaml:"regex,omitempty"`
 	Profiles                []*SpecParamProfile               `json:"profiles" yaml:"profiles"`
+	VariantGroupId          int                               `json:"variant_group_id" yaml:"variant_group_id"`
 	Spec                    *Spec                             `json:"spec" yaml:"spec"`
 }
 
@@ -585,6 +586,7 @@ func schemaParameterToSpecParameter(schemaSpec *parameter.Parameter) (*SpecParam
 			VariantCheck: variantCheck,
 		}
 	}
+
 	specParameter := &SpecParam{
 		Description:             schemaSpec.Description,
 		Type:                    specType,
@@ -595,6 +597,7 @@ func schemaParameterToSpecParameter(schemaSpec *parameter.Parameter) (*SpecParam
 		Hashing:                 specHashing,
 		Profiles:                profiles,
 		Spec:                    innerSpec,
+		VariantGroupId:          schemaSpec.VariantGroupId,
 	}
 
 	for _, v := range schemaSpec.Validators {

--- a/pkg/schema/parameter/parameter.go
+++ b/pkg/schema/parameter/parameter.go
@@ -27,6 +27,7 @@ type Parameter struct {
 	Required         bool                  `yaml:"required"`
 	Profiles         []profile.Profile     `yaml:"profiles"`
 	Validators       []validator.Validator `yaml:"validators"`
+	VariantGroupId   int                   `yaml:"variant_group_id"`
 	Spec             any                   `yaml:"-"`
 }
 


### PR DESCRIPTION
For future use, some specs will have multiple <choice> XML nodes within a single parent, and those should not all be validated within terraform against each other.