### PR TITLE
fix(terraform): Use terraform types for position and location struct members

### DIFF
--- a/assets/terraform/internal/provider/errors.go
+++ b/assets/terraform/internal/provider/errors.go
@@ -1,3 +1,33 @@
 package provider
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
 var InspectionModeError = "Resources are unavailable when the provider is in inspection mode.  Resources are only available in API mode."
+
+type DiagnosticsError struct {
+	message     string
+	diagnostics diag.Diagnostics
+}
+
+func NewDiagnosticsError(message string, diags diag.Diagnostics) *DiagnosticsError {
+	return &DiagnosticsError{
+		diagnostics: diags.Errors(),
+	}
+}
+
+func (o *DiagnosticsError) Diagnostics() diag.Diagnostics {
+	return o.diagnostics
+}
+
+func (o *DiagnosticsError) Error() string {
+	var summaries []string
+	for _, elt := range o.diagnostics {
+		summaries = append(summaries, elt.Summary())
+	}
+	return fmt.Sprintf("%s: %s", o.message, strings.Join(summaries, ", "))
+}

--- a/assets/terraform/internal/provider/position.go
+++ b/assets/terraform/internal/provider/position.go
@@ -2,8 +2,10 @@ package provider
 
 import (
 	"encoding/json"
+	"fmt"
 	"slices"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	rsschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -16,6 +18,14 @@ type TerraformPositionObject struct {
 	Where    types.String `tfsdk:"where"`
 	Pivot    types.String `tfsdk:"pivot"`
 	Directly types.Bool   `tfsdk:"directly"`
+}
+
+func (o *TerraformPositionObject) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"where":    types.StringType,
+		"pivot":    types.StringType,
+		"directly": types.BoolType,
+	}
 }
 
 func TerraformPositionObjectSchema() rsschema.SingleNestedAttribute {
@@ -60,10 +70,10 @@ func (o *TerraformPositionObject) ValidateConfig(resp *resource.ValidateConfigRe
 	allowedPositions := []string{"first", "last", "before", "after"}
 
 	if !slices.Contains(allowedPositions, o.Where.ValueString()) {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("position").AtName("directly"),
+		resp.Diagnostics.AddAttributeWarning(
+			path.Root("position").AtName("where"),
 			"Missing attribute configuration",
-			"where attribute must be one of the valid values: first, last, before, after")
+			fmt.Sprintf("where attribute must be one of the valid values: first, last, before, after, found: '%s'", o.Where.ValueString()))
 	}
 
 	if !o.Pivot.IsNull() && o.Directly.IsNull() {

--- a/pkg/translate/terraform_provider/device_group_parent_crud.go
+++ b/pkg/translate/terraform_provider/device_group_parent_crud.go
@@ -4,6 +4,8 @@ const deviceGroupParentImports = `
 import (
   "encoding/xml"
 
+  "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
   sdkerrors "github.com/PaloAltoNetworks/pango/errors"
   "github.com/PaloAltoNetworks/pango/util"
   "github.com/PaloAltoNetworks/pango/xmlapi"

--- a/pkg/translate/terraform_provider/terraform_provider_file.go
+++ b/pkg/translate/terraform_provider/terraform_provider_file.go
@@ -179,6 +179,9 @@ func (g *GenerateTerraformProvider) GenerateTerraformResource(resourceTyp proper
 		"RenderResourceSchema": func() (string, error) {
 			return RenderResourceSchema(resourceTyp, names, spec, terraformProvider.ImportManager)
 		},
+		"RenderModelAttributeTypesFunction": func() (string, error) {
+			return RenderModelAttributeTypesFunction(resourceTyp, properties.SchemaResource, names, spec)
+		},
 		"RenderCopyToPangoFunctions": func() (string, error) {
 			return RenderCopyToPangoFunctions(resourceTyp, names.PackageName, names.ResourceStructName, spec)
 		},
@@ -211,6 +214,9 @@ func (g *GenerateTerraformProvider) GenerateTerraformResource(resourceTyp proper
 		},
 		"RenderImportStateStructs": func() (string, error) {
 			return RenderImportStateStructs(resourceTyp, names, spec)
+		},
+		"RenderImportStateMarshallers": func() (string, error) {
+			return RenderImportStateMarshallers(resourceTyp, names, spec)
 		},
 		"RenderImportStateCreator": func() (string, error) {
 			return RenderImportStateCreator(resourceTyp, names, spec)
@@ -366,6 +372,9 @@ func (g *GenerateTerraformProvider) GenerateTerraformDataSource(resourceTyp prop
 			"FunctionSupported": func(function string) (bool, error) {
 				return FunctionSupported(spec, function)
 			},
+			"RenderModelAttributeTypesFunction": func() (string, error) {
+				return RenderModelAttributeTypesFunction(resourceTyp, properties.SchemaDataSource, names, spec)
+			},
 			"RenderCopyToPangoFunctions": func() (string, error) {
 				return RenderCopyToPangoFunctions(resourceTyp, names.PackageName, names.DataSourceStructName, spec)
 			},
@@ -414,7 +423,9 @@ func (g *GenerateTerraformProvider) GenerateCommonCode(resourceTyp properties.Re
 		terraformProvider.ImportManager.AddStandardImport("encoding/base64", "")
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/types/basetypes", "")
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/path", "")
-	case properties.ResourceConfig, properties.ResourceCustom:
+	case properties.ResourceConfig:
+		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/types/basetypes", "")
+	case properties.ResourceCustom:
 	}
 
 	names := NewNameProvider(spec, resourceTyp)
@@ -425,7 +436,10 @@ func (g *GenerateTerraformProvider) GenerateCommonCode(resourceTyp properties.Re
 			return RenderLocationSchemaGetter(names, spec, terraformProvider.ImportManager)
 		},
 		"RenderLocationMarshallers": func() (string, error) { return RenderLocationMarshallers(names, spec) },
-		"RenderCustomCommonCode":    func() string { return RenderCustomCommonCode(names, spec) },
+		"RenderLocationAttributeTypes": func() (string, error) {
+			return RenderLocationAttributeTypes(names, spec)
+		},
+		"RenderCustomCommonCode": func() string { return RenderCustomCommonCode(names, spec) },
 	}
 	return g.generateTerraformEntityTemplate(resourceTyp, properties.SchemaCommon, names, spec, terraformProvider, commonTemplate, funcMap)
 }


### PR DESCRIPTION
By using terraform types for locations and positions we allow use of variables to populate those fields wholesale, and not on by-attribute basis.

This fixes usage of variables to provide location and position in resources.