### PR TITLE
fix(specs,codegen): Add template import location for tunnel interfaces

### DIFF
--- a/pkg/translate/terraform_provider/funcs.go
+++ b/pkg/translate/terraform_provider/funcs.go
@@ -875,11 +875,23 @@ func RenderLocationSchemaGetter(names *NameProvider, spec *properties.Normalizat
 
 			for _, elt := range i.OrderedLocations() {
 				if elt.Required {
+					var defaultValue *defaultCtx
+					for varName, variable := range elt.XpathVariables {
+						if varName == elt.Name.Original && variable.Default != "" {
+							defaultValue = &defaultCtx{
+								Type:  "stringdefault.StaticString",
+								Value: fmt.Sprintf(`"%s"`, variable.Default),
+							}
+						}
+					}
 					variableAttrs = append(variableAttrs, attributeCtx{
 						Name:         elt.Name,
 						SchemaType:   "rsschema.StringAttribute",
-						Required:     true,
+						Required:     defaultValue == nil,
+						Optional:     defaultValue != nil,
+						Computed:     defaultValue != nil,
 						ModifierType: "String",
+						Default:      defaultValue,
 					})
 				}
 			}

--- a/specs/network/interface/tunnel.yaml
+++ b/specs/network/interface/tunnel.yaml
@@ -128,7 +128,29 @@ entries:
 - name: name
   description: ''
   validators: []
-imports: []
+imports:
+- variant: layer3
+  type: template
+  locations:
+  - name: vsys
+    xpath:
+      path:
+      - vsys
+      - $vsys
+      - import
+      - network
+      - interface
+      vars:
+      - name: vsys
+        description: The vsys.
+        required: false
+        default: vsys1
+        validators: []
+        type: entry
+    description: ''
+    validators: []
+    required: true
+    read_only: false
 spec:
   params:
   - name: bonjour


### PR DESCRIPTION
Add a missing template import location for the tunnel interface, and improve codegen
to set default values for the import attribute within terraform locations.