### PR TITLE
feat(codegen): Add support for child specs

### DIFF
--- a/assets/pango/errors/panos.go
+++ b/assets/pango/errors/panos.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+var ObjectExists = stderr.New("object already exists")
 var InvalidFilterError = stderr.New("filter is improperly formatted")
 var NameNotSpecifiedError = stderr.New("name is not specified")
 var NoLocationSpecifiedError = stderr.New("no location specified")
@@ -149,5 +150,19 @@ func (e *errorCheck) CodeError() string {
 		return "Session timed out"
 	default:
 		return fmt.Sprintf("(%d) Unknown failure code, operation failed", e.Code)
+	}
+}
+
+type InvalidXpathComponentError struct {
+	Message string
+}
+
+func (o InvalidXpathComponentError) Error() string {
+	return o.Message
+}
+
+func NewInvalidXpathComponentError(message string) *InvalidXpathComponentError {
+	return &InvalidXpathComponentError{
+		Message: message,
 	}
 }

--- a/assets/pango/example/main.go
+++ b/assets/pango/example/main.go
@@ -670,8 +670,8 @@ func checkSecurityPolicyRules(c *pango.Client, ctx context.Context) {
 	log.Printf("Security policy rule '%s:%s' with description '%s' read by id", *securityPolicyRuleReply.Uuid, securityPolicyRuleReply.Name, *securityPolicyRuleReply.Description)
 
 	// SECURITY POLICY RULE - UPDATE 2
-	securityPolicyRuleEntry.Description = util.String("changed by id description")
-	securityPolicyRuleReply, err = securityPolicyRuleApi.UpdateById(ctx, *securityPolicyRuleLocation, securityPolicyRuleEntry, *securityPolicyRuleReply.Uuid)
+	securityPolicyRuleEntry.Description = util.String("changed by name description")
+	securityPolicyRuleReply, err = securityPolicyRuleApi.Update(ctx, *securityPolicyRuleLocation, securityPolicyRuleEntry, securityPolicyRuleReply.Name)
 	if err != nil {
 		log.Printf("Failed to update security policy rule: %s", err)
 		return

--- a/assets/pango/util/util.go
+++ b/assets/pango/util/util.go
@@ -109,7 +109,7 @@ func AsXpath(i interface{}) string {
 }
 
 // AsEntryXpath returns the given values as an entry xpath segment.
-func AsEntryXpath(vals []string) string {
+func AsEntryXpath(vals ...string) string {
 	if len(vals) == 0 || (len(vals) == 1 && vals[0] == "") {
 		return "entry"
 	}
@@ -160,18 +160,18 @@ func TemplateXpathPrefix(tmpl, ts string) []string {
 		return []string{
 			"config",
 			"devices",
-			AsEntryXpath([]string{"localhost.localdomain"}),
+			AsEntryXpath("localhost.localdomain"),
 			"template",
-			AsEntryXpath([]string{tmpl}),
+			AsEntryXpath(tmpl),
 		}
 	}
 
 	return []string{
 		"config",
 		"devices",
-		AsEntryXpath([]string{"localhost.localdomain"}),
+		AsEntryXpath("localhost.localdomain"),
 		"template-stack",
-		AsEntryXpath([]string{ts}),
+		AsEntryXpath(ts),
 	}
 }
 
@@ -185,9 +185,9 @@ func DeviceGroupXpathPrefix(dg string) []string {
 	return []string{
 		"config",
 		"devices",
-		AsEntryXpath([]string{"localhost.localdomain"}),
+		AsEntryXpath("localhost.localdomain"),
 		"device-group",
-		AsEntryXpath([]string{dg}),
+		AsEntryXpath(dg),
 	}
 }
 
@@ -202,9 +202,9 @@ func VsysXpathPrefix(vsys string) []string {
 	return []string{
 		"config",
 		"devices",
-		AsEntryXpath([]string{"localhost.localdomain"}),
+		AsEntryXpath("localhost.localdomain"),
 		"vsys",
-		AsEntryXpath([]string{vsys}),
+		AsEntryXpath(vsys),
 	}
 }
 

--- a/assets/pango/util/util_test.go
+++ b/assets/pango/util/util_test.go
@@ -106,9 +106,9 @@ func BenchmarkAsXpath(b *testing.B) {
 	p := []string{
 		"config",
 		"devices",
-		AsEntryXpath([]string{"localhost.localdomain"}),
+		AsEntryXpath("localhost.localdomain"),
 		"vsys",
-		AsEntryXpath([]string{"vsys1"}),
+		AsEntryXpath("vsys1"),
 		"import",
 		"network",
 	}
@@ -124,7 +124,7 @@ func BenchmarkAsEntryXpathMultiple(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = AsEntryXpath(v)
+		_ = AsEntryXpath(v...)
 	}
 }
 
@@ -159,7 +159,7 @@ func TestAsEntryXpath(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.r, func(t *testing.T) {
-			if AsEntryXpath(tc.v) != tc.r {
+			if AsEntryXpath(tc.v...) != tc.r {
 				t.Fail()
 			}
 		})

--- a/assets/terraform/go.mod
+++ b/assets/terraform/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.12.0
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
-	golang.org/x/sync v0.13.0
 )
 
 require (
@@ -63,6 +62,7 @@ require (
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 	golang.org/x/tools v0.28.0 // indirect

--- a/assets/terraform/internal/manager/entry_import.go
+++ b/assets/terraform/internal/manager/entry_import.go
@@ -2,27 +2,35 @@ package manager
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	sdkerrors "github.com/PaloAltoNetworks/pango/errors"
+	"github.com/PaloAltoNetworks/pango/util"
+	"github.com/PaloAltoNetworks/pango/xmlapi"
 )
 
 type SDKImportableEntryService[E EntryObject, L EntryLocation, IL ImportLocation] interface {
-	Create(context.Context, L, []IL, E) (E, error)
-	Read(context.Context, L, string, string) (E, error)
+	CreateWithXpath(context.Context, string, E) error
+	ReadWithXpath(context.Context, string, string) (E, error)
 	List(context.Context, L, string, string, string) ([]E, error)
-	Update(context.Context, L, E, string) (E, error)
+	UpdateWithXpath(context.Context, string, E, string) error
 	Delete(context.Context, L, []IL, ...string) error
+	ImportToLocations(context.Context, L, []IL, string) error
+	UnimportFromLocations(context.Context, L, []IL, []string) error
 }
 
 type ImportableEntryObjectManager[E EntryObject, L EntryLocation, IL ImportLocation, IS SDKImportableEntryService[E, L, IL]] struct {
+	batchSize int
 	service   IS
 	client    SDKClient
 	specifier func(E) (any, error)
 	matcher   func(E, E) bool
 }
 
-func NewImportableEntryObjectManager[E EntryObject, L EntryLocation, IL ImportLocation, IS SDKImportableEntryService[E, L, IL]](client SDKClient, service IS, specifier func(E) (any, error), matcher func(E, E) bool) *ImportableEntryObjectManager[E, L, IL, IS] {
+func NewImportableEntryObjectManager[E EntryObject, L EntryLocation, IL ImportLocation, IS SDKImportableEntryService[E, L, IL]](client SDKClient, service IS, batchSize int, specifier func(E) (any, error), matcher func(E, E) bool) *ImportableEntryObjectManager[E, L, IL, IS] {
 	return &ImportableEntryObjectManager[E, L, IL, IS]{
+		batchSize: batchSize,
 		service:   service,
 		client:    client,
 		specifier: specifier,
@@ -34,44 +42,91 @@ func (o *ImportableEntryObjectManager[E, L, IL, IS]) ReadMany(ctx context.Contex
 	return nil, &Error{err: ErrInternal, message: "called ReadMany on an importable singular resource"}
 }
 
-func (o *ImportableEntryObjectManager[E, L, IL, IS]) Read(ctx context.Context, location L, name string) (E, error) {
-	object, err := o.service.Read(ctx, location, name, "get")
+func (o *ImportableEntryObjectManager[E, L, IL, IS]) Read(ctx context.Context, location L, components []string, name string) (E, error) {
+	xpath, err := location.XpathWithComponents(o.client.Versioning(), append(components, util.AsEntryXpath(name))...)
 	if err != nil {
-		return *new(E), ErrObjectNotFound
+		return *new(E), err
+	}
+
+	object, err := o.service.ReadWithXpath(ctx, util.AsXpath(xpath), "get")
+	if err != nil {
+		if sdkerrors.IsObjectNotFound(err) {
+			return *new(E), ErrObjectNotFound
+		}
+		return *new(E), &Error{err: err}
 	}
 
 	return object, nil
 }
 
-func (o *ImportableEntryObjectManager[E, L, IL, IS]) Create(ctx context.Context, location L, importLocs []IL, entry E) (E, error) {
-	existing, err := o.service.List(ctx, location, "get", "", "")
-	if err != nil && !sdkerrors.IsObjectNotFound(err) {
+func (o *ImportableEntryObjectManager[E, L, IL, IS]) Create(ctx context.Context, location L, components []string, entry E) (E, error) {
+	name := entry.EntryName()
+
+	_, err := o.Read(ctx, location, components, name)
+	if err == nil {
+		return *new(E), &Error{err: ErrConflict, message: fmt.Sprintf("entry '%s' already exists", name)}
+	}
+
+	if err != nil && !errors.Is(err, ErrObjectNotFound) {
 		return *new(E), err
 	}
 
-	for _, elt := range existing {
-		if elt.EntryName() == entry.EntryName() {
-			return *new(E), ErrConflict
-		}
+	xpath, err := location.XpathWithComponents(o.client.Versioning(), append(components, util.AsEntryXpath(name))...)
+	if err != nil {
+		return *new(E), err
 	}
 
-	obj, err := o.service.Create(ctx, location, importLocs, entry)
-	return obj, err
+	err = o.service.CreateWithXpath(ctx, util.AsXpath(xpath[:len(xpath)-1]), entry)
+	if err != nil {
+		return *new(E), err
+	}
+
+	return o.Read(ctx, location, components, name)
 }
 
-func (o *ImportableEntryObjectManager[E, L, IL, IS]) Update(ctx context.Context, location L, entry E, name string) (E, error) {
-	updated, err := o.service.Update(ctx, location, entry, name)
+func (o *ImportableEntryObjectManager[E, L, IL, IS]) Update(ctx context.Context, location L, components []string, entry E, name string) (E, error) {
+	xpath, err := location.XpathWithComponents(o.client.Versioning(), append(components, util.AsEntryXpath(entry.EntryName()))...)
 	if err != nil {
 		return *new(E), &Error{err: err, message: "error during Update call"}
 	}
 
-	return updated, nil
+	err = o.service.UpdateWithXpath(ctx, util.AsXpath(xpath), entry, name)
+	if err != nil {
+		return *new(E), &Error{err: err, message: "error during Update call"}
+	}
+
+	return o.service.ReadWithXpath(ctx, util.AsXpath(xpath), "get")
 }
 
-func (o *ImportableEntryObjectManager[E, L, IL, IS]) Delete(ctx context.Context, location L, importLocations []IL, names []string, exhaustive ExhaustiveType) error {
-	err := o.service.Delete(ctx, location, importLocations, names...)
+func (o *ImportableEntryObjectManager[E, L, IL, IS]) Delete(ctx context.Context, location L, importLocations []IL, components []string, names []string) error {
+	deletes := xmlapi.NewChunkedMultiConfig(o.batchSize, len(names))
+
+	for _, elt := range names {
+		components := append(components, util.AsEntryXpath(elt))
+		xpath, err := location.XpathWithComponents(o.client.Versioning(), components...)
+		if err != nil {
+			return err
+		}
+
+		deletes.Add(&xmlapi.Config{
+			Action: "delete",
+			Xpath:  util.AsXpath(xpath),
+			Target: o.client.GetTarget(),
+		})
+	}
+
+	_, _, _, err := o.client.MultiConfig(ctx, deletes, false, nil)
 	if err != nil {
 		return &Error{err: err, message: "sdk error while deleting"}
 	}
+
 	return nil
+}
+
+func (o *ImportableEntryObjectManager[E, L, IL, IS]) ImportToLocations(ctx context.Context, location L, importLocs []IL, entry string) error {
+	return o.service.ImportToLocations(ctx, location, importLocs, entry)
+}
+
+func (o *ImportableEntryObjectManager[E, L, IL, IS]) UnimportFromLocations(ctx context.Context, location L, importLocs []IL, entry string) error {
+	return o.service.UnimportFromLocations(ctx, location, importLocs, []string{entry})
 }

--- a/assets/terraform/internal/manager/uuid_test.go
+++ b/assets/terraform/internal/manager/uuid_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Server", func() {
 
 			It("CreateMany() should create new entries on the server, and return them with uuid set", func() {
 				entries := []*MockUuidObject{{Name: "1", Value: "A"}}
-				processed, err := manager.CreateMany(ctx, location, entries, sdkmanager.Exhaustive, movement.PositionFirst{})
+				processed, err := manager.CreateMany(ctx, location, []string{}, entries, sdkmanager.Exhaustive, movement.PositionFirst{})
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(processed).To(HaveLen(1))
@@ -91,7 +91,7 @@ var _ = Describe("Server", func() {
 				})
 
 				It("should not create any entries and return an error", func() {
-					processed, err := manager.CreateMany(ctx, location, entries, mode, position)
+					processed, err := manager.CreateMany(ctx, location, []string{}, entries, mode, position)
 
 					Expect(err).To(MatchError(sdkmanager.ErrConflict))
 					Expect(processed).To(BeNil())
@@ -102,7 +102,7 @@ var _ = Describe("Server", func() {
 
 			Context("and all entries being created are new to the server", func() {
 				It("should create those entries in the correct position", func() {
-					processed, err := manager.CreateMany(ctx, location, entries, sdkmanager.NonExhaustive, movement.PositionFirst{})
+					processed, err := manager.CreateMany(ctx, location, []string{}, entries, sdkmanager.NonExhaustive, movement.PositionFirst{})
 
 					Expect(err).ToNot(HaveOccurred())
 					Expect(processed).To(HaveLen(2))
@@ -123,7 +123,7 @@ var _ = Describe("Server", func() {
 				})
 
 				It("should not return any error and overwrite all entries on the server", func() {
-					processed, err := manager.CreateMany(ctx, location, entries, mode, position)
+					processed, err := manager.CreateMany(ctx, location, []string{}, entries, mode, position)
 
 					Expect(err).ToNot(HaveOccurred())
 
@@ -172,7 +172,7 @@ var _ = Describe("Server", func() {
 				Expect(processed).To(HaveLen(3))
 				Expect(processed).NotTo(MatchEntries(entries))
 
-				processed, err = manager.UpdateMany(ctx, location, entries, entries, sdkmanager.NonExhaustive, movement.PositionFirst{})
+				processed, err = manager.UpdateMany(ctx, location, []string{}, entries, entries, sdkmanager.NonExhaustive, movement.PositionFirst{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(processed).To(HaveLen(3))
 
@@ -187,7 +187,7 @@ var _ = Describe("Server", func() {
 				It("should create new entries on the top of the list", func() {
 					entries := []*MockUuidObject{{Name: "4", Value: "D"}, {Name: "5", Value: "E"}, {Name: "6", Value: "F"}}
 
-					processed, err := manager.CreateMany(ctx, location, entries, sdkmanager.NonExhaustive, movement.PositionFirst{})
+					processed, err := manager.CreateMany(ctx, location, []string{}, entries, sdkmanager.NonExhaustive, movement.PositionFirst{})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(processed).To(HaveLen(3))
 
@@ -205,7 +205,7 @@ var _ = Describe("Server", func() {
 				It("should create new entries on the bottom of the list", func() {
 					entries := []*MockUuidObject{{Name: "4", Value: "D"}, {Name: "5", Value: "E"}, {Name: "6", Value: "F"}}
 
-					processed, err := manager.CreateMany(ctx, location, entries, sdkmanager.NonExhaustive, movement.PositionLast{})
+					processed, err := manager.CreateMany(ctx, location, []string{}, entries, sdkmanager.NonExhaustive, movement.PositionLast{})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(processed).To(HaveLen(3))
 
@@ -223,7 +223,7 @@ var _ = Describe("Server", func() {
 				It("should create new entries directly after first existing element", func() {
 					entries := []*MockUuidObject{{Name: "4", Value: "D"}, {Name: "5", Value: "E"}, {Name: "6", Value: "F"}}
 
-					processed, err := manager.CreateMany(ctx, location, entries, sdkmanager.NonExhaustive, movement.PositionAfter{Directly: true, Pivot: initial[0].Name})
+					processed, err := manager.CreateMany(ctx, location, []string{}, entries, sdkmanager.NonExhaustive, movement.PositionAfter{Directly: true, Pivot: initial[0].Name})
 
 					Expect(err).ToNot(HaveOccurred())
 					Expect(processed).To(HaveLen(3))
@@ -248,7 +248,7 @@ var _ = Describe("Server", func() {
 
 					pivot := initial[2].Name // "3"
 					position = movement.PositionBefore{Directly: true, Pivot: pivot}
-					processed, err := manager.CreateMany(ctx, location, entries, sdkmanager.NonExhaustive, position)
+					processed, err := manager.CreateMany(ctx, location, []string{}, entries, sdkmanager.NonExhaustive, position)
 
 					Expect(err).ToNot(HaveOccurred())
 					Expect(processed).To(HaveLen(3))
@@ -267,7 +267,7 @@ var _ = Describe("Server", func() {
 			Context("and there is a duplicate entry within a list", func() {
 				It("should properly raise an error", func() {
 					entries := []*MockUuidObject{{Name: "4", Value: "D"}, {Name: "4", Value: "D"}}
-					_, err := manager.CreateMany(ctx, location, entries, sdkmanager.NonExhaustive, movement.PositionFirst{})
+					_, err := manager.CreateMany(ctx, location, []string{}, entries, sdkmanager.NonExhaustive, movement.PositionFirst{})
 
 					Expect(err).To(MatchError(sdkmanager.ErrPlanConflict))
 				})
@@ -295,13 +295,13 @@ var _ = Describe("Server", func() {
 
 				var position movement.Position
 				position = movement.PositionFirst{}
-				_, err := manager.CreateMany(ctx, location, entries, sdkmanager.NonExhaustive, position)
+				_, err := manager.CreateMany(ctx, location, []string{}, entries, sdkmanager.NonExhaustive, position)
 				Expect(err).ToNot(HaveOccurred())
 
 				entries = []*MockUuidObject{{Name: "99", Value: "ZZ"}}
 
 				position = movement.PositionLast{}
-				_, err = manager.CreateMany(ctx, location, entries, sdkmanager.NonExhaustive, position)
+				_, err = manager.CreateMany(ctx, location, []string{}, entries, sdkmanager.NonExhaustive, position)
 				Expect(err).ToNot(HaveOccurred())
 
 				current := client.list()
@@ -313,7 +313,7 @@ var _ = Describe("Server", func() {
 
 				entries = []*MockUuidObject{{Name: "2", Value: "B"}, {Name: "3", Value: "C"}}
 				position = movement.PositionAfter{Pivot: "1", Directly: true}
-				_, err = manager.CreateMany(ctx, location, entries, sdkmanager.NonExhaustive, position)
+				_, err = manager.CreateMany(ctx, location, []string{}, entries, sdkmanager.NonExhaustive, position)
 				Expect(err).ToNot(HaveOccurred())
 
 				current = client.list()
@@ -330,7 +330,7 @@ var _ = Describe("Server", func() {
 				entries = []*MockUuidObject{{Name: "4", Value: "D"}, {Name: "5", Value: "E"}}
 				position = movement.PositionAfter{Pivot: "1", Directly: false}
 
-				_, err = manager.CreateMany(ctx, location, entries, sdkmanager.NonExhaustive, position)
+				_, err = manager.CreateMany(ctx, location, []string{}, entries, sdkmanager.NonExhaustive, position)
 				Expect(err).ToNot(HaveOccurred())
 
 				current = client.list()
@@ -349,7 +349,7 @@ var _ = Describe("Server", func() {
 				entries = []*MockUuidObject{{Name: "6", Value: "F"}, {Name: "7", Value: "G"}}
 				position = movement.PositionBefore{Pivot: "99", Directly: true}
 
-				_, err = manager.CreateMany(ctx, location, entries, sdkmanager.NonExhaustive, position)
+				_, err = manager.CreateMany(ctx, location, []string{}, entries, sdkmanager.NonExhaustive, position)
 				Expect(err).ToNot(HaveOccurred())
 
 				current = client.list()
@@ -370,7 +370,7 @@ var _ = Describe("Server", func() {
 				entries = []*MockUuidObject{{Name: "8", Value: "H"}, {Name: "9", Value: "I"}}
 				position = movement.PositionBefore{Pivot: "99", Directly: false}
 
-				_, err = manager.CreateMany(ctx, location, entries, sdkmanager.NonExhaustive, position)
+				_, err = manager.CreateMany(ctx, location, []string{}, entries, sdkmanager.NonExhaustive, position)
 				Expect(err).ToNot(HaveOccurred())
 
 				current = client.list()

--- a/assets/terraform/internal/manager/uuid_utils_test.go
+++ b/assets/terraform/internal/manager/uuid_utils_test.go
@@ -212,7 +212,7 @@ func (o *MockUuidService[E, T]) MoveGroup(ctx context.Context, location MockLoca
 
 	updates := xmlapi.NewMultiConfig(len(movements))
 	for _, elt := range movements {
-		path, err := location.XpathWithEntryName(o.client.Versioning(), elt.Movable.EntryName())
+		path, err := location.XpathWithComponents(o.client.Versioning(), elt.Movable.EntryName())
 		if err != nil {
 			return err
 		}

--- a/assets/terraform/test/resource_administrative_tag_test.go
+++ b/assets/terraform/test/resource_administrative_tag_test.go
@@ -2,14 +2,9 @@ package provider_test
 
 import (
 	"bytes"
-	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"text/template"
-
-	sdkerrors "github.com/PaloAltoNetworks/pango/errors"
-	tag "github.com/PaloAltoNetworks/pango/objects/admintag"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -17,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -111,24 +105,4 @@ func makeAdministrativeTagConfig(resourceName string) string {
 	}
 
 	return buf.String()
-}
-
-func administrativeTagCheckDestroy(prefix string, location tag.Location) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		service := tag.NewService(sdkClient)
-		ctx := context.TODO()
-
-		tags, err := service.List(ctx, location, "get", "", "")
-		if err != nil && !sdkerrors.IsObjectNotFound(err) {
-			return err
-		}
-
-		for _, elt := range tags {
-			if strings.HasPrefix(elt.Name, prefix) {
-				return DanglingObjectsError
-			}
-		}
-
-		return nil
-	}
 }

--- a/assets/terraform/test/resource_aggregate_interface_test.go
+++ b/assets/terraform/test/resource_aggregate_interface_test.go
@@ -1,20 +1,14 @@
 package provider_test
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"testing"
-
-	sdkErrors "github.com/PaloAltoNetworks/pango/errors"
-	"github.com/PaloAltoNetworks/pango/network/interface/aggregate"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -28,9 +22,6 @@ func TestAccAggregateInterface_DecryptMirror(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy: testAccCheckPanosEthernetInterfaceDestroy(
-			prefix, interfaceName,
-		),
 		Steps: []resource.TestStep{
 			{
 				Config: aggregateInterfaceDecryptMirror1,
@@ -99,9 +90,6 @@ func TestAccAggregateInterface_HA(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy: testAccCheckPanosEthernetInterfaceDestroy(
-			prefix, interfaceName,
-		),
 		Steps: []resource.TestStep{
 			{
 				Config: aggregateInterfaceHa1,
@@ -220,9 +208,6 @@ func TestAccAggregateInterface_Layer2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy: testAccCheckPanosEthernetInterfaceDestroy(
-			prefix, interfaceName,
-		),
 		Steps: []resource.TestStep{
 			{
 				Config: aggregateInterfaceLayer21,
@@ -330,9 +315,6 @@ func TestAccAggregateInterface_Layer3_1(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy: testAccCheckPanosEthernetInterfaceDestroy(
-			prefix, interfaceName,
-		),
 		Steps: []resource.TestStep{
 			{
 				Config: aggregateInterfaceLayer31,
@@ -513,9 +495,6 @@ func TestAccAggregateInterface_Layer3_2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy: testAccCheckPanosEthernetInterfaceDestroy(
-			prefix, interfaceName,
-		),
 		Steps: []resource.TestStep{
 			{
 				Config: aggregateInterfaceLayer32,
@@ -662,9 +641,6 @@ func TestAccAggregateInterface_Layer3_3(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy: testAccCheckPanosEthernetInterfaceDestroy(
-			prefix, interfaceName,
-		),
 		Steps: []resource.TestStep{
 			{
 				Config: aggregateInterfaceLayer33,
@@ -1179,9 +1155,6 @@ func TestAccAggregateInterface_VirtualWire(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy: testAccCheckPanosEthernetInterfaceDestroy(
-			prefix, interfaceName,
-		),
 		Steps: []resource.TestStep{
 			{
 				Config: aggregateInterfaceVirtualWire1,
@@ -1248,29 +1221,3 @@ resource "panos_aggregate_interface" "iface" {
   }
 }
 `
-
-func testAccCheckPanosAggregateInterfaceDestroy(prefix string, entry string) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		api := aggregate.NewService(sdkClient)
-		ctx := context.TODO()
-
-		location := aggregate.NewTemplateLocation()
-		location.Template.Template = fmt.Sprintf("%s-tmpl", prefix)
-
-		reply, err := api.Read(ctx, *location, entry, "show")
-		if err != nil && !sdkErrors.IsObjectNotFound(err) {
-			return fmt.Errorf("reading ethernet entry via sdk: %v", err)
-		}
-
-		if reply != nil {
-			err := fmt.Errorf("terraform didn't delete the server entry properly")
-			delErr := api.Delete(ctx, *location, entry)
-			if delErr != nil {
-				return errors.Join(err, delErr)
-			}
-			return err
-		}
-
-		return nil
-	}
-}

--- a/assets/terraform/test/resource_application_test.go
+++ b/assets/terraform/test/resource_application_test.go
@@ -1,21 +1,14 @@
 package provider_test
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"strings"
 	"testing"
-
-	sdkErrors "github.com/PaloAltoNetworks/pango/errors"
-	"github.com/PaloAltoNetworks/pango/objects/application"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -28,7 +21,6 @@ func TestAccApplication(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccApplicationDestroy(prefix),
 		Steps: []resource.TestStep{
 			{
 				Config: testApplicationTmpl,
@@ -316,34 +308,3 @@ resource "panos_application" "app4" {
 }
 
 `
-
-func testAccApplicationDestroy(prefix string) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		api := application.NewService(sdkClient)
-		ctx := context.TODO()
-
-		location := application.NewSharedLocation()
-
-		entries, err := api.List(ctx, *location, "get", "", "")
-		if err != nil && !sdkErrors.IsObjectNotFound(err) {
-			return fmt.Errorf("listing interface management entries via sdk: %v", err)
-		}
-
-		var leftEntries []string
-		for _, elt := range entries {
-			if strings.HasPrefix(elt.Name, prefix) {
-				leftEntries = append(leftEntries, elt.Name)
-			}
-		}
-
-		if len(leftEntries) > 0 {
-			err := fmt.Errorf("terraform failed to remove entries from the server")
-			delErr := api.Delete(ctx, *location, leftEntries...)
-			if delErr != nil {
-				return errors.Join(err, delErr)
-			}
-		}
-
-		return nil
-	}
-}

--- a/assets/terraform/test/resource_custom_url_category_test.go
+++ b/assets/terraform/test/resource_custom_url_category_test.go
@@ -1,21 +1,14 @@
 package provider_test
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"strings"
 	"testing"
-
-	sdkErrors "github.com/PaloAltoNetworks/pango/errors"
-	category "github.com/PaloAltoNetworks/pango/objects/profiles/customurlcategory"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -28,7 +21,6 @@ func TestAccCustomUrlCategory(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccCustomUrlCategoryDestroy(prefix),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCustomUrlCategoryResourceTmpl,
@@ -101,34 +93,3 @@ resource "panos_custom_url_category" "category" {
   list = var.list
 }
 `
-
-func testAccCustomUrlCategoryDestroy(prefix string) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		api := category.NewService(sdkClient)
-		ctx := context.TODO()
-
-		location := category.NewSharedLocation()
-
-		entries, err := api.List(ctx, *location, "get", "", "")
-		if err != nil && !sdkErrors.IsObjectNotFound(err) {
-			return fmt.Errorf("listing interface management entries via sdk: %v", err)
-		}
-
-		var leftEntries []string
-		for _, elt := range entries {
-			if strings.HasPrefix(elt.Name, prefix) {
-				leftEntries = append(leftEntries, elt.Name)
-			}
-		}
-
-		if len(leftEntries) > 0 {
-			err := fmt.Errorf("terraform failed to remove entries from the server")
-			delErr := api.Delete(ctx, *location, leftEntries...)
-			if delErr != nil {
-				return errors.Join(err, delErr)
-			}
-		}
-
-		return nil
-	}
-}

--- a/assets/terraform/test/resource_device_group_test.go
+++ b/assets/terraform/test/resource_device_group_test.go
@@ -1,21 +1,14 @@
 package provider_test
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"strings"
 	"testing"
-
-	sdkErrors "github.com/PaloAltoNetworks/pango/errors"
-	"github.com/PaloAltoNetworks/pango/panorama/devicegroup"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -28,7 +21,6 @@ func TestAccDeviceGroup(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccDeviceGroupDestroy(prefix),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeviceGroupResourceTmpl,
@@ -95,35 +87,3 @@ resource "panos_device_group" "dg" {
   authorization_code = "code"
 }
 `
-
-func testAccDeviceGroupDestroy(prefix string) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		api := devicegroup.NewService(sdkClient)
-		ctx := context.TODO()
-
-		location := devicegroup.NewPanoramaLocation()
-
-		entries, err := api.List(ctx, *location, "get", "", "")
-		if err != nil && !sdkErrors.IsObjectNotFound(err) {
-			return fmt.Errorf("listing interface management entries via sdk: %v", err)
-		}
-
-		var leftEntries []string
-		for _, elt := range entries {
-			if strings.HasPrefix(elt.Name, prefix) {
-				leftEntries = append(leftEntries, elt.Name)
-			}
-		}
-
-		if len(leftEntries) > 0 {
-			err := fmt.Errorf("terraform failed to remove entries from the server")
-			delErr := api.Delete(ctx, *location, leftEntries...)
-			if delErr != nil {
-				return errors.Join(err, delErr)
-			}
-			return err
-		}
-
-		return nil
-	}
-}

--- a/assets/terraform/test/resource_external_dynamic_list_test.go
+++ b/assets/terraform/test/resource_external_dynamic_list_test.go
@@ -1,19 +1,14 @@
 package provider_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
-
-	sdkErrors "github.com/PaloAltoNetworks/pango/errors"
-	"github.com/PaloAltoNetworks/pango/objects/extdynlist"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -25,7 +20,6 @@ func TestAccPanosExternalDynamicList_1(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccExternalDynamicListCheckDestroy(prefix),
 		Steps: []resource.TestStep{
 			{
 				Config: externalDynamicList1Tmpl,
@@ -89,7 +83,6 @@ func TestAccPanosExternalDynamicList_2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccExternalDynamicListCheckDestroy(prefix),
 		Steps: []resource.TestStep{
 			{
 				Config: externalDynamicList2Tmpl,
@@ -150,7 +143,6 @@ func TestAccPanosExternalDynamicList_3(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccExternalDynamicListCheckDestroy(prefix),
 		Steps: []resource.TestStep{
 			{
 				Config: externalDynamicList3Tmpl,
@@ -211,7 +203,6 @@ func TestAccPanosExternalDynamicList_4(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccExternalDynamicListCheckDestroy(prefix),
 		Steps: []resource.TestStep{
 			{
 				Config: externalDynamicList4Tmpl,
@@ -275,7 +266,6 @@ func TestAccPanosExternalDynamicList_5(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccExternalDynamicListCheckDestroy(prefix),
 		Steps: []resource.TestStep{
 			{
 				Config: externalDynamicList5Tmpl,
@@ -324,7 +314,6 @@ func TestAccPanosExternalDynamicList_6(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccExternalDynamicListCheckDestroy(prefix),
 		Steps: []resource.TestStep{
 			{
 				Config: externalDynamicList6Tmpl,
@@ -373,7 +362,6 @@ func TestAccPanosExternalDynamicList_7(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccExternalDynamicListCheckDestroy(prefix),
 		Steps: []resource.TestStep{
 			{
 				Config: externalDynamicList7Tmpl,
@@ -653,29 +641,3 @@ resource "panos_external_dynamic_list" "list" {
   }
 }
 `
-
-func testAccExternalDynamicListCheckDestroy(prefix string) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		api := extdynlist.NewService(sdkClient)
-		location := extdynlist.NewDeviceGroupLocation()
-
-		location.DeviceGroup.DeviceGroup = fmt.Sprintf("%s-dg", prefix)
-
-		ctx := context.TODO()
-
-		entry := fmt.Sprintf("%s-list", prefix)
-
-		reply, err := api.Read(ctx, *location, entry, "show")
-		if err != nil && !sdkErrors.IsObjectNotFound(err) {
-			return fmt.Errorf("reading external dynamic list entry %s via sdk: %w", entry, err)
-		}
-
-		if reply != nil {
-			if reply.EntryName() == entry {
-				return fmt.Errorf("external dynamic list object still exists: %s", entry)
-			}
-		}
-
-		return nil
-	}
-}

--- a/assets/terraform/test/resource_ike_crypto_profile_test.go
+++ b/assets/terraform/test/resource_ike_crypto_profile_test.go
@@ -1,20 +1,14 @@
 package provider_test
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"testing"
-
-	sdkErrors "github.com/PaloAltoNetworks/pango/errors"
-	"github.com/PaloAltoNetworks/pango/objects/profiles/ikecrypto"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -27,7 +21,6 @@ func TestAccIkeCryptoProfile_1(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccIkeCryptoProfileDestroy(prefix),
 		Steps: []resource.TestStep{
 			{
 				Config: ikeCryptoProfile1,
@@ -172,30 +165,3 @@ resource "panos_ike_crypto_profile" "profile4" {
   }
 }
 `
-
-func testAccIkeCryptoProfileDestroy(prefix string) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		entry := fmt.Sprintf("%s-profile", prefix)
-		api := ikecrypto.NewService(sdkClient)
-		ctx := context.TODO()
-
-		location := ikecrypto.NewTemplateLocation()
-		location.Template.Template = fmt.Sprintf("%s-tmpl", prefix)
-
-		reply, err := api.Read(ctx, *location, entry, "show")
-		if err != nil && !sdkErrors.IsObjectNotFound(err) {
-			return fmt.Errorf("reading ethernet entry via sdk: %v", err)
-		}
-
-		if reply != nil {
-			err := fmt.Errorf("terraform didn't delete the server entry properly")
-			delErr := api.Delete(ctx, *location, entry)
-			if delErr != nil {
-				return errors.Join(err, delErr)
-			}
-			return err
-		}
-
-		return nil
-	}
-}

--- a/assets/terraform/test/resource_ipsec_crypto_profile_test.go
+++ b/assets/terraform/test/resource_ipsec_crypto_profile_test.go
@@ -1,20 +1,14 @@
 package provider_test
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"testing"
-
-	sdkErrors "github.com/PaloAltoNetworks/pango/errors"
-	"github.com/PaloAltoNetworks/pango/objects/profiles/ipseccrypto"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -27,7 +21,6 @@ func TestAccIpsecCryptoProfile_1(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccIpsecCryptoProfileDestroy(prefix),
 		Steps: []resource.TestStep{
 			{
 				Config: ipsecCryptoProfile1,
@@ -227,30 +220,3 @@ resource "panos_ipsec_crypto_profile" "profile4" {
   }
 }
 `
-
-func testAccIpsecCryptoProfileDestroy(prefix string) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		entry := fmt.Sprintf("%s-profile", prefix)
-		api := ipseccrypto.NewService(sdkClient)
-		ctx := context.TODO()
-
-		location := ipseccrypto.NewTemplateLocation()
-		location.Template.Template = fmt.Sprintf("%s-tmpl", prefix)
-
-		reply, err := api.Read(ctx, *location, entry, "show")
-		if err != nil && !sdkErrors.IsObjectNotFound(err) {
-			return fmt.Errorf("reading ethernet entry via sdk: %v", err)
-		}
-
-		if reply != nil {
-			err := fmt.Errorf("terraform didn't delete the server entry properly")
-			delErr := api.Delete(ctx, *location, entry)
-			if delErr != nil {
-				return errors.Join(err, delErr)
-			}
-			return err
-		}
-
-		return nil
-	}
-}

--- a/assets/terraform/test/resource_log_forwarding_test.go
+++ b/assets/terraform/test/resource_log_forwarding_test.go
@@ -1,21 +1,14 @@
 package provider_test
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"strings"
 	"testing"
-
-	sdkErrors "github.com/PaloAltoNetworks/pango/errors"
-	"github.com/PaloAltoNetworks/pango/objects/profiles/logforwarding"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -27,7 +20,6 @@ func TestAccLogForwarding(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccLogForwardingDestroy(prefix),
 		Steps: []resource.TestStep{
 			{
 				Config: logForwardingResource1,
@@ -336,39 +328,3 @@ resource "panos_log_forwarding_profile" "profile" {
   }]
 }
 `
-
-func testAccLogForwardingDestroy(prefix string) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		api := logforwarding.NewService(sdkClient)
-		ctx := context.TODO()
-
-		location := logforwarding.NewDeviceGroupLocation()
-		location.DeviceGroup = &logforwarding.DeviceGroupLocation{
-			DeviceGroup:    fmt.Sprintf("%s-dg", prefix),
-			PanoramaDevice: "localhost.localdomain",
-		}
-
-		entries, err := api.List(ctx, *location, "get", "", "")
-		if err != nil && !sdkErrors.IsObjectNotFound(err) {
-			return fmt.Errorf("error while listing entries via sdk: %v", err)
-		}
-
-		var leftEntries []string
-		for _, elt := range entries {
-			if strings.HasPrefix(elt.Name, prefix) {
-				leftEntries = append(leftEntries, elt.Name)
-			}
-		}
-
-		if len(leftEntries) > 0 {
-			err := fmt.Errorf("terraform failed to remove entries from the server")
-			delErr := api.Delete(ctx, *location, leftEntries...)
-			if delErr != nil {
-				return errors.Join(err, delErr)
-			}
-			return err
-		}
-
-		return nil
-	}
-}

--- a/assets/terraform/test/resource_panorama_template_test.go
+++ b/assets/terraform/test/resource_panorama_template_test.go
@@ -1,19 +1,14 @@
 package provider_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
-
-	sdkErrors "github.com/PaloAltoNetworks/pango/errors"
-	"github.com/PaloAltoNetworks/pango/panorama/template"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -27,7 +22,6 @@ func TestAccPanosTemplate_RequiredInputs(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccCheckPanoramaTemplateDestroy(templateName),
 		Steps: []resource.TestStep{
 			{
 				Config: makePanosTemplateConfig(resourceName),
@@ -61,25 +55,4 @@ func makePanosTemplateConfig(label string) string {
     }
     `
 	return fmt.Sprintf(configTpl, label)
-}
-
-func testAccCheckPanoramaTemplateDestroy(name string) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		api := template.NewService(sdkClient)
-		location := template.NewPanoramaLocation()
-		ctx := context.TODO()
-
-		reply, err := api.Read(ctx, *location, name, "show")
-		if err != nil && !sdkErrors.IsObjectNotFound(err) {
-			return fmt.Errorf("reading template entry via sdk: %v", err)
-		}
-
-		if reply != nil {
-			if reply.EntryName() == name {
-				return fmt.Errorf("template object still exists: %s", name)
-			}
-		}
-
-		return nil
-	}
 }

--- a/assets/terraform/test/resource_vulnerability_security_profile_test.go
+++ b/assets/terraform/test/resource_vulnerability_security_profile_test.go
@@ -1,10 +1,7 @@
-// In TestAccVulnerabilitySecurityProfile function implement all checks indicated by "MISSING" comment
-
 package provider_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -17,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -30,7 +26,6 @@ func TestAccVulnerabilitySecurityProfile(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProviders,
-		CheckDestroy:             testAccVulnerabilitySecurityProfileDestroy(prefix),
 		Steps: []resource.TestStep{
 			{
 				Config: vulnerabilitySecurityProfileTmpl,
@@ -267,37 +262,5 @@ func (o *vulnerabilitySecurityProfileExpectNoEntriesInLocation) CheckState(ctx c
 
 	if len(dangling) > 0 {
 		resp.Error = fmt.Errorf("delete of the resource didn't remove it from the server")
-	}
-}
-
-func testAccVulnerabilitySecurityProfileDestroy(prefix string) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		service := vulnerability.NewService(sdkClient)
-
-		location := vulnerability.NewDeviceGroupLocation()
-		location.DeviceGroup.DeviceGroup = fmt.Sprintf("%s-dg1", prefix)
-
-		ctx := context.TODO()
-		entries, err := service.List(ctx, *location, "get", "", "")
-		if err != nil && !sdkerrors.IsObjectNotFound(err) {
-			return fmt.Errorf("failed to list existing entries via sdk: %w", err)
-		}
-
-		var leftEntries []string
-		for _, elt := range entries {
-			if strings.HasPrefix(elt.Name, prefix) {
-				leftEntries = append(leftEntries, elt.Name)
-			}
-		}
-
-		if len(leftEntries) > 0 {
-			err := fmt.Errorf("terraform failed to remove entries from the server")
-			delErr := service.Delete(ctx, *location, leftEntries...)
-			if delErr != nil {
-				return errors.Join(err, delErr)
-			}
-		}
-
-		return nil
 	}
 }

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -250,8 +250,10 @@ func writeContentToFile(content *bytes.Buffer, file *os.File) error {
 func (c *Creator) parseTemplate(templateName string) (*template.Template, error) {
 	templatePath := filepath.Join(c.TemplatesDir, templateName)
 	funcMap := template.FuncMap{
-		"Map":                       codegentmpl.TemplateMap,
-		"renderImports":             translate.RenderImports,
+		"Map": codegentmpl.TemplateMap,
+		"renderImports": func(templateTypes ...string) (string, error) {
+			return translate.RenderImports(c.Spec, templateTypes...)
+		},
 		"RenderEntryImportStructs":  func() (string, error) { return translate.RenderEntryImportStructs(c.Spec) },
 		"packageName":               translate.PackageName,
 		"locationType":              translate.LocationType,
@@ -289,6 +291,7 @@ func (c *Creator) parseTemplate(templateName string) (*template.Template, error)
 			return translate.RenderSpecMatchers(spec)
 		},
 		"createGoSuffixFromVersion": translate.CreateGoSuffixFromVersionTmpl,
+		"paramNotSkipped":           translate.ParamNotSkippedTmpl,
 		"paramSupportedInVersion":   translate.ParamSupportedInVersionTmpl,
 		"xmlPathSuffixes":           translate.XmlPathSuffixes,
 		"underscore":                naming.Underscore,

--- a/pkg/schema/parameter/parameter.go
+++ b/pkg/schema/parameter/parameter.go
@@ -3,6 +3,7 @@ package parameter
 import (
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -50,17 +51,23 @@ const (
 	VariantCheckExactlyOneOf  VariantCheckType = "ExactlyOneOf"
 )
 
+type CodegenOverridesGoSdk struct {
+	Skip *bool `yaml:"skip"`
+}
+
 type CodegenOverridesTerraform struct {
-	Name         *string           `yaml:"name"`
-	Type         *string           `yaml:"type"`
-	Private      *bool             `yaml:"private"`
-	Sensitive    *bool             `yaml:"sensitive"`
-	Computed     *bool             `yaml:"computed"`
-	Required     *bool             `yaml:"required"`
-	VariantCheck *VariantCheckType `yaml:"variant_check"`
+	Name          *string           `yaml:"name"`
+	Type          *string           `yaml:"type"`
+	Private       *bool             `yaml:"private"`
+	Sensitive     *bool             `yaml:"sensitive"`
+	Computed      *bool             `yaml:"computed"`
+	Required      *bool             `yaml:"required"`
+	VariantCheck  *VariantCheckType `yaml:"variant_check"`
+	XpathVariable *string           `yaml:"xpath_variable"`
 }
 
 type CodegenOverrides struct {
+	GoSdk     CodegenOverridesGoSdk     `yaml:"gosdk"`
 	Terraform CodegenOverridesTerraform `yaml:"terraform"`
 }
 
@@ -148,6 +155,9 @@ func (p *Parameter) UnmarshalYAML(n *yaml.Node) error {
 	default:
 		return errors.NewSchemaError(fmt.Sprintf("unsupported parameter type: '%s'", p.Type))
 	}
+
+	// Escape value of a description, making sure all backslashes are handled properly
+	obj.Description = strings.ReplaceAll(obj.Description, "\\", "\\\\")
 
 	// Finally, decode obj.Spec (which is yaml.Node type) into the parameter
 	// spec structure

--- a/pkg/translate/funcs_test.go
+++ b/pkg/translate/funcs_test.go
@@ -12,10 +12,10 @@ func TestGenerateEntryXpath(t *testing.T) {
 	// given
 
 	// when
-	asEntryXpath, _ := GenerateEntryXpath("util.AsEntryXpath([]string{", "})", "DeviceGroup", "{{ Entry $panorama_device }}")
+	asEntryXpath, _ := GenerateEntryXpath("util.AsEntryXpath(", ")", "DeviceGroup", "{{ Entry $panorama_device }}")
 
 	// then
-	assert.Equal(t, "util.AsEntryXpath([]string{o.DeviceGroup.PanoramaDevice}),", asEntryXpath)
+	assert.Equal(t, "util.AsEntryXpath(o.DeviceGroup.PanoramaDevice),", asEntryXpath)
 }
 
 func TestSpecMatchesFunction(t *testing.T) {

--- a/pkg/translate/imports.go
+++ b/pkg/translate/imports.go
@@ -2,10 +2,11 @@ package translate
 
 import (
 	"github.com/paloaltonetworks/pan-os-codegen/pkg/imports"
+	"github.com/paloaltonetworks/pan-os-codegen/pkg/properties"
 )
 
 // RenderImports render string, which contains import required in entry, location or service template.
-func RenderImports(templateTypes ...string) (string, error) {
+func RenderImports(spec *properties.Normalization, templateTypes ...string) (string, error) {
 	manager := imports.NewManager()
 
 	for _, templateType := range templateTypes {
@@ -30,6 +31,9 @@ func RenderImports(templateTypes ...string) (string, error) {
 			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/errors", "")
 			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/util", "")
 			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/version", "")
+			if spec.ResourceXpathVariablesWithChecks(true) {
+				manager.AddStandardImport("strings", "")
+			}
 		case "service":
 			manager.AddStandardImport("context", "")
 			manager.AddStandardImport("fmt", "")

--- a/pkg/translate/imports_test.go
+++ b/pkg/translate/imports_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/paloaltonetworks/pan-os-codegen/pkg/properties"
 )
 
 func TestRenderImports(t *testing.T) {
@@ -18,7 +20,13 @@ import (
 )`
 
 	// when
-	actualImports, _ := RenderImports("location")
+	spec := &properties.Normalization{
+		PanosXpath: properties.PanosXpath{
+			Path: []string{"test"},
+		},
+	}
+
+	actualImports, _ := RenderImports(spec, "location")
 
 	// then
 	assert.NotNil(t, actualImports)

--- a/pkg/translate/structs.go
+++ b/pkg/translate/structs.go
@@ -236,7 +236,7 @@ func createImportLocationSpecsForLocation(location properties.ImportLocation) im
 	for _, elt := range location.XpathElements {
 		if strings.HasPrefix(elt, "$") {
 			variableName := elt[1:]
-			asEntryXpath := fmt.Sprintf("util.AsEntryXpath([]string{o.%s})", variablesByName[variableName].Name.LowerCamelCase)
+			asEntryXpath := fmt.Sprintf("util.AsEntryXpath(o.%s)", variablesByName[variableName].Name.LowerCamelCase)
 			elements = append(elements, asEntryXpath)
 		} else {
 			elements = append(elements, fmt.Sprintf("\"%s\"", elt))
@@ -447,6 +447,14 @@ func CreateGoSuffixFromVersion(v *version.Version) string {
 	}
 
 	return fmt.Sprintf("_%s", strings.ReplaceAll(v.String(), ".", "_"))
+}
+
+func ParamNotSkippedTmpl(param *properties.SpecParam) bool {
+	if param.GoSdkConfig != nil && param.GoSdkConfig.Skip != nil {
+		return !*param.GoSdkConfig.Skip
+	}
+
+	return true
 }
 
 func ParamSupportedInVersionTmpl(param *properties.SpecParam, deviceVersion any) (bool, error) {
@@ -673,6 +681,10 @@ func createEntryXmlStructSpecsForParameter(structTyp structType, parentPrefix *p
 	}
 
 	processParameter := func(prefix *properties.NameVariant, param *properties.SpecParam) {
+		if param.GoSdkConfig != nil && param.GoSdkConfig.Skip != nil && *param.GoSdkConfig.Skip {
+			return
+		}
+
 		if !ParamSupportedInVersion(param, version) {
 			return
 		}
@@ -777,6 +789,10 @@ func creasteStructSpecsForNormalization(structTyp structType, parentPrefix *prop
 	}
 
 	processParameter := func(prefix *properties.NameVariant, param *properties.SpecParam) {
+		if param.GoSdkConfig != nil && param.GoSdkConfig.Skip != nil && *param.GoSdkConfig.Skip {
+			return
+		}
+
 		if !ParamSupportedInVersion(param, version) {
 			return
 		}

--- a/specs/device/adminrole.yaml
+++ b/specs/device/adminrole.yaml
@@ -14,8 +14,10 @@ go_sdk_config:
   package:
   - device
   - adminrole
-xpath_suffix:
-- admin-role
+panos_xpath:
+  path:
+  - admin-role
+  vars: []
 locations:
 - name: template
   xpath:
@@ -2338,6 +2340,27 @@ spec:
                       - value: disable
                     description: ''
                     required: false
+                  - name: dhcp-syslog-server
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - dhcp-syslog-server
+                      min_version: 11.0.2
+                      max_version: 11.0.3
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - enable
+                        - read-only
+                        - disable
+                    spec:
+                      values:
+                      - value: enable
+                      - value: read-only
+                      - value: disable
+                    description: ''
+                    required: false
                   - name: dynamic-updates
                     type: enum
                     profiles:
@@ -3325,27 +3348,6 @@ spec:
                     profiles:
                     - xpath:
                       - vm-info-source
-                    validators:
-                    - type: values
-                      spec:
-                        values:
-                        - enable
-                        - read-only
-                        - disable
-                    spec:
-                      values:
-                      - value: enable
-                      - value: read-only
-                      - value: disable
-                    description: ''
-                    required: false
-                  - name: dhcp-syslog-server
-                    type: enum
-                    profiles:
-                    - xpath:
-                      - dhcp-syslog-server
-                      min_version: 11.0.2
-                      max_version: 11.0.3
                     validators:
                     - type: values
                       spec:
@@ -5125,6 +5127,27 @@ spec:
                       - value: disable
                     description: ''
                     required: false
+                  - name: secure-web-gateway
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - secure-web-gateway
+                      min_version: 11.0.2
+                      max_version: 11.0.3
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - enable
+                        - read-only
+                        - disable
+                    spec:
+                      values:
+                      - value: enable
+                      - value: read-only
+                      - value: disable
+                    description: ''
+                    required: false
                   - name: virtual-routers
                     type: enum
                     profiles:
@@ -5187,27 +5210,6 @@ spec:
                     profiles:
                     - xpath:
                       - zones
-                    validators:
-                    - type: values
-                      spec:
-                        values:
-                        - enable
-                        - read-only
-                        - disable
-                    spec:
-                      values:
-                      - value: enable
-                      - value: read-only
-                      - value: disable
-                    description: ''
-                    required: false
-                  - name: secure-web-gateway
-                    type: enum
-                    profiles:
-                    - xpath:
-                      - secure-web-gateway
-                      min_version: 11.0.2
-                      max_version: 11.0.3
                     validators:
                     - type: values
                       spec:
@@ -6416,6 +6418,25 @@ spec:
                 validators: []
                 spec:
                   params:
+                  - name: object-level-changes
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - object-level-changes
+                      min_version: 11.0.2
+                      max_version: 11.0.3
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - enable
+                        - disable
+                    spec:
+                      values:
+                      - value: enable
+                      - value: disable
+                    description: ''
+                    required: false
                   - name: partial-save
                     type: enum
                     profiles:
@@ -6438,25 +6459,6 @@ spec:
                     profiles:
                     - xpath:
                       - save-for-other-admins
-                    validators:
-                    - type: values
-                      spec:
-                        values:
-                        - enable
-                        - disable
-                    spec:
-                      values:
-                      - value: enable
-                      - value: disable
-                    description: ''
-                    required: false
-                  - name: object-level-changes
-                    type: enum
-                    profiles:
-                    - xpath:
-                      - object-level-changes
-                      min_version: 11.0.2
-                      max_version: 11.0.3
                     validators:
                     - type: values
                       spec:
@@ -6956,11 +6958,13 @@ spec:
                       - value: disable
                     description: ''
                     required: false
-                  - name: zones
+                  - name: sdwan-interface-profiles
                     type: enum
                     profiles:
                     - xpath:
-                      - zones
+                      - sdwan-interface-profiles
+                      min_version: 11.0.2
+                      max_version: 11.0.3
                     validators:
                     - type: values
                       spec:
@@ -6975,13 +6979,11 @@ spec:
                       - value: disable
                     description: ''
                     required: false
-                  - name: sdwan-interface-profiles
+                  - name: zones
                     type: enum
                     profiles:
                     - xpath:
-                      - sdwan-interface-profiles
-                      min_version: 11.0.2
-                      max_version: 11.0.3
+                      - zones
                     validators:
                     - type: values
                       spec:
@@ -8336,6 +8338,27 @@ spec:
                       - value: disable
                     description: ''
                     required: false
+                  - name: dhcp-syslog-server
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - dhcp-syslog-server
+                      min_version: 11.0.2
+                      max_version: 11.0.3
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - enable
+                        - read-only
+                        - disable
+                    spec:
+                      values:
+                      - value: enable
+                      - value: read-only
+                      - value: disable
+                    description: ''
+                    required: false
                   - name: local-user-database
                     type: object
                     profiles:
@@ -9033,27 +9056,6 @@ spec:
                     profiles:
                     - xpath:
                       - vm-info-source
-                    validators:
-                    - type: values
-                      spec:
-                        values:
-                        - enable
-                        - read-only
-                        - disable
-                    spec:
-                      values:
-                      - value: enable
-                      - value: read-only
-                      - value: disable
-                    description: ''
-                    required: false
-                  - name: dhcp-syslog-server
-                    type: enum
-                    profiles:
-                    - xpath:
-                      - dhcp-syslog-server
-                      min_version: 11.0.2
-                      max_version: 11.0.3
                     validators:
                     - type: values
                       spec:
@@ -11319,6 +11321,25 @@ spec:
                 validators: []
                 spec:
                   params:
+                  - name: object-level-changes
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - object-level-changes
+                      min_version: 11.0.2
+                      max_version: 11.0.3
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - enable
+                        - disable
+                    spec:
+                      values:
+                      - value: enable
+                      - value: disable
+                    description: ''
+                    required: false
                   - name: partial-save
                     type: enum
                     profiles:
@@ -11341,25 +11362,6 @@ spec:
                     profiles:
                     - xpath:
                       - save-for-other-admins
-                    validators:
-                    - type: values
-                      spec:
-                        values:
-                        - enable
-                        - disable
-                    spec:
-                      values:
-                      - value: enable
-                      - value: disable
-                    description: ''
-                    required: false
-                  - name: object-level-changes
-                    type: enum
-                    profiles:
-                    - xpath:
-                      - object-level-changes
-                      min_version: 11.0.2
-                      max_version: 11.0.3
                     validators:
                     - type: values
                       spec:

--- a/specs/device/api_key.yaml
+++ b/specs/device/api_key.yaml
@@ -11,7 +11,8 @@ terraform_provider_config:
 go_sdk_config:
   skip: true
   package: ["api_key"]
-xpath_suffix: ["api-key"]
+panos_xpath:
+  path: ["api-key"]
 locations: []
 entries: []
 imports: []

--- a/specs/device/dns.yaml
+++ b/specs/device/dns.yaml
@@ -15,7 +15,9 @@ go_sdk_config:
   - device
   - services
   - dns
-xpath_suffix: []
+panos_xpath:
+  path: []
+  vars: []
 locations:
 - name: system
   xpath:

--- a/specs/device/dynamic-updates.yaml
+++ b/specs/device/dynamic-updates.yaml
@@ -14,7 +14,9 @@ go_sdk_config:
   package:
   - device
   - dynamicupdates
-xpath_suffix: []
+panos_xpath:
+  path: []
+  vars: []
 locations:
 - name: system
   xpath:
@@ -204,6 +206,7 @@ spec:
                   variants: []
                 description: Everyday
                 required: false
+                variant_group_id: 0
               - name: hourly
                 type: object
                 profiles:
@@ -245,6 +248,7 @@ spec:
                   variants: []
                 description: Every hour
                 required: false
+                variant_group_id: 0
               - name: none
                 type: object
                 profiles:
@@ -256,6 +260,7 @@ spec:
                   variants: []
                 description: No schedule
                 required: false
+                variant_group_id: 0
               - name: weekly
                 type: object
                 profiles:
@@ -324,6 +329,7 @@ spec:
                   variants: []
                 description: Once a week
                 required: false
+                variant_group_id: 0
             description: ''
             required: false
           variants: []
@@ -409,6 +415,7 @@ spec:
                   variants: []
                 description: Everyday
                 required: false
+                variant_group_id: 0
               - name: none
                 type: object
                 profiles:
@@ -420,6 +427,7 @@ spec:
                   variants: []
                 description: No schedule
                 required: false
+                variant_group_id: 0
               - name: weekly
                 type: object
                 profiles:
@@ -488,6 +496,7 @@ spec:
                   variants: []
                 description: Once a week
                 required: false
+                variant_group_id: 0
             description: ''
             required: false
           variants: []
@@ -551,6 +560,7 @@ spec:
                   variants: []
                 description: Everyday
                 required: false
+                variant_group_id: 0
               - name: hourly
                 type: object
                 profiles:
@@ -592,6 +602,7 @@ spec:
                   variants: []
                 description: Every hour
                 required: false
+                variant_group_id: 0
               - name: none
                 type: object
                 profiles:
@@ -603,6 +614,7 @@ spec:
                   variants: []
                 description: No schedule
                 required: false
+                variant_group_id: 0
               - name: weekly
                 type: object
                 profiles:
@@ -671,6 +683,7 @@ spec:
                   variants: []
                 description: Once a week
                 required: false
+                variant_group_id: 0
             description: ''
             required: false
           variants: []
@@ -732,6 +745,7 @@ spec:
                   variants: []
                 description: Everyday
                 required: false
+                variant_group_id: 0
               - name: hourly
                 type: object
                 profiles:
@@ -773,6 +787,7 @@ spec:
                   variants: []
                 description: Every hour
                 required: false
+                variant_group_id: 0
               - name: none
                 type: object
                 profiles:
@@ -784,6 +799,7 @@ spec:
                   variants: []
                 description: No schedule
                 required: false
+                variant_group_id: 0
               - name: weekly
                 type: object
                 profiles:
@@ -852,6 +868,7 @@ spec:
                   variants: []
                 description: Once a week
                 required: false
+                variant_group_id: 0
             description: ''
             required: false
           variants: []
@@ -1042,6 +1059,7 @@ spec:
                   variants: []
                 description: Everyday
                 required: false
+                variant_group_id: 0
               - name: every-30-mins
                 type: object
                 profiles:
@@ -1092,6 +1110,7 @@ spec:
                   variants: []
                 description: Every 0, 30 minutes past the hour
                 required: false
+                variant_group_id: 0
               - name: hourly
                 type: object
                 profiles:
@@ -1142,6 +1161,7 @@ spec:
                   variants: []
                 description: Every hour
                 required: false
+                variant_group_id: 0
               - name: none
                 type: object
                 profiles:
@@ -1153,6 +1173,7 @@ spec:
                   variants: []
                 description: No schedule
                 required: false
+                variant_group_id: 0
               - name: weekly
                 type: object
                 profiles:
@@ -1230,6 +1251,7 @@ spec:
                   variants: []
                 description: Once a week
                 required: false
+                variant_group_id: 0
             description: ''
             required: false
           variants: []
@@ -1302,6 +1324,7 @@ spec:
                   variants: []
                 description: Every 15 minutes
                 required: false
+                variant_group_id: 0
               - name: every-30-mins
                 type: object
                 profiles:
@@ -1343,6 +1366,7 @@ spec:
                   variants: []
                 description: Every 30 minutes
                 required: false
+                variant_group_id: 0
               - name: every-5-mins
                 type: object
                 profiles:
@@ -1384,6 +1408,7 @@ spec:
                   variants: []
                 description: Every 5 minutes
                 required: false
+                variant_group_id: 0
               - name: every-hour
                 type: object
                 profiles:
@@ -1425,6 +1450,7 @@ spec:
                   variants: []
                 description: Every hour
                 required: false
+                variant_group_id: 0
               - name: none
                 type: object
                 profiles:
@@ -1436,6 +1462,7 @@ spec:
                   variants: []
                 description: No schedule
                 required: false
+                variant_group_id: 0
             description: ''
             required: false
           variants: []
@@ -1508,6 +1535,7 @@ spec:
                   variants: []
                 description: Every 0, 15, 30, 45 minutes past the hour
                 required: false
+                variant_group_id: 0
               - name: every-30-mins
                 type: object
                 profiles:
@@ -1558,6 +1586,7 @@ spec:
                   variants: []
                 description: Every 0, 30 minutes past the hour
                 required: false
+                variant_group_id: 0
               - name: every-hour
                 type: object
                 profiles:
@@ -1608,6 +1637,7 @@ spec:
                   variants: []
                 description: Every 0 minutes past the hour
                 required: false
+                variant_group_id: 0
               - name: every-min
                 type: object
                 profiles:
@@ -1645,6 +1675,7 @@ spec:
                   variants: []
                 description: Every minute
                 required: false
+                variant_group_id: 0
               - name: none
                 type: object
                 profiles:
@@ -1656,6 +1687,7 @@ spec:
                   variants: []
                 description: No schedule
                 required: false
+                variant_group_id: 0
               - name: real-time
                 type: object
                 profiles:
@@ -1667,6 +1699,7 @@ spec:
                   variants: []
                 description: Real-time Streaming
                 required: false
+                variant_group_id: 0
             description: ''
             required: false
           variants: []

--- a/specs/device/ntp.yaml
+++ b/specs/device/ntp.yaml
@@ -15,7 +15,9 @@ go_sdk_config:
   - device
   - services
   - ntp
-xpath_suffix: []
+panos_xpath:
+  path: []
+  vars: []
 locations:
 - name: system
   xpath:

--- a/specs/device/profiles/ldap.yaml
+++ b/specs/device/profiles/ldap.yaml
@@ -16,9 +16,11 @@ go_sdk_config:
   - device
   - profiles
   - ldap
-xpath_suffix:
-- server-profile
-- ldap
+panos_xpath:
+  path:
+  - server-profile
+  - ldap
+  vars: []
 locations:
 - name: panorama
   xpath:

--- a/specs/device/ssl-decrypt.yaml
+++ b/specs/device/ssl-decrypt.yaml
@@ -14,7 +14,9 @@ go_sdk_config:
   package:
   - device
   - ssldecrypt
-xpath_suffix: []
+panos_xpath:
+  path: []
+  vars: []
 locations:
 - name: panorama
   xpath:
@@ -213,6 +215,58 @@ spec:
         type: string
     description: List of disabled predefined exclude certificates.
     required: false
+  - name: forward-trust-certificate-ecdsa
+    type: string
+    profiles:
+    - xpath:
+      - forward-trust-certificate
+      - ecdsa
+    validators:
+    - type: length
+      spec:
+        max: 63
+    spec: {}
+    description: Forward trust ECDSA certificate.
+    required: false
+  - name: forward-trust-certificate-rsa
+    type: string
+    profiles:
+    - xpath:
+      - forward-trust-certificate
+      - rsa
+    validators:
+    - type: length
+      spec:
+        max: 63
+    spec: {}
+    description: Forward trust RSA certificate.
+    required: false
+  - name: forward-untrust-certificate-ecdsa
+    type: string
+    profiles:
+    - xpath:
+      - forward-untrust-certificate
+      - ecdsa
+    validators:
+    - type: length
+      spec:
+        max: 63
+    spec: {}
+    description: Forward untrust ECDSA certificate.
+    required: false
+  - name: forward-untrust-certificate-rsa
+    type: string
+    profiles:
+    - xpath:
+      - forward-untrust-certificate
+      - rsa
+    validators:
+    - type: length
+      spec:
+        max: 63
+    spec: {}
+    description: Forward untrust RSA certificate.
+    required: false
   - name: root-ca-exclude-list
     type: list
     profiles:
@@ -277,57 +331,5 @@ spec:
       items:
         type: string
     description: List of trusted root CAs.
-    required: false
-  - name: forward-trust-certificate-ecdsa
-    type: string
-    profiles:
-    - xpath:
-      - forward-trust-certificate
-      - ecdsa
-    validators:
-    - type: length
-      spec:
-        max: 63
-    spec: {}
-    description: Forward trust ECDSA certificate.
-    required: false
-  - name: forward-trust-certificate-rsa
-    type: string
-    profiles:
-    - xpath:
-      - forward-trust-certificate
-      - rsa
-    validators:
-    - type: length
-      spec:
-        max: 63
-    spec: {}
-    description: Forward trust RSA certificate.
-    required: false
-  - name: forward-untrust-certificate-ecdsa
-    type: string
-    profiles:
-    - xpath:
-      - forward-untrust-certificate
-      - ecdsa
-    validators:
-    - type: length
-      spec:
-        max: 63
-    spec: {}
-    description: Forward untrust ECDSA certificate.
-    required: false
-  - name: forward-untrust-certificate-rsa
-    type: string
-    profiles:
-    - xpath:
-      - forward-untrust-certificate
-      - rsa
-    validators:
-    - type: length
-      spec:
-        max: 63
-    spec: {}
-    description: Forward untrust RSA certificate.
     required: false
   variants: []

--- a/specs/network/ike-gateway.yaml
+++ b/specs/network/ike-gateway.yaml
@@ -6,724 +6,730 @@ terraform_provider_config:
   resource_type: entry
   resource_variants: []
   suffix: ike_gateway
-  plural_suffix: ''
-  plural_name: ''
-  plural_description: ''
+  plural_suffix: ""
+  plural_name: ""
+  plural_description: ""
 go_sdk_config:
   skip: false
   package:
-  - crypto
-  - ike
-  - gateway
-xpath_suffix:
-- network
-- ike
-- gateway
+    - crypto
+    - ike
+    - gateway
+panos_xpath:
+  path:
+    - network
+    - ike
+    - gateway
 locations:
-- name: ngfw
-  xpath:
-    path:
-    - config
-    - devices
-    - $ngfw_device
-    vars:
-    - name: ngfw_device
-      description: The NGFW device
-      required: false
-      default: localhost.localdomain
-      validators: []
-      type: entry
-  description: Located in a specific NGFW device
-  devices:
-  - ngfw
-  validators: []
-  required: false
-  read_only: false
-- name: template
-  xpath:
-    path:
-    - config
-    - devices
-    - $panorama_device
-    - template
-    - $template
-    - config
-    - devices
-    - $ngfw_device
-    vars:
-    - name: panorama_device
-      description: Specific Panorama device
-      required: false
-      default: localhost.localdomain
-      validators: []
-      type: entry
-    - name: template
-      description: Specific Panorama template
-      required: true
-      validators: []
-      type: entry
-    - name: ngfw_device
-      description: The NGFW device
-      required: false
-      default: localhost.localdomain
-      validators: []
-      type: entry
-  description: Located in a specific template
-  devices:
-  - panorama
-  validators: []
-  required: false
-  read_only: false
-- name: template-stack
-  xpath:
-    path:
-    - config
-    - devices
-    - $panorama_device
-    - template-stack
-    - $template_stack
-    - config
-    - devices
-    - $ngfw_device
-    vars:
-    - name: panorama_device
-      description: Specific Panorama device
-      required: false
-      default: localhost.localdomain
-      validators: []
-      type: entry
-    - name: template_stack
-      description: Specific Panorama template stack
-      required: true
-      validators: []
-      type: entry
-    - name: ngfw_device
-      description: The NGFW device
-      required: false
-      default: localhost.localdomain
-      validators: []
-      type: entry
-  description: Located in a specific template stack
-  devices:
-  - panorama
-  validators: []
-  required: false
-  read_only: false
+  - name: ngfw
+    xpath:
+      path:
+        - config
+        - devices
+        - $ngfw_device
+      vars:
+        - name: ngfw_device
+          description: The NGFW device
+          required: false
+          default: localhost.localdomain
+          validators: []
+          type: entry
+    description: Located in a specific NGFW device
+    devices:
+      - ngfw
+    validators: []
+    required: false
+    read_only: false
+  - name: template
+    xpath:
+      path:
+        - config
+        - devices
+        - $panorama_device
+        - template
+        - $template
+        - config
+        - devices
+        - $ngfw_device
+      vars:
+        - name: panorama_device
+          description: Specific Panorama device
+          required: false
+          default: localhost.localdomain
+          validators: []
+          type: entry
+        - name: template
+          description: Specific Panorama template
+          required: true
+          validators: []
+          type: entry
+        - name: ngfw_device
+          description: The NGFW device
+          required: false
+          default: localhost.localdomain
+          validators: []
+          type: entry
+    description: Located in a specific template
+    devices:
+      - panorama
+    validators: []
+    required: false
+    read_only: false
+  - name: template-stack
+    xpath:
+      path:
+        - config
+        - devices
+        - $panorama_device
+        - template-stack
+        - $template_stack
+        - config
+        - devices
+        - $ngfw_device
+      vars:
+        - name: panorama_device
+          description: Specific Panorama device
+          required: false
+          default: localhost.localdomain
+          validators: []
+          type: entry
+        - name: template_stack
+          description: Specific Panorama template stack
+          required: true
+          validators: []
+          type: entry
+        - name: ngfw_device
+          description: The NGFW device
+          required: false
+          default: localhost.localdomain
+          validators: []
+          type: entry
+    description: Located in a specific template stack
+    devices:
+      - panorama
+    validators: []
+    required: false
+    read_only: false
 entries:
-- name: name
-  description: ''
-  validators: []
+  - name: name
+    description: ""
+    validators: []
 imports: []
 spec:
   params:
-  - name: authentication
-    type: object
-    profiles:
-    - xpath:
-      - authentication
-    validators: []
-    spec:
-      params: []
-      variants:
-      - name: certificate
-        type: object
-        profiles:
+    - name: authentication
+      type: object
+      profiles:
         - xpath:
-          - certificate
-        validators: []
-        spec:
-          params:
-          - name: allow-id-payload-mismatch
-            type: bool
-            profiles:
-            - xpath:
-              - allow-id-payload-mismatch
-            validators: []
-            spec: {}
-            description: Permit peer identification and certificate payload identification
-              mismatch
-            required: false
-          - name: certificate-profile
-            type: string
-            profiles:
-            - xpath:
-              - certificate-profile
-            validators: []
-            spec: {}
-            description: Profile for certificate valdiation during IKE negotiation
-            required: false
-          - name: local-certificate
+            - authentication
+      validators: []
+      spec:
+        params: []
+        variants:
+          - name: certificate
             type: object
             profiles:
-            - xpath:
-              - local-certificate
+              - xpath:
+                  - certificate
             validators: []
             spec:
               params:
-              - name: hash-and-url
-                type: object
-                profiles:
-                - xpath:
-                  - hash-and-url
-                validators: []
-                spec:
-                  params:
-                  - name: base-url
-                    type: string
-                    profiles:
+                - name: allow-id-payload-mismatch
+                  type: bool
+                  profiles:
                     - xpath:
-                      - base-url
-                    validators:
+                        - allow-id-payload-mismatch
+                  validators: []
+                  spec: {}
+                  description:
+                    Permit peer identification and certificate payload identification
+                    mismatch
+                  required: false
+                - name: certificate-profile
+                  type: string
+                  profiles:
+                    - xpath:
+                        - certificate-profile
+                  validators: []
+                  spec: {}
+                  description: Profile for certificate valdiation during IKE negotiation
+                  required: false
+                - name: local-certificate
+                  type: object
+                  profiles:
+                    - xpath:
+                        - local-certificate
+                  validators: []
+                  spec:
+                    params:
+                      - name: hash-and-url
+                        type: object
+                        profiles:
+                          - xpath:
+                              - hash-and-url
+                        validators: []
+                        spec:
+                          params:
+                            - name: base-url
+                              type: string
+                              profiles:
+                                - xpath:
+                                    - base-url
+                              validators:
+                                - type: length
+                                  spec:
+                                    max: 1024
+                              spec: {}
+                              description:
+                                The host and directory part of URL for local certificates(http
+                                only)
+                              required: false
+                            - name: enable
+                              type: bool
+                              profiles:
+                                - xpath:
+                                    - enable
+                              validators: []
+                              spec: {}
+                              description: Use hash-and-url for local certificate
+                              required: false
+                          variants: []
+                        description: ""
+                        required: false
+                      - name: name
+                        type: string
+                        profiles:
+                          - xpath:
+                              - name
+                        validators:
+                          - type: length
+                            spec:
+                              max: 255
+                        spec: {}
+                        description: Local certificate name
+                        required: false
+                    variants: []
+                  description: ""
+                  required: false
+                - name: strict-validation-revocation
+                  type: bool
+                  profiles:
+                    - xpath:
+                        - strict-validation-revocation
+                  validators: []
+                  spec: {}
+                  description: Enable strict validation of peer's extended key use
+                  required: false
+                - name: use-management-as-source
+                  type: bool
+                  profiles:
+                    - xpath:
+                        - use-management-as-source
+                  validators: []
+                  spec: {}
+                  description: Use management interface IP as source to retrieve http certificates
+                  required: false
+              variants: []
+            description: Use RSA or ECDSA digital signature authentication
+            required: false
+          - name: pre-shared-key
+            type: object
+            profiles:
+              - xpath:
+                  - pre-shared-key
+            validators: []
+            spec:
+              params:
+                - name: key
+                  type: string
+                  profiles:
+                    - xpath:
+                        - key
+                  validators:
                     - type: length
                       spec:
-                        max: 1024
-                    spec: {}
-                    description: The host and directory part of URL for local certificates(http
-                      only)
-                    required: false
-                  - name: enable
-                    type: bool
-                    profiles:
-                    - xpath:
-                      - enable
-                    validators: []
-                    spec: {}
-                    description: Use hash-and-url for local certificate
-                    required: false
-                  variants: []
-                description: ''
-                required: false
-              - name: name
-                type: string
-                profiles:
-                - xpath:
-                  - name
-                validators:
-                - type: length
-                  spec:
-                    max: 255
-                spec: {}
-                description: Local certificate name
-                required: false
+                        max: 255
+                  spec: {}
+                  description: the string used as pre-shared key
+                  required: false
               variants: []
-            description: ''
+            description: Use pre-shared key for mutual authentication
             required: false
-          - name: strict-validation-revocation
-            type: bool
-            profiles:
-            - xpath:
-              - strict-validation-revocation
-            validators: []
-            spec: {}
-            description: Enable strict validation of peer's extended key use
-            required: false
-          - name: use-management-as-source
-            type: bool
-            profiles:
-            - xpath:
-              - use-management-as-source
-            validators: []
-            spec: {}
-            description: Use management interface IP as source to retrieve http certificates
-            required: false
-          variants: []
-        description: Use RSA or ECDSA digital signature authentication
-        required: false
-      - name: pre-shared-key
-        type: object
-        profiles:
+      description: Authentication method
+      required: false
+    - name: comment
+      type: string
+      profiles:
         - xpath:
-          - pre-shared-key
-        validators: []
-        spec:
-          params:
-          - name: key
+            - comment
+      validators:
+        - type: length
+          spec:
+            min: 0
+            max: 1023
+      spec: {}
+      description: ""
+      required: false
+    - name: disabled
+      type: bool
+      profiles:
+        - xpath:
+            - disabled
+      validators: []
+      spec: {}
+      description: Disable the IKE gateway
+      required: false
+    - name: ipv6
+      type: bool
+      profiles:
+        - xpath:
+            - ipv6
+      validators: []
+      spec: {}
+      description: use IPv6 for the IKE gateway
+      required: false
+    - name: local-address
+      type: object
+      profiles:
+        - xpath:
+            - local-address
+      validators: []
+      spec:
+        params:
+          - name: interface
             type: string
             profiles:
-            - xpath:
-              - key
-            validators:
-            - type: length
-              spec:
-                max: 255
+              - xpath:
+                  - interface
+            validators: []
             spec: {}
-            description: the string used as pre-shared key
+            description: local gateway end-point
             required: false
-          variants: []
-        description: Use pre-shared key for mutual authentication
-        required: false
-    description: Authentication method
-    required: false
-  - name: comment
-    type: string
-    profiles:
-    - xpath:
-      - comment
-    validators:
-    - type: length
+        variants:
+          - name: floating-ip
+            type: string
+            profiles:
+              - xpath:
+                  - floating-ip
+            validators: []
+            spec: {}
+            description: Floating IP address in HA Active-Active configuration
+            required: false
+            codegen_overrides:
+              terraform:
+                variant_check: ConflictsWith
+          - name: ip
+            type: string
+            profiles:
+              - xpath:
+                  - ip
+            validators:
+              - type: length
+                spec:
+                  max: 63
+            spec: {}
+            description: specify exact IP address if interface has multiple addresses
+            required: false
+      description: IKE gateway local IP configuration
+      required: false
+    - name: local-id
+      type: object
+      profiles:
+        - xpath:
+            - local-id
+      validators: []
       spec:
-        min: 0
-        max: 1023
-    spec: {}
-    description: ''
-    required: false
-  - name: disabled
-    type: bool
-    profiles:
-    - xpath:
-      - disabled
-    validators: []
-    spec: {}
-    description: Disable the IKE gateway
-    required: false
-  - name: ipv6
-    type: bool
-    profiles:
-    - xpath:
-      - ipv6
-    validators: []
-    spec: {}
-    description: use IPv6 for the IKE gateway
-    required: false
-  - name: local-address
-    type: object
-    profiles:
-    - xpath:
-      - local-address
-    validators: []
-    spec:
-      params:
-      - name: interface
-        type: string
-        profiles:
+        params:
+          - name: id
+            type: string
+            profiles:
+              - xpath:
+                  - id
+            validators:
+              - type: length
+                spec:
+                  min: 1
+                  max: 1024
+            spec: {}
+            description: Local ID string
+            required: false
+          - name: type
+            type: string
+            profiles:
+              - xpath:
+                  - type
+            validators: []
+            spec: {}
+            description: ""
+            required: false
+        variants: []
+      description:
+        optionally how peer gateway will identify local gateway instead of
+        using IP address
+      required: false
+    - name: peer-address
+      type: object
+      profiles:
         - xpath:
-          - interface
-        validators: []
-        spec: {}
-        description: local gateway end-point
-        required: false
-      variants:
-      - name: floating-ip
-        type: string
-        profiles:
-        - xpath:
-          - floating-ip
-        validators: []
-        spec: {}
-        description: Floating IP address in HA Active-Active configuration
-        required: false
-        codegen_overrides:
-          terraform:
-            variant_check: ConflictsWith
-      - name: ip
-        type: string
-        profiles:
-        - xpath:
-          - ip
-        validators:
-        - type: length
-          spec:
-            max: 63
-        spec: {}
-        description: specify exact IP address if interface has multiple addresses
-        required: false
-    description: IKE gateway local IP configuration
-    required: false
-  - name: local-id
-    type: object
-    profiles:
-    - xpath:
-      - local-id
-    validators: []
-    spec:
-      params:
-      - name: id
-        type: string
-        profiles:
-        - xpath:
-          - id
-        validators:
-        - type: length
-          spec:
-            min: 1
-            max: 1024
-        spec: {}
-        description: Local ID string
-        required: false
-      - name: type
-        type: string
-        profiles:
-        - xpath:
-          - type
-        validators: []
-        spec: {}
-        description: ''
-        required: false
-      variants: []
-    description: optionally how peer gateway will identify local gateway instead of
-      using IP address
-    required: false
-  - name: peer-address
-    type: object
-    profiles:
-    - xpath:
-      - peer-address
-    validators: []
-    spec:
-      params: []
-      variants:
-      - name: dynamic
-        type: object
-        profiles:
-        - xpath:
-          - dynamic
-        validators: []
-        spec:
-          params: []
-          variants: []
-        description: peer gateway has dynamic IP address
-        required: false
-      - name: fqdn
-        type: string
-        profiles:
-        - xpath:
-          - fqdn
-        validators:
-        - type: length
-          spec:
-            max: 255
-        spec: {}
-        description: peer gateway FQDN name
-        required: false
-      - name: ip
-        type: string
-        profiles:
-        - xpath:
-          - ip
-        validators: []
-        spec: {}
-        description: peer gateway has static IP address
-        required: false
-    description: Peer gateway address
-    required: false
-  - name: peer-id
-    type: object
-    profiles:
-    - xpath:
-      - peer-id
-    validators: []
-    spec:
-      params:
-      - name: id
-        type: string
-        profiles:
-        - xpath:
-          - id
-        validators:
-        - type: length
-          spec:
-            min: 1
-            max: 1024
-        spec: {}
-        description: Peer ID string
-        required: false
-      - name: matching
-        type: enum
-        profiles:
-        - xpath:
-          - matching
-        validators:
-        - type: values
-          spec:
-            values:
-            - exact
-            - wildcard
-        spec:
-          default: exact
-          values:
-          - value: exact
-          - value: wildcard
-        description: Enable peer ID wildcard match for certificate authentication
-        required: false
-      - name: type
-        type: string
-        profiles:
-        - xpath:
-          - type
-        validators: []
-        spec: {}
-        description: ''
-        required: false
-      variants: []
-    description: optionally how local gateway will identify peer gateway instead of
-      using IP address
-    required: false
-  - name: protocol
-    type: object
-    profiles:
-    - xpath:
-      - protocol
-    validators: []
-    spec:
-      params:
-      - name: ikev1
-        type: object
-        profiles:
-        - xpath:
-          - ikev1
-        validators: []
-        spec:
-          params:
-          - name: dpd
+            - peer-address
+      validators: []
+      spec:
+        params: []
+        variants:
+          - name: dynamic
             type: object
             profiles:
-            - xpath:
-              - dpd
+              - xpath:
+                  - dynamic
             validators: []
             spec:
-              params:
-              - name: enable
-                type: bool
-                profiles:
-                - xpath:
-                  - enable
-                validators: []
-                spec: {}
-                description: Enable Dead-Peer-Detection
-                required: false
-              - name: interval
-                type: int64
-                profiles:
-                - xpath:
-                  - interval
-                validators:
-                - type: length
-                  spec:
-                    min: 2
-                    max: 100
-                spec:
-                  default: 5
-                description: sending interval for probing packets (in seconds)
-                required: false
-              - name: retry
-                type: int64
-                profiles:
-                - xpath:
-                  - retry
-                validators:
-                - type: length
-                  spec:
-                    min: 2
-                    max: 100
-                spec:
-                  default: 5
-                description: number of retries before disconnection
-                required: false
+              params: []
               variants: []
-            description: Dead-Peer-Detection settings
+            description: peer gateway has dynamic IP address
             required: false
-          - name: exchange-mode
+          - name: fqdn
+            type: string
+            profiles:
+              - xpath:
+                  - fqdn
+            validators:
+              - type: length
+                spec:
+                  max: 255
+            spec: {}
+            description: peer gateway FQDN name
+            required: false
+          - name: ip
+            type: string
+            profiles:
+              - xpath:
+                  - ip
+            validators: []
+            spec: {}
+            description: peer gateway has static IP address
+            required: false
+      description: Peer gateway address
+      required: false
+    - name: peer-id
+      type: object
+      profiles:
+        - xpath:
+            - peer-id
+      validators: []
+      spec:
+        params:
+          - name: id
+            type: string
+            profiles:
+              - xpath:
+                  - id
+            validators:
+              - type: length
+                spec:
+                  min: 1
+                  max: 1024
+            spec: {}
+            description: Peer ID string
+            required: false
+          - name: matching
             type: enum
             profiles:
-            - xpath:
-              - exchange-mode
+              - xpath:
+                  - matching
             validators:
-            - type: values
-              spec:
-                values:
-                - auto
-                - main
-                - aggressive
+              - type: values
+                spec:
+                  values:
+                    - exact
+                    - wildcard
             spec:
-              default: auto
+              default: exact
               values:
-              - value: auto
-              - value: main
-              - value: aggressive
-            description: Exchange mode
+                - value: exact
+                - value: wildcard
+            description: Enable peer ID wildcard match for certificate authentication
             required: false
-          - name: ike-crypto-profile
+          - name: type
             type: string
             profiles:
-            - xpath:
-              - ike-crypto-profile
+              - xpath:
+                  - type
             validators: []
-            spec:
-              default: default
-            description: IKE SA crypto profile name
+            spec: {}
+            description: ""
             required: false
-          variants: []
-        description: IKEv1 setting
-        required: false
-      - name: ikev2
-        type: object
-        profiles:
+        variants: []
+      description:
+        optionally how local gateway will identify peer gateway instead of
+        using IP address
+      required: false
+    - name: protocol
+      type: object
+      profiles:
         - xpath:
-          - ikev2
-        validators: []
-        spec:
-          params:
-          - name: dpd
+            - protocol
+      validators: []
+      spec:
+        params:
+          - name: ikev1
             type: object
             profiles:
-            - xpath:
-              - dpd
+              - xpath:
+                  - ikev1
             validators: []
             spec:
               params:
-              - name: enable
-                type: bool
-                profiles:
-                - xpath:
-                  - enable
-                validators: []
-                spec: {}
-                description: Enable sending empty information liveness check message
-                required: false
-              - name: interval
-                type: int64
-                profiles:
-                - xpath:
-                  - interval
-                validators:
-                - type: length
+                - name: dpd
+                  type: object
+                  profiles:
+                    - xpath:
+                        - dpd
+                  validators: []
                   spec:
-                    min: 2
-                    max: 100
-                spec:
-                  default: 5
-                description: delay interval before sending probing packets (in seconds)
-                required: false
+                    params:
+                      - name: enable
+                        type: bool
+                        profiles:
+                          - xpath:
+                              - enable
+                        validators: []
+                        spec: {}
+                        description: Enable Dead-Peer-Detection
+                        required: false
+                      - name: interval
+                        type: int64
+                        profiles:
+                          - xpath:
+                              - interval
+                        validators:
+                          - type: length
+                            spec:
+                              min: 2
+                              max: 100
+                        spec:
+                          default: 5
+                        description: sending interval for probing packets (in seconds)
+                        required: false
+                      - name: retry
+                        type: int64
+                        profiles:
+                          - xpath:
+                              - retry
+                        validators:
+                          - type: length
+                            spec:
+                              min: 2
+                              max: 100
+                        spec:
+                          default: 5
+                        description: number of retries before disconnection
+                        required: false
+                    variants: []
+                  description: Dead-Peer-Detection settings
+                  required: false
+                - name: exchange-mode
+                  type: enum
+                  profiles:
+                    - xpath:
+                        - exchange-mode
+                  validators:
+                    - type: values
+                      spec:
+                        values:
+                          - auto
+                          - main
+                          - aggressive
+                  spec:
+                    default: auto
+                    values:
+                      - value: auto
+                      - value: main
+                      - value: aggressive
+                  description: Exchange mode
+                  required: false
+                - name: ike-crypto-profile
+                  type: string
+                  profiles:
+                    - xpath:
+                        - ike-crypto-profile
+                  validators: []
+                  spec:
+                    default: default
+                  description: IKE SA crypto profile name
+                  required: false
               variants: []
-            description: IKEv2 liveness check setting
+            description: IKEv1 setting
             required: false
-          - name: ike-crypto-profile
-            type: string
+          - name: ikev2
+            type: object
             profiles:
-            - xpath:
-              - ike-crypto-profile
+              - xpath:
+                  - ikev2
             validators: []
             spec:
-              default: default
-            description: IKE SA crypto profile name
+              params:
+                - name: dpd
+                  type: object
+                  profiles:
+                    - xpath:
+                        - dpd
+                  validators: []
+                  spec:
+                    params:
+                      - name: enable
+                        type: bool
+                        profiles:
+                          - xpath:
+                              - enable
+                        validators: []
+                        spec: {}
+                        description: Enable sending empty information liveness check message
+                        required: false
+                      - name: interval
+                        type: int64
+                        profiles:
+                          - xpath:
+                              - interval
+                        validators:
+                          - type: length
+                            spec:
+                              min: 2
+                              max: 100
+                        spec:
+                          default: 5
+                        description: delay interval before sending probing packets (in seconds)
+                        required: false
+                    variants: []
+                  description: IKEv2 liveness check setting
+                  required: false
+                - name: ike-crypto-profile
+                  type: string
+                  profiles:
+                    - xpath:
+                        - ike-crypto-profile
+                  validators: []
+                  spec:
+                    default: default
+                  description: IKE SA crypto profile name
+                  required: false
+                - name: require-cookie
+                  type: bool
+                  profiles:
+                    - xpath:
+                        - require-cookie
+                  validators: []
+                  spec: {}
+                  description: Require cookie
+                  required: false
+              variants: []
+            description: IKEv2 setting
             required: false
-          - name: require-cookie
-            type: bool
+          - name: version
+            type: enum
             profiles:
-            - xpath:
-              - require-cookie
-            validators: []
-            spec: {}
-            description: Require cookie
-            required: false
-          variants: []
-        description: IKEv2 setting
-        required: false
-      - name: version
-        type: enum
-        profiles:
-        - xpath:
-          - version
-        validators:
-        - type: values
-          spec:
-            values:
-            - ikev1
-            - ikev2
-            - ikev2-preferred
-        spec:
-          default: ikev1
-          values:
-          - value: ikev1
-          - value: ikev2
-          - value: ikev2-preferred
-        description: IKE protocol version
-        required: false
-      variants: []
-    description: IKE Protocol settings
-    required: false
-  - name: protocol-common
-    type: object
-    profiles:
-    - xpath:
-      - protocol-common
-    validators: []
-    spec:
-      params:
-      - name: fragmentation
-        type: object
-        profiles:
-        - xpath:
-          - fragmentation
-        validators: []
-        spec:
-          params:
-          - name: enable
-            type: bool
-            profiles:
-            - xpath:
-              - enable
-            validators: []
-            spec: {}
-            description: Enable IKE fragmentation
-            required: false
-          variants: []
-        description: IKE fragmentation settings
-        required: false
-      - name: nat-traversal
-        type: object
-        profiles:
-        - xpath:
-          - nat-traversal
-        validators: []
-        spec:
-          params:
-          - name: enable
-            type: bool
-            profiles:
-            - xpath:
-              - enable
-            validators: []
-            spec: {}
-            description: Enable NAT-Traversal
-            required: false
-          - name: keep-alive-interval
-            type: int64
-            profiles:
-            - xpath:
-              - keep-alive-interval
+              - xpath:
+                  - version
             validators:
-            - type: length
-              spec:
-                min: 10
-                max: 3600
+              - type: values
+                spec:
+                  values:
+                    - ikev1
+                    - ikev2
+                    - ikev2-preferred
             spec:
-              default: 20
-            description: sending interval for NAT keep-alive packets (in seconds)
+              default: ikev1
+              values:
+                - value: ikev1
+                - value: ikev2
+                - value: ikev2-preferred
+            description: IKE protocol version
             required: false
-          - name: udp-checksum-enable
+        variants: []
+      description: IKE Protocol settings
+      required: false
+    - name: protocol-common
+      type: object
+      profiles:
+        - xpath:
+            - protocol-common
+      validators: []
+      spec:
+        params:
+          - name: fragmentation
+            type: object
+            profiles:
+              - xpath:
+                  - fragmentation
+            validators: []
+            spec:
+              params:
+                - name: enable
+                  type: bool
+                  profiles:
+                    - xpath:
+                        - enable
+                  validators: []
+                  spec: {}
+                  description: Enable IKE fragmentation
+                  required: false
+              variants: []
+            description: IKE fragmentation settings
+            required: false
+          - name: nat-traversal
+            type: object
+            profiles:
+              - xpath:
+                  - nat-traversal
+            validators: []
+            spec:
+              params:
+                - name: enable
+                  type: bool
+                  profiles:
+                    - xpath:
+                        - enable
+                  validators: []
+                  spec: {}
+                  description: Enable NAT-Traversal
+                  required: false
+                - name: keep-alive-interval
+                  type: int64
+                  profiles:
+                    - xpath:
+                        - keep-alive-interval
+                  validators:
+                    - type: length
+                      spec:
+                        min: 10
+                        max: 3600
+                  spec:
+                    default: 20
+                  description: sending interval for NAT keep-alive packets (in seconds)
+                  required: false
+                - name: udp-checksum-enable
+                  type: bool
+                  profiles:
+                    - xpath:
+                        - udp-checksum-enable
+                  validators: []
+                  spec: {}
+                  description: Enable UDP checksum
+                  required: false
+              variants: []
+            description: NAT-Traversal settings
+            required: false
+          - name: passive-mode
             type: bool
             profiles:
-            - xpath:
-              - udp-checksum-enable
+              - xpath:
+                  - passive-mode
             validators: []
             spec: {}
-            description: Enable UDP checksum
+            description: Enable passive mode (responder only)
             required: false
-          variants: []
-        description: NAT-Traversal settings
-        required: false
-      - name: passive-mode
-        type: bool
-        profiles:
-        - xpath:
-          - passive-mode
-        validators: []
-        spec: {}
-        description: Enable passive mode (responder only)
-        required: false
-      variants: []
-    description: IKE Protocol settings common to IKEv1 and IKEv2 (IKEv2 to be supported
-      in the future)
-    required: false
+        variants: []
+      description:
+        IKE Protocol settings common to IKEv1 and IKEv2 (IKEv2 to be supported
+        in the future)
+      required: false
   variants: []

--- a/specs/network/interface/aggregate.yaml
+++ b/specs/network/interface/aggregate.yaml
@@ -16,10 +16,12 @@ go_sdk_config:
   - network
   - interface
   - aggregate
-xpath_suffix:
-- network
-- interface
-- aggregate-ethernet
+panos_xpath:
+  path:
+  - network
+  - interface
+  - aggregate-ethernet
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -155,6 +157,7 @@ spec:
       variants: []
     description: Interface to mirror decrypted packet
     required: false
+    variant_group_id: 0
   - name: ha
     type: object
     profiles:
@@ -259,6 +262,7 @@ spec:
       variants: []
     description: Interface for high-availability functions
     required: false
+    variant_group_id: 0
   - name: layer2
     type: object
     profiles:
@@ -444,6 +448,7 @@ spec:
       variants: []
     description: Layer2 interface
     required: false
+    variant_group_id: 0
   - name: layer3
     type: object
     profiles:
@@ -940,365 +945,6 @@ spec:
                     required: false
                   variants: []
             description: ''
-            required: false
-          - name: enabled
-            type: bool
-            profiles:
-            - xpath:
-              - enabled
-            validators: []
-            spec: {}
-            description: Enable IPv6 on the interface
-            required: false
-          - name: interface-id
-            type: string
-            profiles:
-            - xpath:
-              - interface-id
-            validators: []
-            spec:
-              default: EUI-64
-            description: ''
-            required: false
-          - name: neighbor-discovery
-            type: object
-            profiles:
-            - xpath:
-              - neighbor-discovery
-            validators: []
-            spec:
-              params:
-              - name: dad-attempts
-                type: int64
-                profiles:
-                - xpath:
-                  - dad-attempts
-                validators:
-                - type: length
-                  spec:
-                    min: 0
-                    max: 10
-                spec:
-                  default: 1
-                description: number of consecutive neighbor solicitation messages
-                  sent for duplicate address detection
-                required: false
-              - name: enable-dad
-                type: bool
-                profiles:
-                - xpath:
-                  - enable-dad
-                validators: []
-                spec: {}
-                description: enable duplicate address detection
-                required: false
-              - name: enable-ndp-monitor
-                type: bool
-                profiles:
-                - xpath:
-                  - enable-ndp-monitor
-                validators: []
-                spec: {}
-                description: enable ndp monitoring
-                required: false
-              - name: neighbor
-                type: list
-                profiles:
-                - xpath:
-                  - neighbor
-                  - entry
-                  type: entry
-                validators: []
-                spec:
-                  type: object
-                  items:
-                    type: object
-                    spec:
-                      params:
-                      - name: hw-address
-                        type: string
-                        profiles:
-                        - xpath:
-                          - hw-address
-                        validators: []
-                        spec: {}
-                        description: MAC address (format xx:xx:xx:xx:xx:xx)
-                        required: false
-                      variants: []
-                description: ''
-                required: false
-              - name: ns-interval
-                type: int64
-                profiles:
-                - xpath:
-                  - ns-interval
-                validators:
-                - type: length
-                  spec:
-                    min: 1
-                    max: 3600
-                spec:
-                  default: 1
-                description: interval (in seconds) between consecutive neighbor solicitation
-                  messages
-                required: false
-              - name: reachable-time
-                type: int64
-                profiles:
-                - xpath:
-                  - reachable-time
-                validators:
-                - type: length
-                  spec:
-                    min: 10
-                    max: 36000
-                spec:
-                  default: 30
-                description: time (in seconds) that the Reachable status for a neighbor
-                  can be maintained
-                required: false
-              - name: router-advertisement
-                type: object
-                profiles:
-                - xpath:
-                  - router-advertisement
-                validators: []
-                spec:
-                  params:
-                  - name: dns-support
-                    type: object
-                    profiles:
-                    - xpath:
-                      - dns-support
-                    validators: []
-                    spec:
-                      params:
-                      - name: enable
-                        type: bool
-                        profiles:
-                        - xpath:
-                          - enable
-                        validators: []
-                        spec: {}
-                        description: ''
-                        required: false
-                      - name: server
-                        type: list
-                        profiles:
-                        - xpath:
-                          - server
-                          - entry
-                          type: entry
-                        validators: []
-                        spec:
-                          type: object
-                          items:
-                            type: object
-                            spec:
-                              params:
-                              - name: lifetime
-                                type: int64
-                                profiles:
-                                - xpath:
-                                  - lifetime
-                                validators:
-                                - type: length
-                                  spec:
-                                    min: 4
-                                    max: 3600
-                                spec:
-                                  default: 1200
-                                description: (4-3600) lifetime in seconds
-                                required: false
-                              variants: []
-                        description: ''
-                        required: false
-                      - name: suffix
-                        type: list
-                        profiles:
-                        - xpath:
-                          - suffix
-                          - entry
-                          type: entry
-                        validators: []
-                        spec:
-                          type: object
-                          items:
-                            type: object
-                            spec:
-                              params:
-                              - name: lifetime
-                                type: int64
-                                profiles:
-                                - xpath:
-                                  - lifetime
-                                validators:
-                                - type: length
-                                  spec:
-                                    min: 4
-                                    max: 3600
-                                spec:
-                                  default: 1200
-                                description: (4-3600) lifetime in seconds
-                                required: false
-                              variants: []
-                        description: ''
-                        required: false
-                      variants: []
-                    description: DNS configuration support
-                    required: false
-                  - name: enable
-                    type: bool
-                    profiles:
-                    - xpath:
-                      - enable
-                    validators: []
-                    spec: {}
-                    description: ''
-                    required: false
-                  - name: enable-consistency-check
-                    type: bool
-                    profiles:
-                    - xpath:
-                      - enable-consistency-check
-                    validators: []
-                    spec: {}
-                    description: check consistency of RA messages from other routers.
-                    required: false
-                  - name: hop-limit
-                    type: string
-                    profiles:
-                    - xpath:
-                      - hop-limit
-                    validators: []
-                    spec:
-                      default: '64'
-                    description: Current Hop Limit advertised in Router Advertisement
-                      messages
-                    required: false
-                  - name: lifetime
-                    type: int64
-                    profiles:
-                    - xpath:
-                      - lifetime
-                    validators:
-                    - type: length
-                      spec:
-                        min: 0
-                        max: 9000
-                    spec:
-                      default: 1800
-                    description: Router Lifetime (in seconds) advertised in Router
-                      Advertisement messages
-                    required: false
-                  - name: link-mtu
-                    type: string
-                    profiles:
-                    - xpath:
-                      - link-mtu
-                    validators: []
-                    spec:
-                      default: unspecified
-                    description: value of MTU option in Router Advertisement messages,
-                      upto 9216 in Jumbo-Frame mode, up to 1500 otherwise
-                    required: false
-                  - name: managed-flag
-                    type: bool
-                    profiles:
-                    - xpath:
-                      - managed-flag
-                    validators: []
-                    spec: {}
-                    description: Set the Managed Configuration Flag (M-bit) in Router
-                      Advertisement messages
-                    required: false
-                  - name: max-interval
-                    type: int64
-                    profiles:
-                    - xpath:
-                      - max-interval
-                    validators:
-                    - type: length
-                      spec:
-                        min: 4
-                        max: 1800
-                    spec:
-                      default: 600
-                    description: Maximum interval (seconds) between consecutive unsolicited
-                      Router Advertisement messages
-                    required: false
-                  - name: min-interval
-                    type: int64
-                    profiles:
-                    - xpath:
-                      - min-interval
-                    validators:
-                    - type: length
-                      spec:
-                        min: 3
-                        max: 1350
-                    spec:
-                      default: 200
-                    description: Minimum interval (seconds) between consecutive unsolicited
-                      Router Advertisement messages
-                    required: false
-                  - name: other-flag
-                    type: bool
-                    profiles:
-                    - xpath:
-                      - other-flag
-                    validators: []
-                    spec: {}
-                    description: Set the Other Stateful Configuration Flag (O-bit)
-                      in Router Advertisement messages
-                    required: false
-                  - name: reachable-time
-                    type: string
-                    profiles:
-                    - xpath:
-                      - reachable-time
-                    validators: []
-                    spec:
-                      default: unspecified
-                    description: Reachable Time (in milliseconds) advertised in Router
-                      Advertisement messages
-                    required: false
-                  - name: retransmission-timer
-                    type: string
-                    profiles:
-                    - xpath:
-                      - retransmission-timer
-                    validators: []
-                    spec:
-                      default: unspecified
-                    description: Retransmission Timer (in milliseconds) advertised
-                      in Router Advertisement messages
-                    required: false
-                  - name: router-preference
-                    type: enum
-                    profiles:
-                    - xpath:
-                      - router-preference
-                    validators:
-                    - type: values
-                      spec:
-                        values:
-                        - High
-                        - Medium
-                        - Low
-                    spec:
-                      default: Medium
-                      values:
-                      - value: High
-                      - value: Medium
-                      - value: Low
-                    description: ''
-                    required: false
-                  variants: []
-                description: Router advertisement configuration
-                required: false
-              variants: []
-            description: Neighbor Discovery configuration
             required: false
           - name: dhcp-client
             type: object
@@ -1811,6 +1457,15 @@ spec:
                 required: false
               variants: []
             description: Configure DHCPv6 Client
+            required: false
+          - name: enabled
+            type: bool
+            profiles:
+            - xpath:
+              - enabled
+            validators: []
+            spec: {}
+            description: Enable IPv6 on the interface
             required: false
           - name: inherited
             type: object
@@ -2552,6 +2207,356 @@ spec:
               variants: []
             description: Configure to inherit properties from another interface
             required: false
+          - name: interface-id
+            type: string
+            profiles:
+            - xpath:
+              - interface-id
+            validators: []
+            spec:
+              default: EUI-64
+            description: ''
+            required: false
+          - name: neighbor-discovery
+            type: object
+            profiles:
+            - xpath:
+              - neighbor-discovery
+            validators: []
+            spec:
+              params:
+              - name: dad-attempts
+                type: int64
+                profiles:
+                - xpath:
+                  - dad-attempts
+                validators:
+                - type: length
+                  spec:
+                    min: 0
+                    max: 10
+                spec:
+                  default: 1
+                description: number of consecutive neighbor solicitation messages
+                  sent for duplicate address detection
+                required: false
+              - name: enable-dad
+                type: bool
+                profiles:
+                - xpath:
+                  - enable-dad
+                validators: []
+                spec: {}
+                description: enable duplicate address detection
+                required: false
+              - name: enable-ndp-monitor
+                type: bool
+                profiles:
+                - xpath:
+                  - enable-ndp-monitor
+                validators: []
+                spec: {}
+                description: enable ndp monitoring
+                required: false
+              - name: neighbor
+                type: list
+                profiles:
+                - xpath:
+                  - neighbor
+                  - entry
+                  type: entry
+                validators: []
+                spec:
+                  type: object
+                  items:
+                    type: object
+                    spec:
+                      params:
+                      - name: hw-address
+                        type: string
+                        profiles:
+                        - xpath:
+                          - hw-address
+                        validators: []
+                        spec: {}
+                        description: MAC address (format xx:xx:xx:xx:xx:xx)
+                        required: false
+                      variants: []
+                description: ''
+                required: false
+              - name: ns-interval
+                type: int64
+                profiles:
+                - xpath:
+                  - ns-interval
+                validators:
+                - type: length
+                  spec:
+                    min: 1
+                    max: 3600
+                spec:
+                  default: 1
+                description: interval (in seconds) between consecutive neighbor solicitation
+                  messages
+                required: false
+              - name: reachable-time
+                type: int64
+                profiles:
+                - xpath:
+                  - reachable-time
+                validators:
+                - type: length
+                  spec:
+                    min: 10
+                    max: 36000
+                spec:
+                  default: 30
+                description: time (in seconds) that the Reachable status for a neighbor
+                  can be maintained
+                required: false
+              - name: router-advertisement
+                type: object
+                profiles:
+                - xpath:
+                  - router-advertisement
+                validators: []
+                spec:
+                  params:
+                  - name: dns-support
+                    type: object
+                    profiles:
+                    - xpath:
+                      - dns-support
+                    validators: []
+                    spec:
+                      params:
+                      - name: enable
+                        type: bool
+                        profiles:
+                        - xpath:
+                          - enable
+                        validators: []
+                        spec: {}
+                        description: ''
+                        required: false
+                      - name: server
+                        type: list
+                        profiles:
+                        - xpath:
+                          - server
+                          - entry
+                          type: entry
+                        validators: []
+                        spec:
+                          type: object
+                          items:
+                            type: object
+                            spec:
+                              params:
+                              - name: lifetime
+                                type: int64
+                                profiles:
+                                - xpath:
+                                  - lifetime
+                                validators:
+                                - type: length
+                                  spec:
+                                    min: 4
+                                    max: 3600
+                                spec:
+                                  default: 1200
+                                description: (4-3600) lifetime in seconds
+                                required: false
+                              variants: []
+                        description: ''
+                        required: false
+                      - name: suffix
+                        type: list
+                        profiles:
+                        - xpath:
+                          - suffix
+                          - entry
+                          type: entry
+                        validators: []
+                        spec:
+                          type: object
+                          items:
+                            type: object
+                            spec:
+                              params:
+                              - name: lifetime
+                                type: int64
+                                profiles:
+                                - xpath:
+                                  - lifetime
+                                validators:
+                                - type: length
+                                  spec:
+                                    min: 4
+                                    max: 3600
+                                spec:
+                                  default: 1200
+                                description: (4-3600) lifetime in seconds
+                                required: false
+                              variants: []
+                        description: ''
+                        required: false
+                      variants: []
+                    description: DNS configuration support
+                    required: false
+                  - name: enable
+                    type: bool
+                    profiles:
+                    - xpath:
+                      - enable
+                    validators: []
+                    spec: {}
+                    description: ''
+                    required: false
+                  - name: enable-consistency-check
+                    type: bool
+                    profiles:
+                    - xpath:
+                      - enable-consistency-check
+                    validators: []
+                    spec: {}
+                    description: check consistency of RA messages from other routers.
+                    required: false
+                  - name: hop-limit
+                    type: string
+                    profiles:
+                    - xpath:
+                      - hop-limit
+                    validators: []
+                    spec:
+                      default: '64'
+                    description: Current Hop Limit advertised in Router Advertisement
+                      messages
+                    required: false
+                  - name: lifetime
+                    type: int64
+                    profiles:
+                    - xpath:
+                      - lifetime
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 9000
+                    spec:
+                      default: 1800
+                    description: Router Lifetime (in seconds) advertised in Router
+                      Advertisement messages
+                    required: false
+                  - name: link-mtu
+                    type: string
+                    profiles:
+                    - xpath:
+                      - link-mtu
+                    validators: []
+                    spec:
+                      default: unspecified
+                    description: value of MTU option in Router Advertisement messages,
+                      upto 9216 in Jumbo-Frame mode, up to 1500 otherwise
+                    required: false
+                  - name: managed-flag
+                    type: bool
+                    profiles:
+                    - xpath:
+                      - managed-flag
+                    validators: []
+                    spec: {}
+                    description: Set the Managed Configuration Flag (M-bit) in Router
+                      Advertisement messages
+                    required: false
+                  - name: max-interval
+                    type: int64
+                    profiles:
+                    - xpath:
+                      - max-interval
+                    validators:
+                    - type: length
+                      spec:
+                        min: 4
+                        max: 1800
+                    spec:
+                      default: 600
+                    description: Maximum interval (seconds) between consecutive unsolicited
+                      Router Advertisement messages
+                    required: false
+                  - name: min-interval
+                    type: int64
+                    profiles:
+                    - xpath:
+                      - min-interval
+                    validators:
+                    - type: length
+                      spec:
+                        min: 3
+                        max: 1350
+                    spec:
+                      default: 200
+                    description: Minimum interval (seconds) between consecutive unsolicited
+                      Router Advertisement messages
+                    required: false
+                  - name: other-flag
+                    type: bool
+                    profiles:
+                    - xpath:
+                      - other-flag
+                    validators: []
+                    spec: {}
+                    description: Set the Other Stateful Configuration Flag (O-bit)
+                      in Router Advertisement messages
+                    required: false
+                  - name: reachable-time
+                    type: string
+                    profiles:
+                    - xpath:
+                      - reachable-time
+                    validators: []
+                    spec:
+                      default: unspecified
+                    description: Reachable Time (in milliseconds) advertised in Router
+                      Advertisement messages
+                    required: false
+                  - name: retransmission-timer
+                    type: string
+                    profiles:
+                    - xpath:
+                      - retransmission-timer
+                    validators: []
+                    spec:
+                      default: unspecified
+                    description: Retransmission Timer (in milliseconds) advertised
+                      in Router Advertisement messages
+                    required: false
+                  - name: router-preference
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - router-preference
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - High
+                        - Medium
+                        - Low
+                    spec:
+                      default: Medium
+                      values:
+                      - value: High
+                      - value: Medium
+                      - value: Low
+                    description: ''
+                    required: false
+                  variants: []
+                description: Router advertisement configuration
+                required: false
+              variants: []
+            description: Neighbor Discovery configuration
+            required: false
           variants: []
         description: Interface IPv6 configuration
         required: false
@@ -2847,6 +2852,7 @@ spec:
                   variants: []
                 description: DDNS derives upstream NAT IP
                 required: false
+                variant_group_id: 0
               - name: static-ip
                 type: object
                 profiles:
@@ -2868,6 +2874,7 @@ spec:
                     spec: {}
                     description: Upstream NAT address FQDN name configuration
                     required: false
+                    variant_group_id: 0
                   - name: ip-address
                     type: string
                     profiles:
@@ -2877,8 +2884,10 @@ spec:
                     spec: {}
                     description: Upstream NAT IP address
                     required: false
+                    variant_group_id: 0
                 description: Upstream NAT IP address
                 required: false
+                variant_group_id: 0
             description: Upstream NAT IP config
             required: false
           variants: []
@@ -2896,6 +2905,7 @@ spec:
       variants: []
     description: Layer3 interface
     required: false
+    variant_group_id: 0
   - name: virtual-wire
     type: object
     profiles:
@@ -2968,3 +2978,4 @@ spec:
       variants: []
     description: Virtual-wire interface
     required: false
+    variant_group_id: 0

--- a/specs/network/interface/ethernet.yaml
+++ b/specs/network/interface/ethernet.yaml
@@ -16,10 +16,12 @@ go_sdk_config:
   - network
   - interface
   - ethernet
-xpath_suffix:
-- network
-- interface
-- ethernet
+panos_xpath:
+  path:
+  - network
+  - interface
+  - ethernet
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -388,6 +390,7 @@ spec:
     spec: {}
     description: Aggregate interface group
     required: false
+    variant_group_id: 0
   - name: decrypt-mirror
     type: object
     profiles:
@@ -399,6 +402,7 @@ spec:
       variants: []
     description: Interface to mirror decrypted packet
     required: false
+    variant_group_id: 0
   - name: ha
     type: object
     profiles:
@@ -410,6 +414,7 @@ spec:
       variants: []
     description: HA mode interface
     required: false
+    variant_group_id: 0
   - name: layer2
     type: object
     profiles:
@@ -482,6 +487,7 @@ spec:
       variants: []
     description: Layer2 interface
     required: false
+    variant_group_id: 0
   - name: layer3
     type: object
     profiles:
@@ -606,6 +612,17 @@ spec:
             required: false
           variants: []
         description: Bonjour configuration
+        required: false
+      - name: cluster-interconnect
+        type: bool
+        profiles:
+        - xpath:
+          - cluster-interconnect
+          min_version: 11.0.2
+          max_version: 11.0.3
+        validators: []
+        spec: {}
+        description: ''
         required: false
       - name: ddns-config
         type: object
@@ -985,367 +1002,6 @@ spec:
             codegen_overrides:
               terraform:
                 name: addresses
-          - name: enabled
-            type: bool
-            profiles:
-            - xpath:
-              - enabled
-            validators: []
-            spec: {}
-            description: Enable IPv6 on the interface
-            required: false
-          - name: interface-id
-            type: string
-            profiles:
-            - xpath:
-              - interface-id
-            validators: []
-            spec:
-              default: EUI-64
-            description: ''
-            required: false
-          - name: neighbor-discovery
-            type: object
-            profiles:
-            - xpath:
-              - neighbor-discovery
-            validators: []
-            spec:
-              params:
-              - name: dad-attempts
-                type: int64
-                profiles:
-                - xpath:
-                  - dad-attempts
-                validators:
-                - type: length
-                  spec:
-                    min: 0
-                    max: 10
-                spec:
-                  default: 1
-                description: Number of consecutive neighbor solicitation messages
-                  sent for duplicate address detection
-                required: false
-              - name: enable-dad
-                type: bool
-                profiles:
-                - xpath:
-                  - enable-dad
-                validators: []
-                spec: {}
-                description: Enable Duplicate ADdress Detection (DAD)
-                required: false
-              - name: enable-ndp-monitor
-                type: bool
-                profiles:
-                - xpath:
-                  - enable-ndp-monitor
-                validators: []
-                spec: {}
-                description: Enable NDP Monitoring
-                required: false
-              - name: neighbor
-                type: list
-                profiles:
-                - xpath:
-                  - neighbor
-                  - entry
-                  type: entry
-                validators: []
-                spec:
-                  type: object
-                  items:
-                    type: object
-                    spec:
-                      params:
-                      - name: hw-address
-                        type: string
-                        profiles:
-                        - xpath:
-                          - hw-address
-                        validators: []
-                        spec: {}
-                        description: MAC address (format xx:xx:xx:xx:xx:xx)
-                        required: false
-                      variants: []
-                description: Static entries in neighbor cache
-                required: false
-              - name: ns-interval
-                type: int64
-                profiles:
-                - xpath:
-                  - ns-interval
-                validators:
-                - type: length
-                  spec:
-                    min: 1
-                    max: 3600
-                spec:
-                  default: 1
-                description: Interval (in seconds) between consecutive neighbor solicitation
-                  messages
-                required: false
-              - name: reachable-time
-                type: int64
-                profiles:
-                - xpath:
-                  - reachable-time
-                validators:
-                - type: length
-                  spec:
-                    min: 10
-                    max: 36000
-                spec:
-                  default: 30
-                description: Time (in seconds) that the Reachable status for a neighbor
-                  can be maintained
-                required: false
-              - name: router-advertisement
-                type: object
-                profiles:
-                - xpath:
-                  - router-advertisement
-                validators: []
-                spec:
-                  params:
-                  - name: dns-support
-                    type: object
-                    profiles:
-                    - xpath:
-                      - dns-support
-                    validators: []
-                    spec:
-                      params:
-                      - name: enable
-                        type: bool
-                        profiles:
-                        - xpath:
-                          - enable
-                        validators: []
-                        spec: {}
-                        description: ''
-                        required: false
-                      - name: server
-                        type: list
-                        profiles:
-                        - xpath:
-                          - server
-                          - entry
-                          type: entry
-                        validators: []
-                        spec:
-                          type: object
-                          items:
-                            type: object
-                            spec:
-                              params:
-                              - name: lifetime
-                                type: int64
-                                profiles:
-                                - xpath:
-                                  - lifetime
-                                validators:
-                                - type: length
-                                  spec:
-                                    min: 4
-                                    max: 3600
-                                spec:
-                                  default: 1200
-                                description: Router Lifetime (in seconds) advertised
-                                  in Router Advertisement messages
-                                required: false
-                              variants: []
-                        description: ''
-                        required: false
-                      - name: suffix
-                        type: list
-                        profiles:
-                        - xpath:
-                          - suffix
-                          - entry
-                          type: entry
-                        validators: []
-                        spec:
-                          type: object
-                          items:
-                            type: object
-                            spec:
-                              params:
-                              - name: lifetime
-                                type: int64
-                                profiles:
-                                - xpath:
-                                  - lifetime
-                                validators:
-                                - type: length
-                                  spec:
-                                    min: 4
-                                    max: 3600
-                                spec:
-                                  default: 1200
-                                description: Router Lifetime (in seconds) advertised
-                                  in Router Advertisement messages
-                                required: false
-                              variants: []
-                        description: ''
-                        required: false
-                      variants: []
-                    description: DNS configuration support
-                    required: false
-                  - name: enable
-                    type: bool
-                    profiles:
-                    - xpath:
-                      - enable
-                    validators: []
-                    spec: {}
-                    description: ''
-                    required: false
-                  - name: enable-consistency-check
-                    type: bool
-                    profiles:
-                    - xpath:
-                      - enable-consistency-check
-                    validators: []
-                    spec: {}
-                    description: check consistency of RA messages from other routers.
-                    required: false
-                  - name: hop-limit
-                    type: string
-                    profiles:
-                    - xpath:
-                      - hop-limit
-                    validators: []
-                    spec:
-                      default: '64'
-                    description: Current Hop Limit advertised in Router Advertisement
-                      messages
-                    required: false
-                  - name: lifetime
-                    type: int64
-                    profiles:
-                    - xpath:
-                      - lifetime
-                    validators:
-                    - type: length
-                      spec:
-                        min: 0
-                        max: 9000
-                    spec:
-                      default: 1800
-                    description: Router Lifetime (in seconds) advertised in Router
-                      Advertisement messages
-                    required: false
-                  - name: link-mtu
-                    type: string
-                    profiles:
-                    - xpath:
-                      - link-mtu
-                    validators: []
-                    spec:
-                      default: unspecified
-                    description: value of MTU option in Router Advertisement messages,
-                      upto 9216 in Jumbo-Frame mode, up to 1500 otherwise
-                    required: false
-                  - name: managed-flag
-                    type: bool
-                    profiles:
-                    - xpath:
-                      - managed-flag
-                    validators: []
-                    spec: {}
-                    description: Set the Managed Configuration Flag (M-bit) in Router
-                      Advertisement messages
-                    required: false
-                  - name: max-interval
-                    type: int64
-                    profiles:
-                    - xpath:
-                      - max-interval
-                    validators:
-                    - type: length
-                      spec:
-                        min: 4
-                        max: 1800
-                    spec:
-                      default: 600
-                    description: Maximum interval (seconds) between consecutive unsolicited
-                      Router Advertisement messages
-                    required: false
-                  - name: min-interval
-                    type: int64
-                    profiles:
-                    - xpath:
-                      - min-interval
-                    validators:
-                    - type: length
-                      spec:
-                        min: 3
-                        max: 1350
-                    spec:
-                      default: 200
-                    description: Minimum interval (seconds) between consecutive unsolicited
-                      Router Advertisement messages
-                    required: false
-                  - name: other-flag
-                    type: bool
-                    profiles:
-                    - xpath:
-                      - other-flag
-                    validators: []
-                    spec: {}
-                    description: Set the Other Stateful Configuration Flag (O-bit)
-                      in Router Advertisement messages
-                    required: false
-                  - name: reachable-time
-                    type: string
-                    profiles:
-                    - xpath:
-                      - reachable-time
-                    validators: []
-                    spec:
-                      default: unspecified
-                    description: Reachable Time (in milliseconds) advertised in Router
-                      Advertisement messages
-                    required: false
-                  - name: retransmission-timer
-                    type: string
-                    profiles:
-                    - xpath:
-                      - retransmission-timer
-                    validators: []
-                    spec:
-                      default: unspecified
-                    description: Retransmission Timer (in milliseconds) advertised
-                      in Router Advertisement messages
-                    required: false
-                  - name: router-preference
-                    type: enum
-                    profiles:
-                    - xpath:
-                      - router-preference
-                    validators:
-                    - type: values
-                      spec:
-                        values:
-                        - High
-                        - Medium
-                        - Low
-                    spec:
-                      default: Medium
-                      values:
-                      - value: High
-                      - value: Medium
-                      - value: Low
-                    description: Router Preference
-                    required: false
-                  variants: []
-                description: Router Advertisement configuration
-                required: false
-              variants: []
-            description: Neighbor Discovery configuration
-            required: false
           - name: dhcp-client
             type: object
             profiles:
@@ -1857,6 +1513,15 @@ spec:
                 required: false
               variants: []
             description: Configure DHCPv6 Client
+            required: false
+          - name: enabled
+            type: bool
+            profiles:
+            - xpath:
+              - enabled
+            validators: []
+            spec: {}
+            description: Enable IPv6 on the interface
             required: false
           - name: inherited
             type: object
@@ -2601,6 +2266,358 @@ spec:
               variants: []
             description: Configure to inherit properties from another interface
             required: false
+          - name: interface-id
+            type: string
+            profiles:
+            - xpath:
+              - interface-id
+            validators: []
+            spec:
+              default: EUI-64
+            description: ''
+            required: false
+          - name: neighbor-discovery
+            type: object
+            profiles:
+            - xpath:
+              - neighbor-discovery
+            validators: []
+            spec:
+              params:
+              - name: dad-attempts
+                type: int64
+                profiles:
+                - xpath:
+                  - dad-attempts
+                validators:
+                - type: length
+                  spec:
+                    min: 0
+                    max: 10
+                spec:
+                  default: 1
+                description: Number of consecutive neighbor solicitation messages
+                  sent for duplicate address detection
+                required: false
+              - name: enable-dad
+                type: bool
+                profiles:
+                - xpath:
+                  - enable-dad
+                validators: []
+                spec: {}
+                description: Enable Duplicate ADdress Detection (DAD)
+                required: false
+              - name: enable-ndp-monitor
+                type: bool
+                profiles:
+                - xpath:
+                  - enable-ndp-monitor
+                validators: []
+                spec: {}
+                description: Enable NDP Monitoring
+                required: false
+              - name: neighbor
+                type: list
+                profiles:
+                - xpath:
+                  - neighbor
+                  - entry
+                  type: entry
+                validators: []
+                spec:
+                  type: object
+                  items:
+                    type: object
+                    spec:
+                      params:
+                      - name: hw-address
+                        type: string
+                        profiles:
+                        - xpath:
+                          - hw-address
+                        validators: []
+                        spec: {}
+                        description: MAC address (format xx:xx:xx:xx:xx:xx)
+                        required: false
+                      variants: []
+                description: Static entries in neighbor cache
+                required: false
+              - name: ns-interval
+                type: int64
+                profiles:
+                - xpath:
+                  - ns-interval
+                validators:
+                - type: length
+                  spec:
+                    min: 1
+                    max: 3600
+                spec:
+                  default: 1
+                description: Interval (in seconds) between consecutive neighbor solicitation
+                  messages
+                required: false
+              - name: reachable-time
+                type: int64
+                profiles:
+                - xpath:
+                  - reachable-time
+                validators:
+                - type: length
+                  spec:
+                    min: 10
+                    max: 36000
+                spec:
+                  default: 30
+                description: Time (in seconds) that the Reachable status for a neighbor
+                  can be maintained
+                required: false
+              - name: router-advertisement
+                type: object
+                profiles:
+                - xpath:
+                  - router-advertisement
+                validators: []
+                spec:
+                  params:
+                  - name: dns-support
+                    type: object
+                    profiles:
+                    - xpath:
+                      - dns-support
+                    validators: []
+                    spec:
+                      params:
+                      - name: enable
+                        type: bool
+                        profiles:
+                        - xpath:
+                          - enable
+                        validators: []
+                        spec: {}
+                        description: ''
+                        required: false
+                      - name: server
+                        type: list
+                        profiles:
+                        - xpath:
+                          - server
+                          - entry
+                          type: entry
+                        validators: []
+                        spec:
+                          type: object
+                          items:
+                            type: object
+                            spec:
+                              params:
+                              - name: lifetime
+                                type: int64
+                                profiles:
+                                - xpath:
+                                  - lifetime
+                                validators:
+                                - type: length
+                                  spec:
+                                    min: 4
+                                    max: 3600
+                                spec:
+                                  default: 1200
+                                description: Router Lifetime (in seconds) advertised
+                                  in Router Advertisement messages
+                                required: false
+                              variants: []
+                        description: ''
+                        required: false
+                      - name: suffix
+                        type: list
+                        profiles:
+                        - xpath:
+                          - suffix
+                          - entry
+                          type: entry
+                        validators: []
+                        spec:
+                          type: object
+                          items:
+                            type: object
+                            spec:
+                              params:
+                              - name: lifetime
+                                type: int64
+                                profiles:
+                                - xpath:
+                                  - lifetime
+                                validators:
+                                - type: length
+                                  spec:
+                                    min: 4
+                                    max: 3600
+                                spec:
+                                  default: 1200
+                                description: Router Lifetime (in seconds) advertised
+                                  in Router Advertisement messages
+                                required: false
+                              variants: []
+                        description: ''
+                        required: false
+                      variants: []
+                    description: DNS configuration support
+                    required: false
+                  - name: enable
+                    type: bool
+                    profiles:
+                    - xpath:
+                      - enable
+                    validators: []
+                    spec: {}
+                    description: ''
+                    required: false
+                  - name: enable-consistency-check
+                    type: bool
+                    profiles:
+                    - xpath:
+                      - enable-consistency-check
+                    validators: []
+                    spec: {}
+                    description: check consistency of RA messages from other routers.
+                    required: false
+                  - name: hop-limit
+                    type: string
+                    profiles:
+                    - xpath:
+                      - hop-limit
+                    validators: []
+                    spec:
+                      default: '64'
+                    description: Current Hop Limit advertised in Router Advertisement
+                      messages
+                    required: false
+                  - name: lifetime
+                    type: int64
+                    profiles:
+                    - xpath:
+                      - lifetime
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 9000
+                    spec:
+                      default: 1800
+                    description: Router Lifetime (in seconds) advertised in Router
+                      Advertisement messages
+                    required: false
+                  - name: link-mtu
+                    type: string
+                    profiles:
+                    - xpath:
+                      - link-mtu
+                    validators: []
+                    spec:
+                      default: unspecified
+                    description: value of MTU option in Router Advertisement messages,
+                      upto 9216 in Jumbo-Frame mode, up to 1500 otherwise
+                    required: false
+                  - name: managed-flag
+                    type: bool
+                    profiles:
+                    - xpath:
+                      - managed-flag
+                    validators: []
+                    spec: {}
+                    description: Set the Managed Configuration Flag (M-bit) in Router
+                      Advertisement messages
+                    required: false
+                  - name: max-interval
+                    type: int64
+                    profiles:
+                    - xpath:
+                      - max-interval
+                    validators:
+                    - type: length
+                      spec:
+                        min: 4
+                        max: 1800
+                    spec:
+                      default: 600
+                    description: Maximum interval (seconds) between consecutive unsolicited
+                      Router Advertisement messages
+                    required: false
+                  - name: min-interval
+                    type: int64
+                    profiles:
+                    - xpath:
+                      - min-interval
+                    validators:
+                    - type: length
+                      spec:
+                        min: 3
+                        max: 1350
+                    spec:
+                      default: 200
+                    description: Minimum interval (seconds) between consecutive unsolicited
+                      Router Advertisement messages
+                    required: false
+                  - name: other-flag
+                    type: bool
+                    profiles:
+                    - xpath:
+                      - other-flag
+                    validators: []
+                    spec: {}
+                    description: Set the Other Stateful Configuration Flag (O-bit)
+                      in Router Advertisement messages
+                    required: false
+                  - name: reachable-time
+                    type: string
+                    profiles:
+                    - xpath:
+                      - reachable-time
+                    validators: []
+                    spec:
+                      default: unspecified
+                    description: Reachable Time (in milliseconds) advertised in Router
+                      Advertisement messages
+                    required: false
+                  - name: retransmission-timer
+                    type: string
+                    profiles:
+                    - xpath:
+                      - retransmission-timer
+                    validators: []
+                    spec:
+                      default: unspecified
+                    description: Retransmission Timer (in milliseconds) advertised
+                      in Router Advertisement messages
+                    required: false
+                  - name: router-preference
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - router-preference
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - High
+                        - Medium
+                        - Low
+                    spec:
+                      default: Medium
+                      values:
+                      - value: High
+                      - value: Medium
+                      - value: Low
+                    description: Router Preference
+                    required: false
+                  variants: []
+                description: Router Advertisement configuration
+                required: false
+              variants: []
+            description: Neighbor Discovery configuration
+            required: false
           variants: []
         description: Interface IPv6 configuration
         required: false
@@ -2945,6 +2962,7 @@ spec:
                   variants: []
                 description: DDNS derives upstream NAT IP
                 required: false
+                variant_group_id: 0
               - name: static-ip
                 type: object
                 profiles:
@@ -2966,6 +2984,7 @@ spec:
                     spec: {}
                     description: Upstream NAT address FQDN name configuration
                     required: false
+                    variant_group_id: 0
                   - name: ip-address
                     type: string
                     profiles:
@@ -2975,32 +2994,14 @@ spec:
                     spec: {}
                     description: Upstream NAT IP address
                     required: false
+                    variant_group_id: 0
                 description: Upstream NAT IP address
                 required: false
+                variant_group_id: 0
             description: Upstream NAT IP config
             required: false
           variants: []
         description: Sdwan related settings
-        required: false
-      - name: untagged-sub-interface
-        type: bool
-        profiles:
-        - xpath:
-          - untagged-sub-interface
-        validators: []
-        spec: {}
-        description: Enable untagged sub-interface
-        required: false
-      - name: cluster-interconnect
-        type: bool
-        profiles:
-        - xpath:
-          - cluster-interconnect
-          min_version: 11.0.2
-          max_version: 11.0.3
-        validators: []
-        spec: {}
-        description: ''
         required: false
       - name: traffic-interconnect
         type: bool
@@ -3013,9 +3014,19 @@ spec:
         spec: {}
         description: ''
         required: false
+      - name: untagged-sub-interface
+        type: bool
+        profiles:
+        - xpath:
+          - untagged-sub-interface
+        validators: []
+        spec: {}
+        description: Enable untagged sub-interface
+        required: false
       variants: []
     description: Layer 3 interface
     required: false
+    variant_group_id: 0
   - name: log-card
     type: object
     profiles:
@@ -3072,6 +3083,7 @@ spec:
       variants: []
     description: log card parameters
     required: false
+    variant_group_id: 0
   - name: tap
     type: object
     profiles:
@@ -3095,6 +3107,7 @@ spec:
       variants: []
     description: Tap mode interface
     required: false
+    variant_group_id: 0
   - name: virtual-wire
     type: object
     profiles:
@@ -3199,3 +3212,4 @@ spec:
       variants: []
     description: Virtual-wire interface
     required: false
+    variant_group_id: 0

--- a/specs/network/interface/loopback.yaml
+++ b/specs/network/interface/loopback.yaml
@@ -16,11 +16,13 @@ go_sdk_config:
   - network
   - interface
   - loopback
-xpath_suffix:
-- network
-- interface
-- loopback
-- units
+panos_xpath:
+  path:
+  - network
+  - interface
+  - loopback
+  - units
+  vars: []
 locations:
 - name: ngfw
   xpath:

--- a/specs/network/interface/tunnel.yaml
+++ b/specs/network/interface/tunnel.yaml
@@ -16,11 +16,13 @@ go_sdk_config:
   - network
   - interface
   - tunnel
-xpath_suffix:
-- network
-- interface
-- tunnel
-- units
+panos_xpath:
+  path:
+  - network
+  - interface
+  - tunnel
+  - units
+  vars: []
 locations:
 - name: shared
   xpath:

--- a/specs/network/interface/vlan.yaml
+++ b/specs/network/interface/vlan.yaml
@@ -16,11 +16,13 @@ go_sdk_config:
   - network
   - interface
   - vlan
-xpath_suffix:
-- network
-- interface
-- vlan
-- units
+panos_xpath:
+  path:
+  - network
+  - interface
+  - vlan
+  - units
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -624,365 +626,6 @@ spec:
               variants: []
         description: ''
         required: false
-      - name: enabled
-        type: bool
-        profiles:
-        - xpath:
-          - enabled
-        validators: []
-        spec: {}
-        description: Enable IPv6 on the interface
-        required: false
-      - name: interface-id
-        type: string
-        profiles:
-        - xpath:
-          - interface-id
-        validators: []
-        spec:
-          default: EUI-64
-        description: ''
-        required: false
-      - name: neighbor-discovery
-        type: object
-        profiles:
-        - xpath:
-          - neighbor-discovery
-        validators: []
-        spec:
-          params:
-          - name: dad-attempts
-            type: int64
-            profiles:
-            - xpath:
-              - dad-attempts
-            validators:
-            - type: length
-              spec:
-                min: 0
-                max: 10
-            spec:
-              default: 1
-            description: number of consecutive neighbor solicitation messages sent
-              for duplicate address detection
-            required: false
-          - name: enable-dad
-            type: bool
-            profiles:
-            - xpath:
-              - enable-dad
-            validators: []
-            spec: {}
-            description: enable duplicate address detection
-            required: false
-          - name: enable-ndp-monitor
-            type: bool
-            profiles:
-            - xpath:
-              - enable-ndp-monitor
-            validators: []
-            spec: {}
-            description: enable ndp monitoring
-            required: false
-          - name: neighbor
-            type: list
-            profiles:
-            - xpath:
-              - neighbor
-              - entry
-              type: entry
-            validators: []
-            spec:
-              type: object
-              items:
-                type: object
-                spec:
-                  params:
-                  - name: hw-address
-                    type: string
-                    profiles:
-                    - xpath:
-                      - hw-address
-                    validators: []
-                    spec: {}
-                    description: MAC address (format xx:xx:xx:xx:xx:xx)
-                    required: false
-                  variants: []
-            description: ''
-            required: false
-          - name: ns-interval
-            type: int64
-            profiles:
-            - xpath:
-              - ns-interval
-            validators:
-            - type: length
-              spec:
-                min: 1
-                max: 3600
-            spec:
-              default: 1
-            description: interval (in seconds) between consecutive neighbor solicitation
-              messages
-            required: false
-          - name: reachable-time
-            type: int64
-            profiles:
-            - xpath:
-              - reachable-time
-            validators:
-            - type: length
-              spec:
-                min: 10
-                max: 36000
-            spec:
-              default: 30
-            description: time (in seconds) that the Reachable status for a neighbor
-              can be maintained
-            required: false
-          - name: router-advertisement
-            type: object
-            profiles:
-            - xpath:
-              - router-advertisement
-            validators: []
-            spec:
-              params:
-              - name: dns-support
-                type: object
-                profiles:
-                - xpath:
-                  - dns-support
-                validators: []
-                spec:
-                  params:
-                  - name: enable
-                    type: bool
-                    profiles:
-                    - xpath:
-                      - enable
-                    validators: []
-                    spec: {}
-                    description: ''
-                    required: false
-                  - name: server
-                    type: list
-                    profiles:
-                    - xpath:
-                      - server
-                      - entry
-                      type: entry
-                    validators: []
-                    spec:
-                      type: object
-                      items:
-                        type: object
-                        spec:
-                          params:
-                          - name: lifetime
-                            type: int64
-                            profiles:
-                            - xpath:
-                              - lifetime
-                            validators:
-                            - type: length
-                              spec:
-                                min: 4
-                                max: 3600
-                            spec:
-                              default: 1200
-                            description: (4-3600) lifetime in seconds
-                            required: false
-                          variants: []
-                    description: ''
-                    required: false
-                  - name: suffix
-                    type: list
-                    profiles:
-                    - xpath:
-                      - suffix
-                      - entry
-                      type: entry
-                    validators: []
-                    spec:
-                      type: object
-                      items:
-                        type: object
-                        spec:
-                          params:
-                          - name: lifetime
-                            type: int64
-                            profiles:
-                            - xpath:
-                              - lifetime
-                            validators:
-                            - type: length
-                              spec:
-                                min: 4
-                                max: 3600
-                            spec:
-                              default: 1200
-                            description: (4-3600) lifetime in seconds
-                            required: false
-                          variants: []
-                    description: ''
-                    required: false
-                  variants: []
-                description: DNS configuration support
-                required: false
-              - name: enable
-                type: bool
-                profiles:
-                - xpath:
-                  - enable
-                validators: []
-                spec: {}
-                description: ''
-                required: false
-              - name: enable-consistency-check
-                type: bool
-                profiles:
-                - xpath:
-                  - enable-consistency-check
-                validators: []
-                spec: {}
-                description: check consistency of RA messages from other routers.
-                required: false
-              - name: hop-limit
-                type: string
-                profiles:
-                - xpath:
-                  - hop-limit
-                validators: []
-                spec:
-                  default: '64'
-                description: Current Hop Limit advertised in Router Advertisement
-                  messages
-                required: false
-              - name: lifetime
-                type: int64
-                profiles:
-                - xpath:
-                  - lifetime
-                validators:
-                - type: length
-                  spec:
-                    min: 0
-                    max: 9000
-                spec:
-                  default: 1800
-                description: Router Lifetime (in seconds) advertised in Router Advertisement
-                  messages
-                required: false
-              - name: link-mtu
-                type: string
-                profiles:
-                - xpath:
-                  - link-mtu
-                validators: []
-                spec:
-                  default: unspecified
-                description: value of MTU option in Router Advertisement messages,
-                  upto 9216 in Jumbo-Frame mode, up to 1500 otherwise
-                required: false
-              - name: managed-flag
-                type: bool
-                profiles:
-                - xpath:
-                  - managed-flag
-                validators: []
-                spec: {}
-                description: Set the Managed Configuration Flag (M-bit) in Router
-                  Advertisement messages
-                required: false
-              - name: max-interval
-                type: int64
-                profiles:
-                - xpath:
-                  - max-interval
-                validators:
-                - type: length
-                  spec:
-                    min: 4
-                    max: 1800
-                spec:
-                  default: 600
-                description: Maximum interval (seconds) between consecutive unsolicited
-                  Router Advertisement messages
-                required: false
-              - name: min-interval
-                type: int64
-                profiles:
-                - xpath:
-                  - min-interval
-                validators:
-                - type: length
-                  spec:
-                    min: 3
-                    max: 1350
-                spec:
-                  default: 200
-                description: Minimum interval (seconds) between consecutive unsolicited
-                  Router Advertisement messages
-                required: false
-              - name: other-flag
-                type: bool
-                profiles:
-                - xpath:
-                  - other-flag
-                validators: []
-                spec: {}
-                description: Set the Other Stateful Configuration Flag (O-bit) in
-                  Router Advertisement messages
-                required: false
-              - name: reachable-time
-                type: string
-                profiles:
-                - xpath:
-                  - reachable-time
-                validators: []
-                spec:
-                  default: unspecified
-                description: Reachable Time (in milliseconds) advertised in Router
-                  Advertisement messages
-                required: false
-              - name: retransmission-timer
-                type: string
-                profiles:
-                - xpath:
-                  - retransmission-timer
-                validators: []
-                spec:
-                  default: unspecified
-                description: Retransmission Timer (in milliseconds) advertised in
-                  Router Advertisement messages
-                required: false
-              - name: router-preference
-                type: enum
-                profiles:
-                - xpath:
-                  - router-preference
-                validators:
-                - type: values
-                  spec:
-                    values:
-                    - High
-                    - Medium
-                    - Low
-                spec:
-                  default: Medium
-                  values:
-                  - value: High
-                  - value: Medium
-                  - value: Low
-                description: ''
-                required: false
-              variants: []
-            description: Router advertisement configuration
-            required: false
-          variants: []
-        description: Neighbor Discovery configuration
-        required: false
       - name: dhcp-client
         type: object
         profiles:
@@ -1492,6 +1135,15 @@ spec:
             required: false
           variants: []
         description: Configure DHCPv6 Client
+        required: false
+      - name: enabled
+        type: bool
+        profiles:
+        - xpath:
+          - enabled
+        validators: []
+        spec: {}
+        description: Enable IPv6 on the interface
         required: false
       - name: inherited
         type: object
@@ -2224,6 +1876,356 @@ spec:
             required: false
           variants: []
         description: Configure to inherit properties from another interface
+        required: false
+      - name: interface-id
+        type: string
+        profiles:
+        - xpath:
+          - interface-id
+        validators: []
+        spec:
+          default: EUI-64
+        description: ''
+        required: false
+      - name: neighbor-discovery
+        type: object
+        profiles:
+        - xpath:
+          - neighbor-discovery
+        validators: []
+        spec:
+          params:
+          - name: dad-attempts
+            type: int64
+            profiles:
+            - xpath:
+              - dad-attempts
+            validators:
+            - type: length
+              spec:
+                min: 0
+                max: 10
+            spec:
+              default: 1
+            description: number of consecutive neighbor solicitation messages sent
+              for duplicate address detection
+            required: false
+          - name: enable-dad
+            type: bool
+            profiles:
+            - xpath:
+              - enable-dad
+            validators: []
+            spec: {}
+            description: enable duplicate address detection
+            required: false
+          - name: enable-ndp-monitor
+            type: bool
+            profiles:
+            - xpath:
+              - enable-ndp-monitor
+            validators: []
+            spec: {}
+            description: enable ndp monitoring
+            required: false
+          - name: neighbor
+            type: list
+            profiles:
+            - xpath:
+              - neighbor
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: hw-address
+                    type: string
+                    profiles:
+                    - xpath:
+                      - hw-address
+                    validators: []
+                    spec: {}
+                    description: MAC address (format xx:xx:xx:xx:xx:xx)
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          - name: ns-interval
+            type: int64
+            profiles:
+            - xpath:
+              - ns-interval
+            validators:
+            - type: length
+              spec:
+                min: 1
+                max: 3600
+            spec:
+              default: 1
+            description: interval (in seconds) between consecutive neighbor solicitation
+              messages
+            required: false
+          - name: reachable-time
+            type: int64
+            profiles:
+            - xpath:
+              - reachable-time
+            validators:
+            - type: length
+              spec:
+                min: 10
+                max: 36000
+            spec:
+              default: 30
+            description: time (in seconds) that the Reachable status for a neighbor
+              can be maintained
+            required: false
+          - name: router-advertisement
+            type: object
+            profiles:
+            - xpath:
+              - router-advertisement
+            validators: []
+            spec:
+              params:
+              - name: dns-support
+                type: object
+                profiles:
+                - xpath:
+                  - dns-support
+                validators: []
+                spec:
+                  params:
+                  - name: enable
+                    type: bool
+                    profiles:
+                    - xpath:
+                      - enable
+                    validators: []
+                    spec: {}
+                    description: ''
+                    required: false
+                  - name: server
+                    type: list
+                    profiles:
+                    - xpath:
+                      - server
+                      - entry
+                      type: entry
+                    validators: []
+                    spec:
+                      type: object
+                      items:
+                        type: object
+                        spec:
+                          params:
+                          - name: lifetime
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - lifetime
+                            validators:
+                            - type: length
+                              spec:
+                                min: 4
+                                max: 3600
+                            spec:
+                              default: 1200
+                            description: (4-3600) lifetime in seconds
+                            required: false
+                          variants: []
+                    description: ''
+                    required: false
+                  - name: suffix
+                    type: list
+                    profiles:
+                    - xpath:
+                      - suffix
+                      - entry
+                      type: entry
+                    validators: []
+                    spec:
+                      type: object
+                      items:
+                        type: object
+                        spec:
+                          params:
+                          - name: lifetime
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - lifetime
+                            validators:
+                            - type: length
+                              spec:
+                                min: 4
+                                max: 3600
+                            spec:
+                              default: 1200
+                            description: (4-3600) lifetime in seconds
+                            required: false
+                          variants: []
+                    description: ''
+                    required: false
+                  variants: []
+                description: DNS configuration support
+                required: false
+              - name: enable
+                type: bool
+                profiles:
+                - xpath:
+                  - enable
+                validators: []
+                spec: {}
+                description: ''
+                required: false
+              - name: enable-consistency-check
+                type: bool
+                profiles:
+                - xpath:
+                  - enable-consistency-check
+                validators: []
+                spec: {}
+                description: check consistency of RA messages from other routers.
+                required: false
+              - name: hop-limit
+                type: string
+                profiles:
+                - xpath:
+                  - hop-limit
+                validators: []
+                spec:
+                  default: '64'
+                description: Current Hop Limit advertised in Router Advertisement
+                  messages
+                required: false
+              - name: lifetime
+                type: int64
+                profiles:
+                - xpath:
+                  - lifetime
+                validators:
+                - type: length
+                  spec:
+                    min: 0
+                    max: 9000
+                spec:
+                  default: 1800
+                description: Router Lifetime (in seconds) advertised in Router Advertisement
+                  messages
+                required: false
+              - name: link-mtu
+                type: string
+                profiles:
+                - xpath:
+                  - link-mtu
+                validators: []
+                spec:
+                  default: unspecified
+                description: value of MTU option in Router Advertisement messages,
+                  upto 9216 in Jumbo-Frame mode, up to 1500 otherwise
+                required: false
+              - name: managed-flag
+                type: bool
+                profiles:
+                - xpath:
+                  - managed-flag
+                validators: []
+                spec: {}
+                description: Set the Managed Configuration Flag (M-bit) in Router
+                  Advertisement messages
+                required: false
+              - name: max-interval
+                type: int64
+                profiles:
+                - xpath:
+                  - max-interval
+                validators:
+                - type: length
+                  spec:
+                    min: 4
+                    max: 1800
+                spec:
+                  default: 600
+                description: Maximum interval (seconds) between consecutive unsolicited
+                  Router Advertisement messages
+                required: false
+              - name: min-interval
+                type: int64
+                profiles:
+                - xpath:
+                  - min-interval
+                validators:
+                - type: length
+                  spec:
+                    min: 3
+                    max: 1350
+                spec:
+                  default: 200
+                description: Minimum interval (seconds) between consecutive unsolicited
+                  Router Advertisement messages
+                required: false
+              - name: other-flag
+                type: bool
+                profiles:
+                - xpath:
+                  - other-flag
+                validators: []
+                spec: {}
+                description: Set the Other Stateful Configuration Flag (O-bit) in
+                  Router Advertisement messages
+                required: false
+              - name: reachable-time
+                type: string
+                profiles:
+                - xpath:
+                  - reachable-time
+                validators: []
+                spec:
+                  default: unspecified
+                description: Reachable Time (in milliseconds) advertised in Router
+                  Advertisement messages
+                required: false
+              - name: retransmission-timer
+                type: string
+                profiles:
+                - xpath:
+                  - retransmission-timer
+                validators: []
+                spec:
+                  default: unspecified
+                description: Retransmission Timer (in milliseconds) advertised in
+                  Router Advertisement messages
+                required: false
+              - name: router-preference
+                type: enum
+                profiles:
+                - xpath:
+                  - router-preference
+                validators:
+                - type: values
+                  spec:
+                    values:
+                    - High
+                    - Medium
+                    - Low
+                spec:
+                  default: Medium
+                  values:
+                  - value: High
+                  - value: Medium
+                  - value: Low
+                description: ''
+                required: false
+              variants: []
+            description: Router advertisement configuration
+            required: false
+          variants: []
+        description: Neighbor Discovery configuration
         required: false
       variants: []
     description: Interface IPv6 configuration

--- a/specs/network/logical-router.yaml
+++ b/specs/network/logical-router.yaml
@@ -15,9 +15,11 @@ go_sdk_config:
   package:
   - network
   - logical_router
-xpath_suffix:
-- network
-- logical-router
+panos_xpath:
+  path:
+  - network
+  - logical-router
+  vars: []
 locations:
 - name: vsys
   xpath:

--- a/specs/network/profiles/anti-spyware-profile.yaml
+++ b/specs/network/profiles/anti-spyware-profile.yaml
@@ -16,9 +16,11 @@ go_sdk_config:
   - security
   - profiles
   - spyware
-xpath_suffix:
-- profiles
-- spyware
+panos_xpath:
+  path:
+  - profiles
+  - spyware
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -62,7 +64,6 @@ locations:
   description: Located in a specific Virtual System
   devices:
   - ngfw
-  - panorama
   validators: []
   required: false
   read_only: false
@@ -292,6 +293,73 @@ spec:
               variants: []
         description: ''
         required: false
+      - name: rtype-action
+        type: object
+        profiles:
+        - xpath:
+          - rtype-action
+          min_version: 11.0.2
+          max_version: 11.0.3
+        validators: []
+        spec:
+          params:
+          - name: any
+            type: enum
+            profiles:
+            - xpath:
+              - any
+            validators:
+            - type: values
+              spec:
+                values:
+                - allow
+                - block
+            spec:
+              default: allow
+              values:
+              - value: allow
+              - value: block
+            description: ANY(255)
+            required: false
+          - name: https
+            type: enum
+            profiles:
+            - xpath:
+              - https
+            validators:
+            - type: values
+              spec:
+                values:
+                - allow
+                - block
+            spec:
+              default: allow
+              values:
+              - value: allow
+              - value: block
+            description: HTTPS(65)
+            required: false
+          - name: svcb
+            type: enum
+            profiles:
+            - xpath:
+              - svcb
+            validators:
+            - type: values
+              spec:
+                values:
+                - allow
+                - block
+            spec:
+              default: allow
+              values:
+              - value: allow
+              - value: block
+            description: SVCB(64)
+            required: false
+          variants: []
+        description: Action for specific record types
+        required: false
       - name: sinkhole
         type: object
         profiles:
@@ -369,73 +437,6 @@ spec:
                 required: false
               variants: []
         description: ''
-        required: false
-      - name: rtype-action
-        type: object
-        profiles:
-        - xpath:
-          - rtype-action
-          min_version: 11.0.2
-          max_version: 11.0.3
-        validators: []
-        spec:
-          params:
-          - name: any
-            type: enum
-            profiles:
-            - xpath:
-              - any
-            validators:
-            - type: values
-              spec:
-                values:
-                - allow
-                - block
-            spec:
-              default: allow
-              values:
-              - value: allow
-              - value: block
-            description: ANY(255)
-            required: false
-          - name: https
-            type: enum
-            profiles:
-            - xpath:
-              - https
-            validators:
-            - type: values
-              spec:
-                values:
-                - allow
-                - block
-            spec:
-              default: allow
-              values:
-              - value: allow
-              - value: block
-            description: HTTPS(65)
-            required: false
-          - name: svcb
-            type: enum
-            profiles:
-            - xpath:
-              - svcb
-            validators:
-            - type: values
-              spec:
-                values:
-                - allow
-                - block
-            spec:
-              default: allow
-              values:
-              - value: allow
-              - value: block
-            description: SVCB(64)
-            required: false
-          variants: []
-        description: Action for specific record types
         required: false
       variants: []
     description: ''

--- a/specs/network/profiles/interface-management-profile.yaml
+++ b/specs/network/profiles/interface-management-profile.yaml
@@ -15,10 +15,12 @@ go_sdk_config:
   - network
   - profiles
   - interface_management
-xpath_suffix:
-- network
-- profiles
-- interface-management-profile
+panos_xpath:
+  path:
+  - network
+  - profiles
+  - interface-management-profile
+  vars: []
 locations:
 - name: ngfw
   xpath:

--- a/specs/network/tunnels/ipsec.yaml
+++ b/specs/network/tunnels/ipsec.yaml
@@ -16,10 +16,12 @@ go_sdk_config:
   - network
   - tunnel
   - ipsec
-xpath_suffix:
-- network
-- tunnel
-- ipsec
+panos_xpath:
+  path:
+  - network
+  - tunnel
+  - ipsec
+  vars: []
 locations:
 - name: template
   xpath:
@@ -185,6 +187,26 @@ spec:
     spec: {}
     description: allow GRE over IPSec
     required: false
+  - name: ipsec-mode
+    type: enum
+    profiles:
+    - xpath:
+      - ipsec-mode
+      min_version: 11.0.2
+      max_version: 11.0.3
+    validators:
+    - type: values
+      spec:
+        values:
+        - tunnel
+        - transport
+    spec:
+      default: tunnel
+      values:
+      - value: tunnel
+      - value: transport
+    description: ''
+    required: false
   - name: ipv6
     type: bool
     profiles:
@@ -249,26 +271,6 @@ spec:
         required: false
       variants: []
     description: Monitor tunnel status
-    required: false
-  - name: ipsec-mode
-    type: enum
-    profiles:
-    - xpath:
-      - ipsec-mode
-      min_version: 11.0.2
-      max_version: 11.0.3
-    validators:
-    - type: values
-      spec:
-        values:
-        - tunnel
-        - transport
-    spec:
-      default: tunnel
-      values:
-      - value: tunnel
-      - value: transport
-    description: ''
     required: false
   variants:
   - name: auto-key
@@ -605,6 +607,7 @@ spec:
       variants: []
     description: IKE VPN options
     required: false
+    variant_group_id: 0
   - name: global-protect-satellite
     type: object
     profiles:
@@ -702,6 +705,7 @@ spec:
               variants: []
             description: Floating IP address in HA Active-Active configuration
             required: false
+            variant_group_id: 0
           - name: ip
             type: object
             profiles:
@@ -732,6 +736,7 @@ spec:
               variants: []
             description: specify exact IP address if interface has multiple addresses
             required: false
+            variant_group_id: 0
         description: Satellite outgoing interface configuration
         required: false
       - name: portal-address
@@ -782,6 +787,7 @@ spec:
       variants: []
     description: Satellite side of Global Protect Satellite tunnel
     required: false
+    variant_group_id: 0
   - name: manual-key
     type: object
     profiles:
@@ -817,6 +823,7 @@ spec:
             spec: {}
             description: Floating IP address in HA Active-Active configuration
             required: false
+            variant_group_id: 0
           - name: ip
             type: string
             profiles:
@@ -829,6 +836,7 @@ spec:
             spec: {}
             description: specify exact IP address if interface has multiple addresses
             required: false
+            variant_group_id: 0
         description: Tunnel local IP configuration
         required: false
       - name: local-spi
@@ -902,6 +910,7 @@ spec:
               variants: []
             description: key is 128 bit
             required: false
+            variant_group_id: 0
           - name: sha1
             type: object
             profiles:
@@ -925,6 +934,7 @@ spec:
               variants: []
             description: key is 160 bit
             required: false
+            variant_group_id: 0
           - name: sha256
             type: object
             profiles:
@@ -948,6 +958,7 @@ spec:
               variants: []
             description: key is 256 bit
             required: false
+            variant_group_id: 0
           - name: sha384
             type: object
             profiles:
@@ -971,6 +982,7 @@ spec:
               variants: []
             description: key is 384 bit
             required: false
+            variant_group_id: 0
           - name: sha512
             type: object
             profiles:
@@ -994,8 +1006,10 @@ spec:
               variants: []
             description: key is 512 bit
             required: false
+            variant_group_id: 0
         description: AH options
         required: false
+        variant_group_id: 0
       - name: esp
         type: object
         profiles:
@@ -1036,6 +1050,7 @@ spec:
                   variants: []
                 description: key is 128 bit
                 required: false
+                variant_group_id: 0
               - name: none
                 type: object
                 profiles:
@@ -1047,6 +1062,7 @@ spec:
                   variants: []
                 description: no authentication
                 required: false
+                variant_group_id: 0
               - name: sha1
                 type: object
                 profiles:
@@ -1070,6 +1086,7 @@ spec:
                   variants: []
                 description: key is 160 bit
                 required: false
+                variant_group_id: 0
               - name: sha256
                 type: object
                 profiles:
@@ -1093,6 +1110,7 @@ spec:
                   variants: []
                 description: key is 256 bit
                 required: false
+                variant_group_id: 0
               - name: sha384
                 type: object
                 profiles:
@@ -1116,6 +1134,7 @@ spec:
                   variants: []
                 description: key is 384 bit
                 required: false
+                variant_group_id: 0
               - name: sha512
                 type: object
                 profiles:
@@ -1139,6 +1158,7 @@ spec:
                   variants: []
                 description: key is 512 bit
                 required: false
+                variant_group_id: 0
             description: authentication algorithm
             required: false
           - name: encryption
@@ -1194,5 +1214,7 @@ spec:
           variants: []
         description: ESP options
         required: false
+        variant_group_id: 0
     description: Manual-key options
     required: false
+    variant_group_id: 0

--- a/specs/network/virtual-router.yaml
+++ b/specs/network/virtual-router.yaml
@@ -15,9 +15,11 @@ go_sdk_config:
   package:
   - network
   - virtual_router
-xpath_suffix:
-- network
-- virtual-router
+panos_xpath:
+  path:
+  - network
+  - virtual-router
+  vars: []
 locations:
 - name: ngfw
   xpath:
@@ -283,6 +285,7 @@ spec:
               variants: []
             description: Re-balance load on path add/delete
             required: false
+            variant_group_id: 0
           - name: ip-hash
             type: object
             profiles:
@@ -326,6 +329,7 @@ spec:
               variants: []
             description: Hash based on IP addresses and optionally port numbers
             required: false
+            variant_group_id: 0
           - name: ip-modulo
             type: object
             profiles:
@@ -337,6 +341,7 @@ spec:
               variants: []
             description: IP addresses modulo number of path
             required: false
+            variant_group_id: 0
           - name: weighted-round-robin
             type: object
             profiles:
@@ -379,6 +384,7 @@ spec:
               variants: []
             description: Weighted round robin
             required: false
+            variant_group_id: 0
         description: load balancing algorithm
         required: false
       - name: enable
@@ -994,6 +1000,7 @@ spec:
                   variants: []
                 description: Configure device to act as candidate RP
                 required: false
+                variant_group_id: 0
               - name: static-rp
                 type: object
                 profiles:
@@ -1051,6 +1058,7 @@ spec:
                   variants: []
                 description: Configure device to act as a static RP
                 required: false
+                variant_group_id: 0
             description: Local Rendezvous Point configuration
             required: false
           variants: []
@@ -1730,6 +1738,7 @@ spec:
                                 spec: {}
                                 description: peer address configuration
                                 required: false
+                                variant_group_id: 0
                               - name: fqdn
                                 type: string
                                 profiles:
@@ -1742,6 +1751,7 @@ spec:
                                 spec: {}
                                 description: bgp peer FQDN address object configuration
                                 required: false
+                                variant_group_id: 0
                             description: peer address configuration
                             required: false
                           - name: connection-options
@@ -2114,6 +2124,7 @@ spec:
                                       variants: []
                                     description: no change on AS path
                                     required: false
+                                    variant_group_id: 0
                                   - name: prepend
                                     type: int64
                                     profiles:
@@ -2129,6 +2140,7 @@ spec:
                                     description: prepend local AS for specified number
                                       of times
                                     required: false
+                                    variant_group_id: 0
                                 description: AS path update options
                                 required: false
                               - name: community
@@ -2151,6 +2163,7 @@ spec:
                                       variants: []
                                     description: no change on communities
                                     required: false
+                                    variant_group_id: 0
                                   - name: remove-all
                                     type: object
                                     profiles:
@@ -2162,6 +2175,7 @@ spec:
                                       variants: []
                                     description: remove all communities
                                     required: false
+                                    variant_group_id: 0
                                   - name: remove-regex
                                     type: string
                                     profiles:
@@ -2175,6 +2189,7 @@ spec:
                                     description: remove specified coummnity match
                                       regular expression
                                     required: false
+                                    variant_group_id: 0
                                   - name: append
                                     type: list
                                     profiles:
@@ -2188,6 +2203,7 @@ spec:
                                         type: string
                                     description: ''
                                     required: false
+                                    variant_group_id: 0
                                   - name: overwrite
                                     type: list
                                     profiles:
@@ -2201,6 +2217,7 @@ spec:
                                         type: string
                                     description: ''
                                     required: false
+                                    variant_group_id: 0
                                 description: community update options
                                 required: false
                               - name: extended-community
@@ -2223,6 +2240,7 @@ spec:
                                       variants: []
                                     description: no change on communities
                                     required: false
+                                    variant_group_id: 0
                                   - name: remove-all
                                     type: object
                                     profiles:
@@ -2234,6 +2252,7 @@ spec:
                                       variants: []
                                     description: remove all communities
                                     required: false
+                                    variant_group_id: 0
                                   - name: remove-regex
                                     type: string
                                     profiles:
@@ -2247,6 +2266,7 @@ spec:
                                     description: remove specified coummnity match
                                       regular expression
                                     required: false
+                                    variant_group_id: 0
                                   - name: append
                                     type: list
                                     profiles:
@@ -2260,6 +2280,7 @@ spec:
                                         type: string
                                     description: ''
                                     required: false
+                                    variant_group_id: 0
                                   - name: overwrite
                                     type: list
                                     profiles:
@@ -2273,6 +2294,7 @@ spec:
                                         type: string
                                     description: ''
                                     required: false
+                                    variant_group_id: 0
                                 description: extended community update options
                                 required: false
                               variants: []
@@ -2415,6 +2437,7 @@ spec:
                                             spec: {}
                                             description: AS-path regular expression
                                             required: false
+                                            variant_group_id: 0
                                         description: AS-path to match
                                         required: false
                                       - name: community
@@ -2438,6 +2461,7 @@ spec:
                                             spec: {}
                                             description: AS-path regular expression
                                             required: false
+                                            variant_group_id: 0
                                         description: community to match
                                         required: false
                                       - name: extended-community
@@ -2461,6 +2485,7 @@ spec:
                                             spec: {}
                                             description: AS-path regular expression
                                             required: false
+                                            variant_group_id: 0
                                         description: community to match
                                         required: false
                                       variants: []
@@ -2606,6 +2631,7 @@ spec:
                                             spec: {}
                                             description: AS-path regular expression
                                             required: false
+                                            variant_group_id: 0
                                         description: AS-path to match
                                         required: false
                                       - name: community
@@ -2629,6 +2655,7 @@ spec:
                                             spec: {}
                                             description: AS-path regular expression
                                             required: false
+                                            variant_group_id: 0
                                         description: community to match
                                         required: false
                                       - name: extended-community
@@ -2652,6 +2679,7 @@ spec:
                                             spec: {}
                                             description: AS-path regular expression
                                             required: false
+                                            variant_group_id: 0
                                         description: community to match
                                         required: false
                                       variants: []
@@ -2838,6 +2866,7 @@ spec:
                                             spec: {}
                                             description: AS-path regular expression
                                             required: false
+                                            variant_group_id: 0
                                         description: AS-path to match
                                         required: false
                                       - name: community
@@ -2861,6 +2890,7 @@ spec:
                                             spec: {}
                                             description: AS-path regular expression
                                             required: false
+                                            variant_group_id: 0
                                         description: community to match
                                         required: false
                                       - name: extended-community
@@ -2884,6 +2914,7 @@ spec:
                                             spec: {}
                                             description: AS-path regular expression
                                             required: false
+                                            variant_group_id: 0
                                         description: community to match
                                         required: false
                                       variants: []
@@ -3020,6 +3051,7 @@ spec:
                                             spec: {}
                                             description: AS-path regular expression
                                             required: false
+                                            variant_group_id: 0
                                         description: AS-path to match
                                         required: false
                                       - name: community
@@ -3043,6 +3075,7 @@ spec:
                                             spec: {}
                                             description: AS-path regular expression
                                             required: false
+                                            variant_group_id: 0
                                         description: community to match
                                         required: false
                                       - name: extended-community
@@ -3066,6 +3099,7 @@ spec:
                                             spec: {}
                                             description: AS-path regular expression
                                             required: false
+                                            variant_group_id: 0
                                         description: community to match
                                         required: false
                                       variants: []
@@ -3238,6 +3272,7 @@ spec:
                                     spec: {}
                                     description: AS-path regular expression
                                     required: false
+                                    variant_group_id: 0
                                 description: AS-path to match
                                 required: false
                               - name: community
@@ -3261,6 +3296,7 @@ spec:
                                     spec: {}
                                     description: AS-path regular expression
                                     required: false
+                                    variant_group_id: 0
                                 description: community to match
                                 required: false
                               - name: extended-community
@@ -3284,6 +3320,7 @@ spec:
                                     spec: {}
                                     description: AS-path regular expression
                                     required: false
+                                    variant_group_id: 0
                                 description: community to match
                                 required: false
                               variants: []
@@ -3309,6 +3346,7 @@ spec:
                                   variants: []
                                 description: ''
                                 required: false
+                                variant_group_id: 0
                               - name: allow
                                 type: object
                                 profiles:
@@ -3413,6 +3451,7 @@ spec:
                                               variants: []
                                             description: no change on AS path
                                             required: false
+                                            variant_group_id: 0
                                           - name: remove
                                             type: object
                                             profiles:
@@ -3424,6 +3463,7 @@ spec:
                                               variants: []
                                             description: remove matched AS path(s)
                                             required: false
+                                            variant_group_id: 0
                                           - name: prepend
                                             type: int64
                                             profiles:
@@ -3439,6 +3479,7 @@ spec:
                                             description: prepend local AS for specified
                                               number of times
                                             required: false
+                                            variant_group_id: 0
                                           - name: remove-and-prepend
                                             type: int64
                                             profiles:
@@ -3455,6 +3496,7 @@ spec:
                                               and prepend local AS for specified number
                                               of times
                                             required: false
+                                            variant_group_id: 0
                                         description: AS path update options
                                         required: false
                                       - name: community
@@ -3477,6 +3519,7 @@ spec:
                                               variants: []
                                             description: no change on communities
                                             required: false
+                                            variant_group_id: 0
                                           - name: remove-all
                                             type: object
                                             profiles:
@@ -3488,6 +3531,7 @@ spec:
                                               variants: []
                                             description: remove all communities
                                             required: false
+                                            variant_group_id: 0
                                           - name: remove-regex
                                             type: string
                                             profiles:
@@ -3501,6 +3545,7 @@ spec:
                                             description: remove specified coummnity
                                               match regular expression
                                             required: false
+                                            variant_group_id: 0
                                           - name: append
                                             type: list
                                             profiles:
@@ -3514,6 +3559,7 @@ spec:
                                                 type: string
                                             description: ''
                                             required: false
+                                            variant_group_id: 0
                                           - name: overwrite
                                             type: list
                                             profiles:
@@ -3527,6 +3573,7 @@ spec:
                                                 type: string
                                             description: ''
                                             required: false
+                                            variant_group_id: 0
                                         description: community update options
                                         required: false
                                       - name: extended-community
@@ -3549,6 +3596,7 @@ spec:
                                               variants: []
                                             description: no change on communities
                                             required: false
+                                            variant_group_id: 0
                                           - name: remove-all
                                             type: object
                                             profiles:
@@ -3560,6 +3608,7 @@ spec:
                                               variants: []
                                             description: remove all communities
                                             required: false
+                                            variant_group_id: 0
                                           - name: remove-regex
                                             type: string
                                             profiles:
@@ -3573,6 +3622,7 @@ spec:
                                             description: remove specified coummnity
                                               match regular expression
                                             required: false
+                                            variant_group_id: 0
                                           - name: append
                                             type: list
                                             profiles:
@@ -3586,6 +3636,7 @@ spec:
                                                 type: string
                                             description: ''
                                             required: false
+                                            variant_group_id: 0
                                           - name: overwrite
                                             type: list
                                             profiles:
@@ -3599,6 +3650,7 @@ spec:
                                                 type: string
                                             description: ''
                                             required: false
+                                            variant_group_id: 0
                                         description: extended community update options
                                         required: false
                                       variants: []
@@ -3607,6 +3659,7 @@ spec:
                                   variants: []
                                 description: ''
                                 required: false
+                                variant_group_id: 0
                             description: rule action
                             required: false
                           variants: []
@@ -3773,6 +3826,7 @@ spec:
                                     spec: {}
                                     description: AS-path regular expression
                                     required: false
+                                    variant_group_id: 0
                                 description: AS-path to match
                                 required: false
                               - name: community
@@ -3796,6 +3850,7 @@ spec:
                                     spec: {}
                                     description: AS-path regular expression
                                     required: false
+                                    variant_group_id: 0
                                 description: community to match
                                 required: false
                               - name: extended-community
@@ -3819,6 +3874,7 @@ spec:
                                     spec: {}
                                     description: AS-path regular expression
                                     required: false
+                                    variant_group_id: 0
                                 description: community to match
                                 required: false
                               variants: []
@@ -3844,6 +3900,7 @@ spec:
                                   variants: []
                                 description: ''
                                 required: false
+                                variant_group_id: 0
                               - name: allow
                                 type: object
                                 profiles:
@@ -3970,6 +4027,7 @@ spec:
                                               variants: []
                                             description: no change on AS path
                                             required: false
+                                            variant_group_id: 0
                                           - name: remove
                                             type: object
                                             profiles:
@@ -3981,6 +4039,7 @@ spec:
                                               variants: []
                                             description: remove matched AS path(s)
                                             required: false
+                                            variant_group_id: 0
                                         description: AS path update options
                                         required: false
                                       - name: community
@@ -4003,6 +4062,7 @@ spec:
                                               variants: []
                                             description: no change on communities
                                             required: false
+                                            variant_group_id: 0
                                           - name: remove-all
                                             type: object
                                             profiles:
@@ -4014,6 +4074,7 @@ spec:
                                               variants: []
                                             description: remove all communities
                                             required: false
+                                            variant_group_id: 0
                                           - name: remove-regex
                                             type: string
                                             profiles:
@@ -4027,6 +4088,7 @@ spec:
                                             description: remove specified coummnity
                                               match regular expression
                                             required: false
+                                            variant_group_id: 0
                                           - name: append
                                             type: list
                                             profiles:
@@ -4040,6 +4102,7 @@ spec:
                                                 type: string
                                             description: ''
                                             required: false
+                                            variant_group_id: 0
                                           - name: overwrite
                                             type: list
                                             profiles:
@@ -4053,6 +4116,7 @@ spec:
                                                 type: string
                                             description: ''
                                             required: false
+                                            variant_group_id: 0
                                         description: community update options
                                         required: false
                                       - name: extended-community
@@ -4075,6 +4139,7 @@ spec:
                                               variants: []
                                             description: no change on communities
                                             required: false
+                                            variant_group_id: 0
                                           - name: remove-all
                                             type: object
                                             profiles:
@@ -4086,6 +4151,7 @@ spec:
                                               variants: []
                                             description: remove all communities
                                             required: false
+                                            variant_group_id: 0
                                           - name: remove-regex
                                             type: string
                                             profiles:
@@ -4099,6 +4165,7 @@ spec:
                                             description: remove specified coummnity
                                               match regular expression
                                             required: false
+                                            variant_group_id: 0
                                           - name: append
                                             type: list
                                             profiles:
@@ -4112,6 +4179,7 @@ spec:
                                                 type: string
                                             description: ''
                                             required: false
+                                            variant_group_id: 0
                                           - name: overwrite
                                             type: list
                                             profiles:
@@ -4125,6 +4193,7 @@ spec:
                                                 type: string
                                             description: ''
                                             required: false
+                                            variant_group_id: 0
                                         description: extended community update options
                                         required: false
                                       variants: []
@@ -4133,6 +4202,7 @@ spec:
                                   variants: []
                                 description: ''
                                 required: false
+                                variant_group_id: 0
                             description: rule action
                             required: false
                           variants: []
@@ -4732,6 +4802,7 @@ spec:
                                       variants: []
                                     description: do summarization and advertise
                                     required: false
+                                    variant_group_id: 0
                                   - name: suppress
                                     type: object
                                     profiles:
@@ -4744,6 +4815,7 @@ spec:
                                     description: suppress summarization to be sent,
                                       make this subnet hidden from other areas
                                     required: false
+                                    variant_group_id: 0
                             description: ''
                             required: false
                           variants: []
@@ -4777,6 +4849,7 @@ spec:
                               variants: []
                             description: do summarization and advertise
                             required: false
+                            variant_group_id: 0
                           - name: suppress
                             type: object
                             profiles:
@@ -4789,6 +4862,7 @@ spec:
                             description: suppress summarization to be sent, make this
                               subnet hidden from other areas
                             required: false
+                            variant_group_id: 0
                     description: ''
                     required: false
                   - name: interface
@@ -5182,6 +5256,7 @@ spec:
                     spec: {}
                     description: Simple password authentication
                     required: false
+                    variant_group_id: 0
                   - name: md5
                     type: list
                     profiles:
@@ -5220,6 +5295,7 @@ spec:
                           variants: []
                     description: ''
                     required: false
+                    variant_group_id: 0
             description: ''
             required: false
           - name: enable
@@ -5691,6 +5767,7 @@ spec:
                                       variants: []
                                     description: do summarization and advertise
                                     required: false
+                                    variant_group_id: 0
                                   - name: suppress
                                     type: object
                                     profiles:
@@ -5703,6 +5780,7 @@ spec:
                                     description: suppress summarization to be sent,
                                       make this subnet hidden from other areas
                                     required: false
+                                    variant_group_id: 0
                             description: ''
                             required: false
                           variants: []
@@ -5736,6 +5814,7 @@ spec:
                               variants: []
                             description: do summarization and advertise
                             required: false
+                            variant_group_id: 0
                           - name: suppress
                             type: object
                             profiles:
@@ -5748,6 +5827,7 @@ spec:
                             description: suppress summarization to be sent, make this
                               subnet hidden from other areas
                             required: false
+                            variant_group_id: 0
                     description: ''
                     required: false
                   - name: interface
@@ -6208,6 +6288,7 @@ spec:
                               variants: []
                             description: key is 128 bit
                             required: false
+                            variant_group_id: 0
                           - name: sha1
                             type: object
                             profiles:
@@ -6232,6 +6313,7 @@ spec:
                               variants: []
                             description: key is 160 bit
                             required: false
+                            variant_group_id: 0
                           - name: sha256
                             type: object
                             profiles:
@@ -6256,6 +6338,7 @@ spec:
                               variants: []
                             description: key is 256 bit
                             required: false
+                            variant_group_id: 0
                           - name: sha384
                             type: object
                             profiles:
@@ -6280,6 +6363,7 @@ spec:
                               variants: []
                             description: key is 384 bit
                             required: false
+                            variant_group_id: 0
                           - name: sha512
                             type: object
                             profiles:
@@ -6304,6 +6388,7 @@ spec:
                               variants: []
                             description: key is 512 bit
                             required: false
+                            variant_group_id: 0
                           - name: none
                             type: object
                             profiles:
@@ -6315,6 +6400,7 @@ spec:
                               variants: []
                             description: no authentication
                             required: false
+                            variant_group_id: 0
                         description: authentication algorithm
                         required: false
                       - name: encryption
@@ -6368,6 +6454,7 @@ spec:
                       variants: []
                     description: ESP options
                     required: false
+                    variant_group_id: 0
                   - name: ah
                     type: object
                     profiles:
@@ -6401,6 +6488,7 @@ spec:
                           variants: []
                         description: key is 128 bit
                         required: false
+                        variant_group_id: 0
                       - name: sha1
                         type: object
                         profiles:
@@ -6425,6 +6513,7 @@ spec:
                           variants: []
                         description: key is 160 bit
                         required: false
+                        variant_group_id: 0
                       - name: sha256
                         type: object
                         profiles:
@@ -6449,6 +6538,7 @@ spec:
                           variants: []
                         description: key is 256 bit
                         required: false
+                        variant_group_id: 0
                       - name: sha384
                         type: object
                         profiles:
@@ -6473,6 +6563,7 @@ spec:
                           variants: []
                         description: key is 384 bit
                         required: false
+                        variant_group_id: 0
                       - name: sha512
                         type: object
                         profiles:
@@ -6497,8 +6588,10 @@ spec:
                           variants: []
                         description: key is 512 bit
                         required: false
+                        variant_group_id: 0
                     description: AH options
                     required: false
+                    variant_group_id: 0
             description: ''
             required: false
           - name: disable-transit-traffic
@@ -7222,6 +7315,7 @@ spec:
                     spec: {}
                     description: Simple password authentication
                     required: false
+                    variant_group_id: 0
                   - name: md5
                     type: list
                     profiles:
@@ -7260,6 +7354,7 @@ spec:
                           variants: []
                     description: ''
                     required: false
+                    variant_group_id: 0
             description: ''
             required: false
           - name: enable
@@ -7696,6 +7791,7 @@ spec:
                           variants: []
                         description: Install route into unicast routing table
                         required: false
+                        variant_group_id: 0
                       - name: multicast
                         type: object
                         profiles:
@@ -7708,6 +7804,7 @@ spec:
                         description: Install route into multicast routing table, this
                           will create multicast routing table if not exists
                         required: false
+                        variant_group_id: 0
                       - name: both
                         type: object
                         profiles:
@@ -7720,6 +7817,7 @@ spec:
                         description: Install route into both unicast and multicast
                           routing table
                         required: false
+                        variant_group_id: 0
                       - name: no-install
                         type: object
                         profiles:
@@ -7731,6 +7829,7 @@ spec:
                           variants: []
                         description: Do not install route into forwarding table
                         required: false
+                        variant_group_id: 0
                     description: target routing table to install the route
                     required: false
                   - name: bfd
@@ -8028,6 +8127,7 @@ spec:
                           variants: []
                         description: Install route into unicast routing table
                         required: false
+                        variant_group_id: 0
                       - name: no-install
                         type: object
                         profiles:
@@ -8039,6 +8139,7 @@ spec:
                           variants: []
                         description: Do not install route into forwarding table
                         required: false
+                        variant_group_id: 0
                     description: target routing table to install the route
                     required: false
                   - name: bfd

--- a/specs/network/zone.yaml
+++ b/specs/network/zone.yaml
@@ -15,8 +15,10 @@ go_sdk_config:
   package:
   - network
   - zone
-xpath_suffix:
-- zone
+panos_xpath:
+  path:
+  - zone
+  vars: []
 locations:
 - name: vsys
   xpath:
@@ -47,7 +49,6 @@ locations:
   description: Located in a specific Virtual System
   devices:
   - ngfw
-  - panorama
   validators: []
   required: false
   read_only: false
@@ -225,15 +226,6 @@ spec:
         spec: {}
         description: Log setting for forwarding scan logs
         required: false
-      - name: zone-protection-profile
-        type: string
-        profiles:
-        - xpath:
-          - zone-protection-profile
-        validators: []
-        spec: {}
-        description: Zone protection profile
-        required: false
       - name: net-inspection
         type: bool
         profiles:
@@ -244,6 +236,15 @@ spec:
         validators: []
         spec: {}
         description: ''
+        required: false
+      - name: zone-protection-profile
+        type: string
+        profiles:
+        - xpath:
+          - zone-protection-profile
+        validators: []
+        spec: {}
+        description: Zone protection profile
         required: false
       variants:
       - name: external
@@ -259,6 +260,7 @@ spec:
             type: string
         description: ''
         required: false
+        variant_group_id: 0
       - name: layer2
         type: list
         profiles:
@@ -272,6 +274,7 @@ spec:
             type: string
         description: ''
         required: false
+        variant_group_id: 0
       - name: layer3
         type: list
         profiles:
@@ -285,6 +288,7 @@ spec:
             type: string
         description: ''
         required: false
+        variant_group_id: 0
       - name: tap
         type: list
         profiles:
@@ -298,6 +302,7 @@ spec:
             type: string
         description: ''
         required: false
+        variant_group_id: 0
       - name: tunnel
         type: object
         profiles:
@@ -309,6 +314,7 @@ spec:
           variants: []
         description: Tunnel inspection zone
         required: false
+        variant_group_id: 0
       - name: virtual-wire
         type: list
         profiles:
@@ -322,6 +328,7 @@ spec:
             type: string
         description: ''
         required: false
+        variant_group_id: 0
     description: Zone network configuration
     required: false
   - name: user-acl

--- a/specs/objects/address-group.yaml
+++ b/specs/objects/address-group.yaml
@@ -16,8 +16,10 @@ go_sdk_config:
   - objects
   - address
   - group
-xpath_suffix:
-- address-group
+panos_xpath:
+  path:
+  - address-group
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -61,7 +63,6 @@ locations:
   description: Located in a specific Virtual System
   devices:
   - ngfw
-  - panorama
   validators: []
   required: false
   read_only: false
@@ -169,6 +170,7 @@ spec:
       variants: []
     description: ''
     required: false
+    variant_group_id: 0
   - name: static
     type: list
     profiles:
@@ -182,3 +184,4 @@ spec:
         type: string
     description: ''
     required: false
+    variant_group_id: 0

--- a/specs/objects/address.yaml
+++ b/specs/objects/address.yaml
@@ -16,8 +16,10 @@ go_sdk_config:
   package:
   - objects
   - address
-xpath_suffix:
-- address
+panos_xpath:
+  path:
+  - address
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -61,7 +63,6 @@ locations:
   description: Located in a specific Virtual System
   devices:
   - ngfw
-  - panorama
   validators: []
   required: false
   read_only: false
@@ -164,6 +165,7 @@ spec:
     spec: {}
     description: The FQDN value.
     required: false
+    variant_group_id: 0
   - name: ip-netmask
     type: string
     profiles:
@@ -173,6 +175,7 @@ spec:
     spec: {}
     description: The IP netmask value.
     required: false
+    variant_group_id: 0
   - name: ip-range
     type: string
     profiles:
@@ -182,6 +185,7 @@ spec:
     spec: {}
     description: The IP range value.
     required: false
+    variant_group_id: 0
   - name: ip-wildcard
     type: string
     profiles:
@@ -191,3 +195,4 @@ spec:
     spec: {}
     description: The IP wildcard value.
     required: false
+    variant_group_id: 0

--- a/specs/objects/administrative-tag.yaml
+++ b/specs/objects/administrative-tag.yaml
@@ -15,8 +15,10 @@ go_sdk_config:
   package:
   - objects
   - admintag
-xpath_suffix:
-- tag
+panos_xpath:
+  path:
+  - tag
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -60,7 +62,6 @@ locations:
   description: Located in a specific Virtual System
   devices:
   - ngfw
-  - panorama
   validators: []
   required: false
   read_only: false

--- a/specs/objects/application-group.yaml
+++ b/specs/objects/application-group.yaml
@@ -15,8 +15,10 @@ go_sdk_config:
   - objects
   - application
   - group
-xpath_suffix:
-- application-group
+panos_xpath:
+  path:
+  - application-group
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -60,7 +62,6 @@ locations:
   description: Located in a specific Virtual System
   devices:
   - ngfw
-  - panorama
   validators: []
   required: false
   read_only: false

--- a/specs/objects/application.yaml
+++ b/specs/objects/application.yaml
@@ -14,8 +14,10 @@ go_sdk_config:
   package:
   - objects
   - application
-xpath_suffix:
-- application
+panos_xpath:
+  path:
+  - application
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -59,7 +61,6 @@ locations:
   description: Located in a specific Virtual System
   devices:
   - ngfw
-  - panorama
   validators: []
   required: false
   read_only: false

--- a/specs/objects/custom-url-category.yaml
+++ b/specs/objects/custom-url-category.yaml
@@ -16,9 +16,11 @@ go_sdk_config:
   - objects
   - profiles
   - customurlcategory
-xpath_suffix:
-- profiles
-- custom-url-category
+panos_xpath:
+  path:
+  - profiles
+  - custom-url-category
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -62,7 +64,6 @@ locations:
   description: Located in a specific Virtual System
   devices:
   - ngfw
-  - panorama
   validators: []
   required: false
   read_only: false

--- a/specs/objects/ephemeral-vm-auth-key.yaml
+++ b/specs/objects/ephemeral-vm-auth-key.yaml
@@ -10,7 +10,8 @@ terraform_provider_config:
 go_sdk_config:
   skip: true
   package: ["vmauthkey"] # unused
-xpath_suffix: ["vmauthkey"] # unused
+panos_xpath:
+  path: ["vmauthkey"] # unused
 locations: []
 entries: []
 imports: []

--- a/specs/objects/external-dynamic-list.yaml
+++ b/specs/objects/external-dynamic-list.yaml
@@ -15,8 +15,10 @@ go_sdk_config:
   package:
   - objects
   - extdynlist
-xpath_suffix:
-- external-list
+panos_xpath:
+  path:
+  - external-list
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -221,6 +223,7 @@ spec:
                   variants: []
                 description: Everyday
                 required: false
+                variant_group_id: 0
               - name: five-minute
                 type: object
                 profiles:
@@ -232,6 +235,7 @@ spec:
                   variants: []
                 description: Every five minutes
                 required: false
+                variant_group_id: 0
               - name: hourly
                 type: object
                 profiles:
@@ -243,6 +247,7 @@ spec:
                   variants: []
                 description: Everyhour
                 required: false
+                variant_group_id: 0
               - name: monthly
                 type: object
                 profiles:
@@ -281,6 +286,7 @@ spec:
                   variants: []
                 description: Monthly
                 required: false
+                variant_group_id: 0
               - name: weekly
                 type: object
                 profiles:
@@ -333,6 +339,7 @@ spec:
                   variants: []
                 description: Once a week
                 required: false
+                variant_group_id: 0
             description: ''
             required: false
           - name: url
@@ -468,6 +475,7 @@ spec:
                   variants: []
                 description: Everyday
                 required: false
+                variant_group_id: 0
               - name: five-minute
                 type: object
                 profiles:
@@ -479,6 +487,7 @@ spec:
                   variants: []
                 description: Every five minutes
                 required: false
+                variant_group_id: 0
               - name: hourly
                 type: object
                 profiles:
@@ -490,6 +499,7 @@ spec:
                   variants: []
                 description: Everyhour
                 required: false
+                variant_group_id: 0
               - name: monthly
                 type: object
                 profiles:
@@ -528,6 +538,7 @@ spec:
                   variants: []
                 description: Monthly
                 required: false
+                variant_group_id: 0
               - name: weekly
                 type: object
                 profiles:
@@ -580,6 +591,7 @@ spec:
                   variants: []
                 description: Once a week
                 required: false
+                variant_group_id: 0
             description: ''
             required: false
           - name: url
@@ -715,6 +727,7 @@ spec:
                   variants: []
                 description: Everyday
                 required: false
+                variant_group_id: 0
               - name: five-minute
                 type: object
                 profiles:
@@ -726,6 +739,7 @@ spec:
                   variants: []
                 description: Every five minutes
                 required: false
+                variant_group_id: 0
               - name: hourly
                 type: object
                 profiles:
@@ -737,6 +751,7 @@ spec:
                   variants: []
                 description: Everyhour
                 required: false
+                variant_group_id: 0
               - name: monthly
                 type: object
                 profiles:
@@ -775,6 +790,7 @@ spec:
                   variants: []
                 description: Monthly
                 required: false
+                variant_group_id: 0
               - name: weekly
                 type: object
                 profiles:
@@ -827,6 +843,7 @@ spec:
                   variants: []
                 description: Once a week
                 required: false
+                variant_group_id: 0
             description: ''
             required: false
           - name: url
@@ -962,6 +979,7 @@ spec:
                   variants: []
                 description: Everyday
                 required: false
+                variant_group_id: 0
               - name: five-minute
                 type: object
                 profiles:
@@ -973,6 +991,7 @@ spec:
                   variants: []
                 description: Every five minutes
                 required: false
+                variant_group_id: 0
               - name: hourly
                 type: object
                 profiles:
@@ -984,6 +1003,7 @@ spec:
                   variants: []
                 description: Everyhour
                 required: false
+                variant_group_id: 0
               - name: monthly
                 type: object
                 profiles:
@@ -1022,6 +1042,7 @@ spec:
                   variants: []
                 description: Monthly
                 required: false
+                variant_group_id: 0
               - name: weekly
                 type: object
                 profiles:
@@ -1074,6 +1095,7 @@ spec:
                   variants: []
                 description: Once a week
                 required: false
+                variant_group_id: 0
             description: ''
             required: false
           - name: url
@@ -1301,6 +1323,7 @@ spec:
                   variants: []
                 description: Everyday
                 required: false
+                variant_group_id: 0
               - name: five-minute
                 type: object
                 profiles:
@@ -1312,6 +1335,7 @@ spec:
                   variants: []
                 description: Every five minutes
                 required: false
+                variant_group_id: 0
               - name: hourly
                 type: object
                 profiles:
@@ -1323,6 +1347,7 @@ spec:
                   variants: []
                 description: Everyhour
                 required: false
+                variant_group_id: 0
               - name: monthly
                 type: object
                 profiles:
@@ -1361,6 +1386,7 @@ spec:
                   variants: []
                 description: Monthly
                 required: false
+                variant_group_id: 0
               - name: weekly
                 type: object
                 profiles:
@@ -1413,6 +1439,7 @@ spec:
                   variants: []
                 description: Once a week
                 required: false
+                variant_group_id: 0
             description: ''
             required: false
           - name: url

--- a/specs/objects/profiles/antivirus.yaml
+++ b/specs/objects/profiles/antivirus.yaml
@@ -16,9 +16,11 @@ go_sdk_config:
   - objects
   - profiles
   - antivirus
-xpath_suffix:
-- profiles
-- virus
+panos_xpath:
+  path:
+  - profiles
+  - virus
+  vars: []
 locations:
 - name: shared
   xpath:

--- a/specs/objects/profiles/certificate.yaml
+++ b/specs/objects/profiles/certificate.yaml
@@ -15,7 +15,10 @@ go_sdk_config:
   - device
   - profile
   - certificate
-xpath_suffix: []
+panos_xpath:
+  path:
+  - certificate
+  vars: []
 locations:
 - name: panorama
   xpath:
@@ -204,6 +207,44 @@ entries:
 imports: []
 spec:
   params:
+  - name: block-expired-certificate
+    type: bool
+    profiles:
+    - xpath:
+      - block-expired-cert
+    validators: []
+    spec: {}
+    description: Whether to block a session if certificate status is expired.
+    required: false
+  - name: block-timeout-certificate
+    type: bool
+    profiles:
+    - xpath:
+      - block-timeout-cert
+    validators: []
+    spec: {}
+    description: Whether to block a session if cert. status can't be retrieved within
+      timeout.
+    required: false
+  - name: block-unauthenticated-certificate
+    type: bool
+    profiles:
+    - xpath:
+      - block-unauthenticated-cert
+    validators: []
+    spec: {}
+    description: Whether to block session if the certificate was not issued to the
+      authenticating device.
+    required: false
+  - name: block-unknown-certificate
+    type: bool
+    profiles:
+    - xpath:
+      - block-unknown-cert
+    validators: []
+    spec: {}
+    description: Whether to block a session if cert. status is unknown.
+    required: false
   - name: certificate
     type: list
     profiles:
@@ -258,44 +299,6 @@ spec:
             required: false
           variants: []
     description: CA Certificate to assign to the profile.
-    required: false
-  - name: block-expired-certificate
-    type: bool
-    profiles:
-    - xpath:
-      - block-expired-cert
-    validators: []
-    spec: {}
-    description: Whether to block a session if certificate status is expired.
-    required: false
-  - name: block-timeout-certificate
-    type: bool
-    profiles:
-    - xpath:
-      - block-timeout-cert
-    validators: []
-    spec: {}
-    description: Whether to block a session if cert. status can't be retrieved within
-      timeout.
-    required: false
-  - name: block-unauthenticated-certificate
-    type: bool
-    profiles:
-    - xpath:
-      - block-unauthenticated-cert
-    validators: []
-    spec: {}
-    description: Whether to block session if the certificate was not issued to the
-      authenticating device.
-    required: false
-  - name: block-unknown-certificate
-    type: bool
-    profiles:
-    - xpath:
-      - block-unknown-cert
-    validators: []
-    spec: {}
-    description: Whether to block a session if cert. status is unknown.
     required: false
   - name: certificate-status-timeout
     type: int64

--- a/specs/objects/profiles/file-blocking.yaml
+++ b/specs/objects/profiles/file-blocking.yaml
@@ -15,9 +15,11 @@ go_sdk_config:
   - objects
   - profiles
   - fileblocking
-xpath_suffix:
-- profiles
-- file-blocking
+panos_xpath:
+  path:
+  - profiles
+  - file-blocking
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -93,7 +95,6 @@ locations:
   description: Located in a specific Virtual System
   devices:
   - ngfw
-  - panorama
   validators: []
   required: false
   read_only: false

--- a/specs/objects/profiles/ike-crypto-profile.yaml
+++ b/specs/objects/profiles/ike-crypto-profile.yaml
@@ -15,11 +15,13 @@ go_sdk_config:
   - objects
   - profiles
   - ikecrypto
-xpath_suffix:
-- network
-- ike
-- crypto-profiles
-- ike-crypto-profiles
+panos_xpath:
+  path:
+  - network
+  - ike
+  - crypto-profiles
+  - ike-crypto-profiles
+  vars: []
 locations:
 - name: ngfw
   xpath:

--- a/specs/objects/profiles/ipsec-crypto-profile.yaml
+++ b/specs/objects/profiles/ipsec-crypto-profile.yaml
@@ -15,11 +15,13 @@ go_sdk_config:
   - objects
   - profiles
   - ipseccrypto
-xpath_suffix:
-- network
-- ike
-- crypto-profiles
-- ipsec-crypto-profiles
+panos_xpath:
+  path:
+  - network
+  - ike
+  - crypto-profiles
+  - ipsec-crypto-profiles
+  vars: []
 locations:
 - name: ngfw
   xpath:
@@ -317,6 +319,7 @@ spec:
       variants: []
     description: AH only
     required: false
+    variant_group_id: 0
   - name: esp
     type: object
     profiles:
@@ -375,3 +378,4 @@ spec:
       variants: []
     description: ESP options
     required: false
+    variant_group_id: 0

--- a/specs/objects/profiles/log-forwarding.yaml
+++ b/specs/objects/profiles/log-forwarding.yaml
@@ -15,9 +15,11 @@ go_sdk_config:
   - objects
   - profiles
   - logforwarding
-xpath_suffix:
-- log-settings
-- profiles
+panos_xpath:
+  path:
+  - log-settings
+  - profiles
+  vars: []
 locations:
 - name: shared
   xpath:

--- a/specs/objects/profiles/security-profile-group.yaml
+++ b/specs/objects/profiles/security-profile-group.yaml
@@ -15,8 +15,10 @@ go_sdk_config:
   - objects
   - profiles
   - secgroup
-xpath_suffix:
-- profile-group
+panos_xpath:
+  path:
+  - profile-group
+  vars: []
 locations:
 - name: shared
   xpath:

--- a/specs/objects/profiles/ssl-tls-service.yaml
+++ b/specs/objects/profiles/ssl-tls-service.yaml
@@ -16,8 +16,10 @@ go_sdk_config:
   - device
   - profile
   - ssltls
-xpath_suffix:
-- ssl-tls-service-profile
+panos_xpath:
+  path:
+  - ssl-tls-service-profile
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -51,7 +53,8 @@ locations:
     - template
     - $template
     - config
-    - shared
+    - devices
+    - $ngfw_device
     vars:
     - name: panorama_device
       description: Specific Panorama device
@@ -64,13 +67,19 @@ locations:
       required: true
       validators: []
       type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
   description: Located in a specific template
   devices:
   - panorama
   validators: []
   required: false
   read_only: false
-- name: template_vsys
+- name: template-vsys
   xpath:
     path:
     - config
@@ -128,7 +137,8 @@ locations:
     - template-stack
     - $template_stack
     - config
-    - shared
+    - devices
+    - $ngfw_device
     vars:
     - name: panorama_device
       description: Specific Panorama device
@@ -137,11 +147,17 @@ locations:
       validators: []
       type: entry
     - name: template_stack
-      description: The template stack
+      description: Specific Panorama template stack
       required: true
       validators: []
       type: entry
-  description: Located in a specific template
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template stack
   devices:
   - panorama
   validators: []
@@ -226,33 +242,6 @@ spec:
     validators: []
     spec:
       params:
-      - name: allow-authentication-sha1
-        type: bool
-        profiles:
-        - xpath:
-          - auth-algo-sha1
-        validators: []
-        spec: {}
-        description: Allow authentication SHA1
-        required: false
-      - name: allow-authentication-sha256
-        type: bool
-        profiles:
-        - xpath:
-          - auth-algo-sha256
-        validators: []
-        spec: {}
-        description: Allow authentication SHA256
-        required: false
-      - name: allow-authentication-sha384
-        type: bool
-        profiles:
-        - xpath:
-          - auth-algo-sha384
-        validators: []
-        spec: {}
-        description: Allow authentication SHA384
-        required: false
       - name: allow-algorithm-3des
         type: bool
         profiles:
@@ -298,15 +287,6 @@ spec:
         spec: {}
         description: Allow algorithm AES-256-GCM
         required: false
-      - name: allow-algorithm-rc4
-        type: bool
-        profiles:
-        - xpath:
-          - enc-algo-rc4
-        validators: []
-        spec: {}
-        description: Allow algorithm RC4
-        required: false
       - name: allow-algorithm-dhe
         type: bool
         profiles:
@@ -325,6 +305,15 @@ spec:
         spec: {}
         description: Allow algorithm ECDHE
         required: false
+      - name: allow-algorithm-rc4
+        type: bool
+        profiles:
+        - xpath:
+          - enc-algo-rc4
+        validators: []
+        spec: {}
+        description: Allow algorithm RC4
+        required: false
       - name: allow-algorithm-rsa
         type: bool
         profiles:
@@ -333,6 +322,33 @@ spec:
         validators: []
         spec: {}
         description: Allow algorithm RSA
+        required: false
+      - name: allow-authentication-sha1
+        type: bool
+        profiles:
+        - xpath:
+          - auth-algo-sha1
+        validators: []
+        spec: {}
+        description: Allow authentication SHA1
+        required: false
+      - name: allow-authentication-sha256
+        type: bool
+        profiles:
+        - xpath:
+          - auth-algo-sha256
+        validators: []
+        spec: {}
+        description: Allow authentication SHA256
+        required: false
+      - name: allow-authentication-sha384
+        type: bool
+        profiles:
+        - xpath:
+          - auth-algo-sha384
+        validators: []
+        spec: {}
+        description: Allow authentication SHA384
         required: false
       - name: max-version
         type: enum

--- a/specs/objects/profiles/url-filtering.yaml
+++ b/specs/objects/profiles/url-filtering.yaml
@@ -15,9 +15,11 @@ go_sdk_config:
   - objects
   - profiles
   - urlfiltering
-xpath_suffix:
-- profiles
-- url-filtering
+panos_xpath:
+  path:
+  - profiles
+  - url-filtering
+  vars: []
 locations:
 - name: shared
   xpath:

--- a/specs/objects/profiles/vulnerability.yaml
+++ b/specs/objects/profiles/vulnerability.yaml
@@ -15,9 +15,11 @@ go_sdk_config:
   - objects
   - profiles
   - vulnerability
-xpath_suffix:
-- profiles
-- vulnerability
+panos_xpath:
+  path:
+  - profiles
+  - vulnerability
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -71,6 +73,17 @@ entries:
 imports: []
 spec:
   params:
+  - name: cloud-inline-analysis
+    type: bool
+    profiles:
+    - xpath:
+      - cloud-inline-analysis
+      min_version: 11.0.2
+      max_version: 11.0.3
+    validators: []
+    spec: {}
+    description: Enable cloud inline analysis
+    required: false
   - name: description
     type: string
     profiles:
@@ -100,6 +113,79 @@ spec:
       - value: 'yes'
       - value: 'no'
     description: disable object override in child device groups
+    required: false
+  - name: inline-exception-edl-url
+    type: list
+    profiles:
+    - xpath:
+      - inline-exception-edl-url
+      type: member
+      min_version: 11.0.2
+      max_version: 11.0.3
+    validators: []
+    spec:
+      type: string
+      items:
+        type: string
+    description: ''
+    required: false
+  - name: inline-exception-ip-address
+    type: list
+    profiles:
+    - xpath:
+      - inline-exception-ip-address
+      type: member
+      min_version: 11.0.2
+      max_version: 11.0.3
+    validators: []
+    spec:
+      type: string
+      items:
+        type: string
+    description: ''
+    required: false
+  - name: mica-engine-vulnerability-enabled
+    type: list
+    profiles:
+    - xpath:
+      - mica-engine-vulnerability-enabled
+      - entry
+      type: entry
+      min_version: 11.0.2
+      max_version: 11.0.3
+    validators: []
+    spec:
+      type: object
+      items:
+        type: object
+        spec:
+          params:
+          - name: inline-policy-action
+            type: enum
+            profiles:
+            - xpath:
+              - inline-policy-action
+            validators:
+            - type: values
+              spec:
+                values:
+                - alert
+                - allow
+                - reset-both
+                - reset-client
+                - reset-server
+            spec:
+              default: alert
+              values:
+              - value: alert
+              - value: allow
+              - value: reset-both
+              - value: reset-client
+              - value: reset-server
+            description: ''
+            required: false
+          variants: []
+    description: ''
     required: false
   - name: rules
     type: list
@@ -580,90 +666,6 @@ spec:
                 spec:
                   params: []
                   variants: []
-            description: ''
-            required: false
-          variants: []
-    description: ''
-    required: false
-  - name: cloud-inline-analysis
-    type: bool
-    profiles:
-    - xpath:
-      - cloud-inline-analysis
-      min_version: 11.0.2
-      max_version: 11.0.3
-    validators: []
-    spec: {}
-    description: Enable cloud inline analysis
-    required: false
-  - name: inline-exception-edl-url
-    type: list
-    profiles:
-    - xpath:
-      - inline-exception-edl-url
-      type: member
-      min_version: 11.0.2
-      max_version: 11.0.3
-    validators: []
-    spec:
-      type: string
-      items:
-        type: string
-    description: ''
-    required: false
-  - name: inline-exception-ip-address
-    type: list
-    profiles:
-    - xpath:
-      - inline-exception-ip-address
-      type: member
-      min_version: 11.0.2
-      max_version: 11.0.3
-    validators: []
-    spec:
-      type: string
-      items:
-        type: string
-    description: ''
-    required: false
-  - name: mica-engine-vulnerability-enabled
-    type: list
-    profiles:
-    - xpath:
-      - mica-engine-vulnerability-enabled
-      - entry
-      type: entry
-      min_version: 11.0.2
-      max_version: 11.0.3
-    validators: []
-    spec:
-      type: object
-      items:
-        type: object
-        spec:
-          params:
-          - name: inline-policy-action
-            type: enum
-            profiles:
-            - xpath:
-              - inline-policy-action
-            validators:
-            - type: values
-              spec:
-                values:
-                - alert
-                - allow
-                - reset-both
-                - reset-client
-                - reset-server
-            spec:
-              default: alert
-              values:
-              - value: alert
-              - value: allow
-              - value: reset-both
-              - value: reset-client
-              - value: reset-server
             description: ''
             required: false
           variants: []

--- a/specs/objects/profiles/wildfire-analysis.yaml
+++ b/specs/objects/profiles/wildfire-analysis.yaml
@@ -15,9 +15,11 @@ go_sdk_config:
   - objects
   - profiles
   - wildfireanalysis
-xpath_suffix:
-- profiles
-- wildfire-analysis
+panos_xpath:
+  path:
+  - profiles
+  - wildfire-analysis
+  vars: []
 locations:
 - name: shared
   xpath:

--- a/specs/objects/service-group.yaml
+++ b/specs/objects/service-group.yaml
@@ -16,8 +16,10 @@ go_sdk_config:
   - objects
   - service
   - group
-xpath_suffix:
-- service-group
+panos_xpath:
+  path:
+  - service-group
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -61,7 +63,6 @@ locations:
   description: Located in a specific Virtual System
   devices:
   - ngfw
-  - panorama
   validators: []
   required: false
   read_only: false

--- a/specs/objects/service.yaml
+++ b/specs/objects/service.yaml
@@ -15,8 +15,10 @@ go_sdk_config:
   package:
   - objects
   - service
-xpath_suffix:
-- service
+panos_xpath:
+  path:
+  - service
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -60,7 +62,6 @@ locations:
   description: Located in a specific Virtual System
   devices:
   - ngfw
-  - panorama
   validators: []
   required: false
   read_only: false
@@ -148,33 +149,6 @@ spec:
         validators: []
         spec:
           params:
-          - name: port
-            type: string
-            profiles:
-            - xpath:
-              - port
-            validators:
-            - type: length
-              spec:
-                max: 1023
-            spec: {}
-            description: ''
-            required: false
-            codegen_overrides:
-              terraform:
-                name: destination-port
-          - name: source-port
-            type: string
-            profiles:
-            - xpath:
-              - source-port
-            validators:
-            - type: length
-              spec:
-                max: 1023
-            spec: {}
-            description: ''
-            required: false
           - name: override
             type: object
             profiles:
@@ -226,17 +200,6 @@ spec:
               variants: []
             description: ''
             required: false
-          variants: []
-        description: ''
-        required: false
-      - name: udp
-        type: object
-        profiles:
-        - xpath:
-          - udp
-        validators: []
-        spec:
-          params:
           - name: port
             type: string
             profiles:
@@ -264,6 +227,17 @@ spec:
             spec: {}
             description: ''
             required: false
+          variants: []
+        description: ''
+        required: false
+      - name: udp
+        type: object
+        profiles:
+        - xpath:
+          - udp
+        validators: []
+        spec:
+          params:
           - name: override
             type: object
             profiles:
@@ -288,6 +262,33 @@ spec:
                 description: udp session timeout value (in second)
                 required: false
               variants: []
+            description: ''
+            required: false
+          - name: port
+            type: string
+            profiles:
+            - xpath:
+              - port
+            validators:
+            - type: length
+              spec:
+                max: 1023
+            spec: {}
+            description: ''
+            required: false
+            codegen_overrides:
+              terraform:
+                name: destination-port
+          - name: source-port
+            type: string
+            profiles:
+            - xpath:
+              - source-port
+            validators:
+            - type: length
+              spec:
+                max: 1023
+            spec: {}
             description: ''
             required: false
           variants: []

--- a/specs/panorama/device-group-parent.yaml
+++ b/specs/panorama/device-group-parent.yaml
@@ -12,8 +12,9 @@ terraform_provider_config:
 go_sdk_config:
   skip: true
   package: ["device_group_parent"]
-xpath_suffix:
-  - device-group
+panos_xpath:
+  path:
+    - device-group
 locations:
   - name: "panorama"
     description: "Located in a specific Panorama."

--- a/specs/panorama/device-group.yaml
+++ b/specs/panorama/device-group.yaml
@@ -6,8 +6,9 @@ go_sdk_config:
   package:
     - "panorama"
     - "devicegroup"
-xpath_suffix:
-  - "device-group"
+panos_xpath:
+  path:
+    - "device-group"
 locations:
   - name: "panorama"
     description: "Located in a specific Panorama."

--- a/specs/panorama/template-stack.yaml
+++ b/specs/panorama/template-stack.yaml
@@ -6,8 +6,9 @@ go_sdk_config:
   package:
     - "panorama"
     - "template_stack"
-xpath_suffix:
-  - "template-stack"
+panos_xpath:
+  path:
+    - "template-stack"
 locations:
   - name: "panorama"
     description: "Located in a specific Panorama."

--- a/specs/panorama/template-variable.yaml
+++ b/specs/panorama/template-variable.yaml
@@ -6,8 +6,9 @@ go_sdk_config:
   package:
     - "panorama"
     - "template_variable"
-xpath_suffix:
-  - "variable"
+panos_xpath:
+  path:
+    - "variable"
 locations:
   - name: "template"
     description: "Located in a specific template."

--- a/specs/panorama/template.yaml
+++ b/specs/panorama/template.yaml
@@ -6,8 +6,9 @@ go_sdk_config:
   package:
     - "panorama"
     - "template"
-xpath_suffix:
-  - "template"
+panos_xpath:
+  path:
+    - "template"
 locations:
   - name: "panorama"
     description: "Located in a specific Panorama."

--- a/specs/policies/decryption-policy.yaml
+++ b/specs/policies/decryption-policy.yaml
@@ -17,9 +17,11 @@ go_sdk_config:
   - policies
   - rules
   - decryption
-xpath_suffix:
-- decryption
-- rules
+panos_xpath:
+  path:
+  - decryption
+  - rules
+  vars: []
 locations:
 - name: shared
   xpath:

--- a/specs/policies/network-address-translation.yaml
+++ b/specs/policies/network-address-translation.yaml
@@ -17,9 +17,11 @@ go_sdk_config:
   - policies
   - rules
   - nat
-xpath_suffix:
-- nat
-- rules
+panos_xpath:
+  path:
+  - nat
+  - rules
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -317,6 +319,7 @@ spec:
                     spec: {}
                     description: Floating IP address in HA Active-Active configuration
                     required: false
+                    variant_group_id: 0
                   - name: ip
                     type: string
                     profiles:
@@ -327,8 +330,10 @@ spec:
                     description: specify exact IP address if interface has multiple
                       addresses
                     required: false
+                    variant_group_id: 0
                 description: Use interface address as translated address
                 required: false
+                variant_group_id: 0
               - name: translated-address
                 type: list
                 profiles:
@@ -342,6 +347,7 @@ spec:
                     type: string
                 description: ''
                 required: false
+                variant_group_id: 0
             description: Fallback Dynamic IP and port translation
             required: false
           - name: translated-address
@@ -360,6 +366,7 @@ spec:
           variants: []
         description: Dynamic IP-only translation
         required: false
+        variant_group_id: 0
       - name: dynamic-ip-and-port
         type: object
         profiles:
@@ -399,6 +406,7 @@ spec:
                 spec: {}
                 description: Floating IP address in HA Active-Active configuration
                 required: false
+                variant_group_id: 0
               - name: ip
                 type: string
                 profiles:
@@ -408,8 +416,10 @@ spec:
                 spec: {}
                 description: specify exact IP address if interface has multiple addresses
                 required: false
+                variant_group_id: 0
             description: Use interface address as translated address
             required: false
+            variant_group_id: 0
           - name: translated-address
             type: list
             profiles:
@@ -423,8 +433,10 @@ spec:
                 type: string
             description: ''
             required: false
+            variant_group_id: 0
         description: Dynamic IP and port translation
         required: false
+        variant_group_id: 0
       - name: static-ip
         type: object
         profiles:
@@ -464,6 +476,7 @@ spec:
           variants: []
         description: static IP translation via IP shifting
         required: false
+        variant_group_id: 0
     description: ''
     required: false
   - name: tag
@@ -599,28 +612,6 @@ spec:
     validators: []
     spec:
       params:
-      - name: translated-address
-        type: string
-        profiles:
-        - xpath:
-          - translated-address
-        validators: []
-        spec: {}
-        description: ''
-        required: false
-      - name: translated-port
-        type: int64
-        profiles:
-        - xpath:
-          - translated-port
-        validators:
-        - type: length
-          spec:
-            min: 1
-            max: 65535
-        spec: {}
-        description: ''
-        required: false
       - name: dns-rewrite
         type: object
         profiles:
@@ -650,12 +641,36 @@ spec:
           variants: []
         description: ''
         required: false
+        variant_group_id: 0
+      - name: translated-address
+        type: string
+        profiles:
+        - xpath:
+          - translated-address
+        validators: []
+        spec: {}
+        description: ''
+        required: false
+      - name: translated-port
+        type: int64
+        profiles:
+        - xpath:
+          - translated-port
+        validators:
+        - type: length
+          spec:
+            min: 1
+            max: 65535
+        spec: {}
+        description: ''
+        required: false
       variants: []
     description: ''
     required: false
     codegen_overrides:
       terraform:
         variant_check: ConflictsWith
+    variant_group_id: 0
   - name: dynamic-destination-translation
     type: object
     profiles:
@@ -716,3 +731,4 @@ spec:
     codegen_overrides:
       terraform:
         variant_check: ConflictsWith
+    variant_group_id: 0

--- a/specs/policies/security-policy-rule.yaml
+++ b/specs/policies/security-policy-rule.yaml
@@ -17,9 +17,11 @@ go_sdk_config:
   - policies
   - rules
   - security
-xpath_suffix:
-- security
-- rules
+panos_xpath:
+  path:
+  - security
+  - rules
+  vars: []
 locations:
 - name: shared
   xpath:
@@ -232,6 +234,16 @@ spec:
     validators: []
     spec: {}
     description: ''
+    required: false
+  - name: disable-server-response-inspection
+    type: bool
+    profiles:
+    - xpath:
+      - option
+      - disable-server-response-inspection
+    validators: []
+    spec: {}
+    description: Disable inspection of server side traffic
     required: false
   - name: disabled
     type: bool
@@ -778,14 +790,4 @@ spec:
     codegen_overrides:
       terraform:
         private: true
-  - name: disable-server-response-inspection
-    type: bool
-    profiles:
-    - xpath:
-      - option
-      - disable-server-response-inspection
-    validators: []
-    spec: {}
-    description: Disable inspection of server side traffic
-    required: false
   variants: []

--- a/specs/schema/import.schema.json
+++ b/specs/schema/import.schema.json
@@ -14,8 +14,14 @@
         "additionalProperties": false,
         "properties": {
           "name": { "type": "string" },
+          "description": { "type": "string" },
+          "read_only": { "type": "boolean" },
           "required": { "type": "boolean", "default": false },
-          "xpath": { "$ref": "xpath.schema.json" }
+          "xpath": { "$ref": "xpath.schema.json" },
+          "validators": {
+            "type": "array",
+            "items": { "$ref": "validator.schema.json" }
+          }
         }
       }
     }

--- a/specs/schema/object.schema.json
+++ b/specs/schema/object.schema.json
@@ -9,6 +9,7 @@
     "name",
     "terraform_provider_config",
     "go_sdk_config",
+    "panos_xpath",
     "locations",
     "spec"
   ],
@@ -67,10 +68,16 @@
         }
       }
     },
-    "xpath_suffix": {
-      "type": "array",
-      "items": {
-        "type": "string"
+    "panos_xpath": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       }
     },
     "locations": {

--- a/specs/schema/schema.json
+++ b/specs/schema/schema.json
@@ -8,7 +8,7 @@
     "name",
     "terraform_provider_config",
     "go_sdk_config",
-    "xpath_suffix",
+    "panos_xpath",
     "locations",
     "entries",
     "version",
@@ -26,6 +26,13 @@
           "type": "string"
         }
       }
+    },
+    "panos_xpath": {
+      "type": "object",
+      "required": ["path"],
+      "properties": [
+        "path": { "type": "array" }
+      ]
     }
   }
 }

--- a/specs/schema/spec.schema.json
+++ b/specs/schema/spec.schema.json
@@ -21,6 +21,7 @@
       "properties": {
         "name": { "type": "string" },
         "description": { "type": "string" },
+        "variant_group_id": { "type": "integer" },
         "codegen_overrides": {
           "type": "object",
           "additionalProperties": false,

--- a/templates/sdk/entry.tmpl
+++ b/templates/sdk/entry.tmpl
@@ -8,7 +8,7 @@
     )
 
     var (
-    Suffix = []string{
+    suffix = []string{
     {{- $length := subtract (len .XpathSuffix) 1 }}
     {{- range $index, $suffix := .XpathSuffix}}"
     {{- $suffix}}"{{- if lt $index $length}},{{- end}}
@@ -49,6 +49,7 @@
     }
 
     {{- range $_, $param := .Spec.SortedParams}}
+      {{- if not (paramNotSkipped $param) }}{{ continue }}{{- end }}
         if v == "{{$param.Name.Underscore}}" || v == "{{$param.Name.CamelCase}}" {
         return e.{{$param.Name.CamelCase}}, nil
         }

--- a/templates/sdk/location.tmpl
+++ b/templates/sdk/location.tmpl
@@ -74,7 +74,7 @@ switch {
     ans = []string{
     {{- range $name, $xpath := $location.Xpath}}
         {{- if contains $xpath "Entry"}}
-            {{generateEntryXpath "util.AsEntryXpath([]string{" "})" $location.Name.CamelCase $xpath}}
+            {{generateEntryXpath "util.AsEntryXpath(" ")" $location.Name.CamelCase $xpath}}
         {{- else if contains $xpath "Object"}}
             {{generateEntryXpath "" "" $location.Name.CamelCase $xpath}}
         {{- else}}
@@ -90,35 +90,21 @@ return nil, errors.NoLocationSpecifiedError
 return ans, nil
 }
 
-{{- if .Entry}}
-    func (o Location) XpathWithEntryName(vn version.Number, name string) ([]string, error) {
-{{- else}}
-    func (o Location) Xpath(vn version.Number) ([]string, error) {
-{{- end}}
+func (o Location) XpathWithComponents(vn version.Number, components ...string) ([]string, error) {
+	if len(components) != {{ .ResourceXpathVariablesCount }} {
+		return nil, fmt.Errorf("invalid number of arguments for XpathWithComponents() call")
+	}
 
-ans, err := o.XpathPrefix(vn)
-if err != nil {
-return nil, err
+	{{ .ResourceXpathVariableChecks }}
+
+	ans, err := o.XpathPrefix(vn)
+        if err != nil {
+		return nil, err
+	}
+
+	{{- if ge .ResourceXpathVariablesCount 1 }}
+  	{{ .ResourceXpathAssignments }}
+        {{- end }}
+
+	return ans, nil
 }
-
-{{- if .Entry}}
-    ans = append(ans, Suffix...)
-    ans = append(ans, util.AsEntryXpath([]string{name}))
-{{- end}}
-
-return ans, nil
-}
-
-{{- if .Entry}}
-    func (o Location) XpathWithUuid(vn version.Number, uuid string) ([]string, error) {
-
-    ans, err := o.XpathPrefix(vn)
-    if err != nil {
-    return nil, err
-    }
-    ans = append(ans, Suffix...)
-    ans = append(ans, util.AsUuidXpath(uuid))
-
-    return ans, nil
-    }
-{{- end}}

--- a/templates/sdk/service.tmpl
+++ b/templates/sdk/service.tmpl
@@ -55,73 +55,91 @@ client: client,
 }
 
 // Create adds new item, then returns the result.
-{{- if and (.Entry) (.Imports)}}
-    func (s *Service) Create(ctx context.Context, loc Location, importLocations []ImportLocation, entry *Entry) (*Entry, error) {
-{{- else if (.Entry) }}
-    func (s *Service) Create(ctx context.Context, loc Location, entry *Entry) (*Entry, error) {
-{{- else }}
-    func (s *Service) Create(ctx context.Context, loc Location, config *Config) (*Config, error) {
-{{- end}}
+  {{- if and (.Entry) (.Imports)}}
+func (s *Service) Create(ctx context.Context, loc Location, importLocations []ImportLocation, entry *Entry) (*Entry, error) {
+  {{- else if (.Entry) }}
+func (s *Service) Create(ctx context.Context, loc Location, entry *Entry) (*Entry, error) {
+  {{- else }}
+func (s *Service) Create(ctx context.Context, loc Location, config *Config) (*Config, error) {
+  {{- end}}
 
-{{- if .Entry}}
-    if entry.Name == "" {
-    return nil, errors.NameNotSpecifiedError
-    }
-{{- end}}
+  {{- if .Entry}}
+	if entry.Name == "" {
+		return nil, errors.NameNotSpecifiedError
+	}
+  {{- end}}
 
-vn := s.client.Versioning()
+	vn := s.client.Versioning()
 
-specifier, _, err := Versioning(vn)
-if err != nil {
-return nil, err
+  {{- if .Entry}}
+	path, err := loc.XpathWithComponents(vn, util.AsEntryXpath(entry.Name))
+  {{- else}}
+	path, err := loc.XpathWithComponents(vn)
+  {{- end}}
+	if err != nil {
+		return nil, err
+	}
+
+  {{- if .Entry}}
+	err = s.CreateWithXpath(ctx, util.AsXpath(path[:len(path)-1]), entry)
+  {{- else}}
+	err = s.CreateWithXpath(ctx, util.AsXpath(path[:len(path)-1]), config)
+  {{- end}}
+	if err != nil {
+		return nil, err
+	}
+
+  {{- if .Imports }}
+	err = s.ImportToLocations(ctx, loc, importLocations, entry.Name)
+	if err != nil {
+		return nil, err
+	}
+  {{- end }}
+
+	return s.ReadWithXpath(ctx, util.AsXpath(path), "get")
 }
 
-{{- if .Entry}}
-    path, err := loc.XpathWithEntryName(vn, entry.Name)
-{{- else}}
-    path, err := loc.Xpath(vn)
-{{- end}}
-if err != nil {
-return nil, err
-}
 
-{{- if .Entry}}
-    createSpec, err := specifier(entry)
-{{- else}}
-    createSpec, err := specifier(config)
-{{- end}}
-if err != nil {
-return nil, err
-}
+  {{ $funcDef := "" }}
+  {{- if .Entry }}
+    {{ $funcDef = "CreateWithXpath(ctx context.Context, xpath string, entry *Entry) error" }}
+  {{- else }}
+    {{ $funcDef = "CreateWithXpath(ctx context.Context, xpath string, config *Config) error" }}
+  {{- end }}
 
-cmd := &xmlapi.Config{
-Action:  "set",
-Xpath:   util.AsXpath(path[:len(path)-1]),
-Element: createSpec,
-Target:  s.client.GetTarget(),
-}
+func (s *Service) {{ $funcDef }} {
+	vn := s.client.Versioning()
+	specifier, _, err := Versioning(vn)
+	if err != nil {
+		return err
+	}
 
-if _, _, err = s.client.Communicate(ctx, cmd, false, nil); err != nil {
-return nil, err
+  {{- if .Entry}}
+	createSpec, err := specifier(entry)
+  {{- else}}
+	createSpec, err := specifier(config)
+  {{- end}}
+	if err != nil {
+		return err
+	}
+
+	cmd := &xmlapi.Config{
+		Action:  "set",
+		Xpath:   xpath,
+		Element: createSpec,
+		Target:  s.client.GetTarget(),
+	}
+
+	if _, _, err = s.client.Communicate(ctx, cmd, false, nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 {{- if .Imports }}
-err = s.importToLocations(ctx, loc, importLocations, entry.Name)
-if err != nil {
-	return nil, err
-}
-{{- end }}
 
-{{- if .Entry}}
-    return s.Read(ctx, loc, entry.Name, "get")
-{{- else}}
-    return s.Read(ctx, loc, "get")
-{{- end}}
-}
-
-{{- if .Imports }}
-
-func (s *Service) importToLocations(ctx context.Context, loc Location, importLocations []ImportLocation, entryName string) error {
+func (s *Service) ImportToLocations(ctx context.Context, loc Location, importLocations []ImportLocation, entryName string) error {
 	vn := s.client.Versioning()
 
 	importToLocation := func(il ImportLocation) error {
@@ -186,7 +204,7 @@ func (s *Service) importToLocations(ctx context.Context, loc Location, importLoc
 	return nil
 }
 
-func (s *Service) unimportFromLocations(ctx context.Context, loc Location, importLocations []ImportLocation, values []string) error {
+func (s *Service) UnimportFromLocations(ctx context.Context, loc Location, importLocations []ImportLocation, values []string) error {
 	vn := s.client.Versioning()
 	valuesByName := make(map[string]bool)
 	for _, elt := range values {
@@ -259,115 +277,96 @@ func (s *Service) unimportFromLocations(ctx context.Context, loc Location, impor
 {{- if .Entry}}
     func (s *Service) Read(ctx context.Context, loc Location, name, action string) (*Entry, error) {
     {{- if $.Spec.Params.uuid}}
-        return s.read(ctx, loc, name, action, true, false)
+        return s.read(ctx, loc, name, action, true)
     {{- else}}
-        return s.read(ctx, loc, name, action, false)
+        return s.read(ctx, loc, name, action)
     {{- end}}
     }
     {{- if $.Spec.Params.uuid}}
         // ReadById returns the given config object with specified ID, using the specified action ("get" or "show").
         func (s *Service) ReadById(ctx context.Context, loc Location, uuid, action string) (*Entry, error) {
-        return s.read(ctx, loc, uuid, action, false, false)
+        return s.read(ctx, loc, uuid, action, false)
         }
     {{- end}}
 {{- else}}
     func (s *Service) Read(ctx context.Context, loc Location, action string) (*Config, error) {
-    return s.read(ctx, loc, action, false)
+    return s.read(ctx, loc, action)
     }
 {{- end}}
 
-// ReadFromConfig returns the given config object from the loaded XML config.
-// Requires that client.LoadPanosConfig() has been invoked.
-{{- if .Entry}}
-    func (s *Service) ReadFromConfig(ctx context.Context, loc Location, name string) (*Entry, error) {
-    {{- if $.Spec.Params.uuid}}
-        return s.read(ctx, loc, name, "", true, true)
-    {{- else}}
-        return s.read(ctx, loc, name, "", true)
-    {{- end}}
-    }
-    {{- if $.Spec.Params.uuid}}
-        // ReadFromConfigById returns the given config object with specified ID from the loaded XML config.
-        // Requires that client.LoadPanosConfig() has been invoked.
-        func (s *Service) ReadFromConfigById(ctx context.Context, loc Location, uuid string) (*Entry, error) {
-        return s.read(ctx, loc, uuid, "", false, true)
-        }
-    {{- end}}
-{{- else}}
-    func (s *Service) ReadFromConfig(ctx context.Context, loc Location) (*Config, error) {
-    return s.read(ctx, loc, "", true)
-    }
-{{- end}}
+  {{ $funcDef := "" }}
+  {{- if .Entry }}
+    {{ $funcDef = "ReadWithXpath(ctx context.Context, xpath string, action string) (*Entry, error)" }}
+  {{- else }}
+    {{ $funcDef = "ReadWithXpath(ctx context.Context, xpath string, action string) (*Config, error)" }}
+  {{- end }}
+func (s *Service) {{ $funcDef }} {
+	vn := s.client.Versioning()
+	_, normalizer, err := Versioning(vn)
+	if err != nil {
+		return nil, err
+	}
 
-{{if .Entry}}
+	cmd := &xmlapi.Config{
+		Action: action,
+		Xpath:  xpath,
+		Target: s.client.GetTarget(),
+	}
+
+	if _, _, err = s.client.Communicate(ctx, cmd, true, normalizer); err != nil {
+		if err.Error() == "No such node" && action == "show" {
+			return nil, errors.ObjectNotFound()
+		}
+		return nil, err
+	}
+
+	list, err := normalizer.Normalize()
+	if err != nil {
+		return nil, err
+	} else if len(list) != 1 {
+		return nil, fmt.Errorf("expected to %q 1 entry, got %d", action, len(list))
+	}
+
+	return list[0], nil
+}
+
+  {{if .Entry}}
     {{- if $.Spec.Params.uuid}}
-        func (s *Service) read(ctx context.Context, loc Location, value, action string, byName, usePanosConfig bool) (*Entry, error) {
+func (s *Service) read(ctx context.Context, loc Location, value, action string, byName bool) (*Entry, error) {
         if byName && value == "" {
-        return nil, errors.NameNotSpecifiedError
+		return nil, errors.NameNotSpecifiedError
         }
-        if !byName && value == "" {
-        return nil, errors.UuidNotSpecifiedError
-        }
+
+	if !byName && value == "" {
+		return nil, errors.UuidNotSpecifiedError
+	}
     {{- else}}
-        func (s *Service) read(ctx context.Context, loc Location, value, action string, usePanosConfig bool) (*Entry, error) {
+func (s *Service) read(ctx context.Context, loc Location, value, action string) (*Entry, error) {
         if value == "" {
         return nil, errors.NameNotSpecifiedError
         }
     {{- end}}
-{{- else}}
-    func (s *Service) read(ctx context.Context, loc Location, action string, usePanosConfig bool) (*Config, error) {
-{{- end}}
-vn := s.client.Versioning()
-_, normalizer, err := Versioning(vn)
-if err != nil {
-return nil, err
-}
+  {{- else}}
+func (s *Service) read(ctx context.Context, loc Location, action string) (*Config, error) {
+  {{- end}}
+	vn := s.client.Versioning()
 
-{{- if .Entry}}
-    var path []string
+  {{- if .Entry}}
+	var path []string
+        var err error
     {{- if $.Spec.Params.uuid}}
-        if byName {
-        path, err = loc.XpathWithEntryName(vn, value)
-        } else {
-        path, err = loc.XpathWithUuid(vn, value)
-        }
+	path, err = loc.XpathWithComponents(vn, value)
     {{- else}}
-        path, err = loc.XpathWithEntryName(vn, value)
+	path, err = loc.XpathWithComponents(vn, value)
     {{- end}}
-{{- else}}
-    path, err := loc.Xpath(vn)
-{{- end}}
-if err != nil {
-return nil, err
-}
+  {{- else}}
+	path, err := loc.XpathWithComponents(vn)
+  {{- end}}
+	if err != nil {
+		return nil, err
+	}
 
-if usePanosConfig {
-if _, err = s.client.ReadFromConfig(ctx, path, true, normalizer); err != nil {
-return nil, err
-}
-} else {
-cmd := &xmlapi.Config{
-Action: action,
-Xpath:  util.AsXpath(path),
-Target: s.client.GetTarget(),
-}
-
-if _, _, err = s.client.Communicate(ctx, cmd, true, normalizer); err != nil {
-if err.Error() == "No such node" && action == "show" {
-return nil, errors.ObjectNotFound()
-}
-return nil, err
-}
-}
-
-list, err := normalizer.Normalize()
-if err != nil {
-return nil, err
-} else if len(list) != 1 {
-return nil, fmt.Errorf("expected to %q 1 entry, got %d", action, len(list))
-}
-
-return list[0], nil
+	return s.ReadWithXpath(ctx, util.AsXpath(path), action)
 }
 
 {{ $object := "Config" }}
@@ -376,138 +375,127 @@ return list[0], nil
 {{- end }}
 
 {{- if .Entry }}
-    // Update updates the given config object, then returns the result.
-    func (s *Service) Update(ctx context.Context, loc Location, entry *{{ $object }}, name string) (*{{ $object }}, error) {
-  {{- if $.Spec.Params.uuid}}
-        return s.update(ctx, loc, entry, name, true)
-  {{- else}}
-        return s.update(ctx, loc, entry, name)
-  {{- end}}
-    }
+func (s *Service) Update(ctx context.Context, loc Location, entry *{{ $object }}, name string) (*{{ $object }}, error) {
+	if entry.Name == "" {
+		return nil, errors.NameNotSpecifiedError
+	}
 
-  {{- if $.Spec.Params.uuid}}
-        // UpdateById updates the given config object, then returns the result.
-        func (s *Service) UpdateById(ctx context.Context, loc Location, entry *{{ $object }}, uuid string) (*{{ $object }}, error) {
-        return s.update(ctx, loc, entry, uuid, false)
-        }
-  {{- end}}
+	xpath, err := loc.XpathWithComponents(s.client.Versioning(), entry.Name)
+        if err != nil {
+        	return nil, err
+	}
 
-  {{- if $.Spec.Params.uuid}}
-        func (s *Service) update(ctx context.Context, loc Location, entry *{{ $object }}, value string, byName bool) (*{{ $object }}, error) {
-  {{- if .Entry }}
-        if byName && entry.Name == "" {
-        return nil, errors.NameNotSpecifiedError
-        }
-        if !byName && value == "" {
-        return nil, errors.UuidNotSpecifiedError
-        }
-  {{- end }}
-  {{- else}}
-        func (s *Service) update(ctx context.Context, loc Location, entry *{{ $object }}, value string) (*{{ $object }}, error) {
-    {{- if .Entry }}
-        if entry.Name == "" {
-        return nil, errors.NameNotSpecifiedError
-        }
-    {{- end }}
-  {{- end}}
+	err = s.UpdateWithXpath(ctx, util.AsXpath(xpath), entry, name)
+        if err != nil {
+        	return nil, err
+	}
+
+	return s.ReadWithXpath(ctx, util.AsXpath(xpath), "get")
+}
 {{- else }}
-func (s *Service) Update(ctx context.Context, loc Location, entry *{{ $object }}) (*{{ $object }}, error) {
+func (s *Service) Update(ctx context.Context, loc Location, entry *{{ $object }}, name string) (*{{ $object }}, error) {
+	xpath, err := loc.XpathWithComponents(s.client.Versioning())
+        if err != nil {
+        	return nil, err
+	}
+
+	err = s.UpdateWithXpath(ctx, util.AsXpath(xpath), entry)
+        if err != nil {
+        	return nil, err
+	}
+
+	return s.ReadWithXpath(ctx, util.AsXpath(xpath), "get")
+}
 {{- end }}
 
-    vn := s.client.Versioning()
-    updates := xmlapi.NewMultiConfig(2)
-    specifier, _, err := Versioning(vn)
-    if err != nil {
-        return nil, err
-    }
+{{- if .Entry }}
+func (s *Service) UpdateWithXpath(ctx context.Context, xpath string, entry *{{ $object }}, name string) error {
+{{- else }}
+func (s *Service) UpdateWithXpath(ctx context.Context, xpath string, entry *{{ $object }}) error {
+{{- end }}
+	vn := s.client.Versioning()
+	updates := xmlapi.NewMultiConfig(2)
+	specifier, _, err := Versioning(vn)
+	if err != nil {
+		return err
+	}
 
 
-  {{- if .Entry }}
-    var old *{{ $object }}
-    {{- if $.Spec.Params.uuid}}
-        if byName {
-    {{- end}}
-    if value != "" && value != entry.Name {
-        path, err := loc.XpathWithEntryName(vn, value)
-        if err != nil {
-            return nil, err
-        }
-
-        old, err = s.Read(ctx, loc, value, "get")
-
-        updates.Add(&xmlapi.Config{
-            Action:  "rename",
-            Xpath:   util.AsXpath(path),
-            NewName: entry.Name,
-            Target:  s.client.GetTarget(),
-        })
-    } else {
-        old, err = s.Read(ctx, loc, entry.Name, "get")
-    }
-    {{- if $.Spec.Params.uuid}}
-        } else {
-        old, err = s.ReadById(ctx, loc, value, "get")
-        }
-    {{- end}}
-    if err != nil {
-        return nil, err
-    } else if old == nil {
-        return nil, fmt.Errorf("previous object doesn't exist for update")
-    }
-  {{- else }}
-    var old *{{ $object }}
-    old, err = s.Read(ctx, loc, "get")
-    if err != nil {
-        return nil, err
-    } else if old == nil {
-        return nil, fmt.Errorf("previous object doesn't exist for update")
-    }
-  {{- end }}
+	var old *{{ $object }}
 
   {{- if .Entry }}
-    if !SpecMatches(entry, old) {
-        path, err := loc.XpathWithEntryName(vn, entry.Name)
+	if name != "" && name != entry.Name {
+		old, err = s.ReadWithXpath(ctx, xpath, "get")
+		if err != nil {
+			return err
+		}
+
+		if old != nil {
+			return errors.ObjectExists
+		}
+
+		updates.Add(&xmlapi.Config{
+			Action:  "rename",
+			Xpath:   util.AsXpath(xpath),
+			NewName: entry.Name,
+			Target:  s.client.GetTarget(),
+		})
+	} else {
+		old, err = s.ReadWithXpath(ctx, xpath, "get")
+		if err != nil {
+			return err
+		}
+
+		if old == nil {
+        		return errors.ObjectNotFound()
+		}
+
+		if SpecMatches(entry, old) {
+        		return nil
+		}
+
+			updateSpec, err := specifier(entry)
+		if err != nil {
+			return err
+		}
+
+		updates.Add(&xmlapi.Config{
+			Action:  "edit",
+			Xpath:   util.AsXpath(xpath),
+			Element: updateSpec,
+			Target:  s.client.GetTarget(),
+		})
+	}
   {{- else }}
-    if !SpecMatches(entry, old) {
-        path, err := loc.Xpath(vn)
-  {{- end }}
+	old, err = s.ReadWithXpath(ctx, xpath, "get")
         if err != nil {
-            return nil, err
-        }
+        	return err
+	}
 
+	if SpecMatches(entry, old) {
+        	return nil
+	}
 
-        updateSpec, err := specifier(entry)
-        if err != nil {
-            return nil, err
-        }
+	updateSpec, err := specifier(entry)
+	if err != nil {
+		return err
+	}
 
-        updates.Add(&xmlapi.Config{
-            Action:  "edit",
-            Xpath:   util.AsXpath(path),
-            Element: updateSpec,
-            Target:  s.client.GetTarget(),
-        })
-    }
-
-    if len(updates.Operations) != 0 {
-        if _, _, _, err = s.client.MultiConfig(ctx, updates, false, nil); err != nil {
-            return nil, err
-        }
-    }
-
-  {{- if .Entry }}
-    {{- if $.Spec.Params.uuid}}
-        if byName {
-            return s.Read(ctx, loc, entry.Name, "get")
-        } else {
-            return s.ReadById(ctx, loc, value, "get")
-        }
-    {{- else}}
-        return s.Read(ctx, loc, entry.Name, "get")
-    {{- end}}
-  {{- else }}
-        return s.Read(ctx, loc, "get")
+	updates.Add(&xmlapi.Config{
+		Action:  "edit",
+		Xpath:   util.AsXpath(xpath),
+		Element: updateSpec,
+		Target:  s.client.GetTarget(),
+	})
   {{- end }}
+
+	if len(updates.Operations) != 0 {
+		if _, _, _, err = s.client.MultiConfig(ctx, updates, false, nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Delete deletes the given item.
@@ -585,24 +573,16 @@ vn := s.client.Versioning()
     var err error
     deletes := xmlapi.NewMultiConfig(len(values))
   {{- if .Imports }}
-    err = s.unimportFromLocations(ctx, loc, importLocations, values)
+    err = s.UnimportFromLocations(ctx, loc, importLocations, values)
     if err != nil {
         return err
     }
   {{- end }}
     for _, value := range values {
     var path []string
-    {{- if $.Spec.Params.uuid}}
-        if byName {
-        path, err = loc.XpathWithEntryName(vn, value)
-        } else {
-        path, err = loc.XpathWithUuid(vn, value)
-        }
-    {{- else}}
-        path, err = loc.XpathWithEntryName(vn, value)
-    {{- end}}
+        path, err = loc.XpathWithComponents(vn, util.AsEntryXpath(value))
 {{- else}}
-    path, err := loc.Xpath(vn)
+    path, err := loc.XpathWithComponents(vn)
 {{- end}}
 if err != nil {
 return err
@@ -725,85 +705,75 @@ func (s *Service) RemoveFromImport(ctx context.Context, loc Location, entry Entr
 {{- end}}
 
 {{- if .Entry}}
-    // List returns a list of objects using the given action ("get" or "show").
-    // Params filter and quote are for client side filtering.
-    func (s *Service) List(ctx context.Context, loc Location, action, filter, quote string) ([]*Entry, error) {
-    return s.list(ctx, loc, action, filter, quote, false)
-    }
+// List returns a list of objects using the given action ("get" or "show").
+// Params filter and quote are for client side filtering.
+func (s *Service) List(ctx context.Context, loc Location, action, filter, quote string) ([]*Entry, error) {
+	return s.list(ctx, loc, action, filter, quote)
+}
 
-    // ListFromConfig returns a list of objects at the given location.
-    // Requires that client.LoadPanosConfig() has been invoked.
-    // Params filter and quote are for client side filtering.
-    func (s *Service) ListFromConfig(ctx context.Context, loc Location, filter, quote string) ([]*Entry, error) {
-    return s.list(ctx, loc, "", filter, quote, true)
-    }
+func (s *Service) list(ctx context.Context, loc Location, action, filter, quote string) ([]*Entry, error) {
+	xpath, err := loc.XpathWithComponents(s.client.Versioning(), util.AsEntryXpath(""))
+        if err != nil {
+        	return nil, err
+	}
 
-    func (s *Service) list(ctx context.Context, loc Location, action, filter, quote string, usePanosConfig bool) ([]*Entry, error) {
-    var err error
+	return s.ListWithXpath(ctx, util.AsXpath(xpath), action, filter, quote)
+}
 
-    var logic *filtering.Group
-    if filter != "" {
-    logic, err = filtering.Parse(filter, quote)
-    if err != nil {
-    return nil, err
-    }
-    }
+func (s *Service) ListWithXpath(ctx context.Context, xpath string, action, filter, quote string) ([]*Entry, error) {
+	var logic *filtering.Group
+	if filter != "" {
+        	var err error
+		logic, err = filtering.Parse(filter, quote)
+		if err != nil {
+			return nil, err
+		}
+	}
 
-    vn := s.client.Versioning()
+	vn := s.client.Versioning()
 
-    _, normalizer, err := Versioning(vn)
-    if err != nil {
-    return nil, err
-    }
+   	_, normalizer, err := Versioning(vn)
+	if err != nil {
+		return nil, err
+	}
 
-    path, err := loc.XpathWithEntryName(vn, "")
-    if err != nil {
-    return nil, err
-    }
+	cmd := &xmlapi.Config{
+		Action: action,
+		Xpath:  util.AsXpath(xpath),
+		Target: s.client.GetTarget(),
+	}
 
-    if usePanosConfig {
-    if _, err = s.client.ReadFromConfig(ctx, path, false, normalizer); err != nil {
-    return nil, err
-    }
-    } else{
-    cmd := &xmlapi.Config{
-    Action: action,
-    Xpath:  util.AsXpath(path),
-    Target: s.client.GetTarget(),
-    }
+	if _, _, err = s.client.Communicate(ctx, cmd, true, normalizer); err != nil {
+		if err.Error() == "No such node" && action == "show" {
+			return nil, nil
+    		}
+		return nil, err
+	}
 
-    if _, _, err = s.client.Communicate(ctx, cmd, true, normalizer); err != nil {
-    if err.Error() == "No such node" && action == "show" {
-    return nil, nil
-    }
-    return nil, err
-    }
-    }
+	listing, err := normalizer.Normalize()
+	if err != nil || logic == nil {
+		return listing, err
+	}
 
-    listing, err := normalizer.Normalize()
-    if err != nil || logic == nil {
-    return listing, err
-    }
+	filtered := make([]*Entry, 0, len(listing))
+	for _, x := range listing {
+		ok, err := logic.Matches(x)
+		if err != nil {
+			return nil, err
+    		}
+		if ok {
+			filtered = append(filtered, x)
+    		}
+    	}
 
-    filtered := make([]*Entry, 0, len(listing))
-    for _, x := range listing {
-    ok, err := logic.Matches(x)
-    if err != nil {
-    return nil, err
-    }
-    if ok {
-    filtered = append(filtered, x)
-    }
-    }
+	return filtered, nil
+}
 
-    return filtered, nil
-    }
-
-    {{- if $.Spec.Params.uuid}}
-        // MoveGroup arranges the given rules in the order specified.
-        // Any rule with a UUID specified is ignored.
-        // Only the rule names are considered for the purposes of the rule placement.
- func (s *Service) MoveGroup(ctx context.Context, loc Location, position movement.Position, entries []*Entry, batchSize int) error {
+{{- if $.Spec.Params.uuid}}
+// MoveGroup arranges the given rules in the order specified.
+// Any rule with a UUID specified is ignored.
+// Only the rule names are considered for the purposes of the rule placement.
+func (s *Service) MoveGroup(ctx context.Context, loc Location, position movement.Position, entries []*Entry, batchSize int) error {
         if len(entries) == 0 {
         	return nil
         }
@@ -823,7 +793,7 @@ func (s *Service) RemoveFromImport(ctx context.Context, loc Location, entry Entr
 	updates := xmlapi.NewChunkedMultiConfig(len(movements), batchSize)
 
 	for _, elt := range movements {
-	        path, err := loc.XpathWithEntryName(s.client.Versioning(), elt.Movable.EntryName())
+	        path, err := loc.XpathWithComponents(s.client.Versioning(), util.AsEntryXpath(elt.Movable.EntryName()))
 	        if err != nil {
 		        return err
 	        }
@@ -886,7 +856,7 @@ func (s *Service) RemoveFromImport(ctx context.Context, loc Location, entry Entr
 
         vn := s.client.Versioning()
 
-        path, err := loc.XpathWithEntryName(vn, name)
+        path, err := loc.XpathWithComponents(vn, name)
         if err != nil {
         return err
         }
@@ -911,7 +881,7 @@ func (s *Service) RemoveFromImport(ctx context.Context, loc Location, entry Entr
 
         vn := s.client.Versioning()
 
-        path, err := loc.XpathWithEntryName(vn, name)
+        path, err := loc.XpathWithComponents(vn, name)
         if err != nil {
         return "", err
         }


### PR DESCRIPTION
Child specs describe resources nested within other resources, e.g. ethernet subinterfaces within parent interface, or ipv4 static routes for a virtual router.