### PR TITLE
feat(codegen): Parametrize which SDK CRUD methods are to be implemented

### DIFF
--- a/assets/pango/errors/panos.go
+++ b/assets/pango/errors/panos.go
@@ -15,6 +15,7 @@ var RelativePositionWithRemoveEverythingElseError = stderr.New("cannot do relati
 var UnrecognizedOperatorError = stderr.New("unsupported filter operator")
 var UnsupportedFilterTypeError = stderr.New("unsupported type for filtering")
 var UuidNotSpecifiedError = stderr.New("uuid is not specified")
+var UnsupportedMethodError = stderr.New("method is not supported")
 
 // Panos is an error returned from PAN-OS.
 //

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/paloaltonetworks/pan-os-codegen/pkg/naming"
 	"github.com/paloaltonetworks/pan-os-codegen/pkg/properties"
+	"github.com/paloaltonetworks/pan-os-codegen/pkg/schema/object"
 	codegentmpl "github.com/paloaltonetworks/pan-os-codegen/pkg/template"
 	"github.com/paloaltonetworks/pan-os-codegen/pkg/translate"
 	"github.com/paloaltonetworks/pan-os-codegen/pkg/translate/terraform_provider"
@@ -254,6 +255,7 @@ func (c *Creator) parseTemplate(templateName string) (*template.Template, error)
 		"renderImports": func(templateTypes ...string) (string, error) {
 			return translate.RenderImports(c.Spec, templateTypes...)
 		},
+		"SupportedMethod":           func(method object.GoSdkMethod) bool { return c.Spec.SupportedMethod(method) },
 		"RenderEntryImportStructs":  func() (string, error) { return translate.RenderEntryImportStructs(c.Spec) },
 		"packageName":               translate.PackageName,
 		"locationType":              translate.LocationType,

--- a/pkg/properties/normalized.go
+++ b/pkg/properties/normalized.go
@@ -26,6 +26,7 @@ type Normalization struct {
 	TerraformProviderConfig TerraformProviderConfig `json:"terraform_provider_config" yaml:"terraform_provider_config"`
 	GoSdkSkip               bool                    `json:"go_sdk_skip" yaml:"go_sdk_skip"`
 	GoSdkPath               []string                `json:"go_sdk_path" yaml:"go_sdk_path"`
+	GoSdkSupportedMethods   []object.GoSdkMethod    `json:"go_sdk_supported_methods" yaml:"go_sdk_supported_methods"`
 	PanosXpath              PanosXpath              `json:"panos_xpath" yaml:"panos_xpath"`
 	Locations               map[string]*Location    `json:"locations" yaml:"locations"`
 	Entry                   *Entry                  `json:"entry" yaml:"entry"`
@@ -701,11 +702,12 @@ func schemaToSpec(object object.Object) (*Normalization, error) {
 			PluralType:            object.TerraformConfig.PluralType,
 			PluralDescription:     object.TerraformConfig.PluralDescription,
 		},
-		Locations:  make(map[string]*Location),
-		GoSdkSkip:  object.GoSdkConfig.Skip,
-		GoSdkPath:  object.GoSdkConfig.Package,
-		PanosXpath: panosXpath,
-		Version:    object.Version,
+		Locations:             make(map[string]*Location),
+		GoSdkSkip:             object.GoSdkConfig.Skip,
+		GoSdkPath:             object.GoSdkConfig.Package,
+		GoSdkSupportedMethods: object.GoSdkConfig.SupportedMethods,
+		PanosXpath:            panosXpath,
+		Version:               object.Version,
 		Spec: &Spec{
 			Params: make(map[string]*SpecParam),
 			OneOf:  make(map[string]*SpecParam),
@@ -920,6 +922,10 @@ func ParseSpec(input []byte) (*Normalization, error) {
 	}
 
 	return spec, err
+}
+
+func (spec *Normalization) SupportedMethod(method object.GoSdkMethod) bool {
+	return slices.Contains(spec.GoSdkSupportedMethods, method)
 }
 
 func (spec *Normalization) OrderedLocations() []*Location {

--- a/pkg/schema/object/object.go
+++ b/pkg/schema/object/object.go
@@ -51,9 +51,20 @@ type TerraformConfig struct {
 	PluralDescription     string                     `yaml:"plural_description"`
 }
 
+type GoSdkMethod string
+
+const (
+	GoSdkMethodCreate = "create"
+	GoSdkMethodUpdate = "update"
+	GoSdkMethodDelete = "delete"
+	GoSdkMethodRead   = "read"
+	GoSdkMethodList   = "list"
+)
+
 type GoSdkConfig struct {
-	Skip    bool     `yaml:"skip"`
-	Package []string `yaml:"package"`
+	Skip             bool          `yaml:"skip"`
+	SupportedMethods []GoSdkMethod `yaml:"supported_methods"`
+	Package          []string      `yaml:"package"`
 }
 
 type Entry struct {
@@ -111,8 +122,19 @@ func (o *Object) UnmarshalYAML(n *yaml.Node) error {
 	}
 
 	obj := &S{O: (*O)(o)}
+
 	if err := n.Decode(obj); err != nil {
 		return err
+	}
+
+	if o.GoSdkConfig == nil || o.GoSdkConfig.SupportedMethods == nil {
+		o.GoSdkConfig.SupportedMethods = []GoSdkMethod{
+			GoSdkMethodCreate,
+			GoSdkMethodDelete,
+			GoSdkMethodRead,
+			GoSdkMethodList,
+			GoSdkMethodUpdate,
+		}
 	}
 
 	switch obj.TerraformConfig.ResourceType {

--- a/pkg/translate/terraform_provider/device_group_parent_crud.go
+++ b/pkg/translate/terraform_provider/device_group_parent_crud.go
@@ -4,8 +4,6 @@ const deviceGroupParentImports = `
 import (
   "encoding/xml"
 
-  "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-
   sdkerrors "github.com/PaloAltoNetworks/pango/errors"
   "github.com/PaloAltoNetworks/pango/util"
   "github.com/PaloAltoNetworks/pango/xmlapi"
@@ -15,6 +13,8 @@ import (
 const deviceGroupParentCommon = `
 var _ = tflog.Warn
 type _ = diag.Diagnostics
+var _ = errors.ErrUnsupported
+
 type dgpReq struct {
 	XMLName xml.Name ` + "`" + `xml:"show"` + "`" + `
 	Cmd     string   ` + "`" + `xml:"dg-hierarchy"` + "`" + `

--- a/pkg/translate/terraform_provider/funcs.go
+++ b/pkg/translate/terraform_provider/funcs.go
@@ -3635,7 +3635,8 @@ func RenderResourceFuncMap(names map[string]properties.TerraformProviderSpecMeta
 
 		metadata := names[key]
 
-		if metadata.Flags&properties.TerraformSpecImportable == 0 {
+		// If the spec is either explicitly marked as non-importable, or spec only generates datasource don't generate import code
+		if metadata.Flags&properties.TerraformSpecImportable == 0 || metadata.Flags&properties.TerraformSpecResource == 0 {
 			continue
 		}
 

--- a/pkg/translate/terraform_provider/terraform_provider_file.go
+++ b/pkg/translate/terraform_provider/terraform_provider_file.go
@@ -377,9 +377,24 @@ func (g *GenerateTerraformProvider) GenerateTerraformDataSource(resourceTyp prop
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/types", "")
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/datasource", "")
 
+		terraformProvider.ImportManager.AddStandardImport("context", "")
+		terraformProvider.ImportManager.AddStandardImport("fmt", "")
+		terraformProvider.ImportManager.AddStandardImport("errors", "")
+		terraformProvider.ImportManager.AddSdkImport("github.com/PaloAltoNetworks/pango", "")
+		if spec.TerraformProviderConfig.ResourceType != properties.TerraformResourceCustom {
+			terraformProvider.ImportManager.AddOtherImport("github.com/PaloAltoNetworks/terraform-provider-panos/internal/manager", "sdkmanager")
+		}
+
 		conditionallyAddValidators(terraformProvider.ImportManager, spec)
 		conditionallyAddModifiers(terraformProvider.ImportManager, spec)
 
+		if !spec.GoSdkSkip {
+			terraformProvider.ImportManager.AddSdkImport(sdkPkgPath(spec), "")
+		}
+
+		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-log/tflog", "")
+		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/attr", "")
+		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/diag", "")
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/resource/schema", "rsschema")
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault", "")
 
@@ -465,12 +480,17 @@ func (g *GenerateTerraformProvider) GenerateCommonCode(resourceTyp properties.Re
 	// Imports required by resources that can be imported into state
 	switch resourceTyp {
 	case properties.ResourceEntry, properties.ResourceEntryPlural, properties.ResourceUuid, properties.ResourceUuidPlural:
-		terraformProvider.ImportManager.AddStandardImport("encoding/base64", "")
+		if !spec.TerraformProviderConfig.SkipResource {
+			terraformProvider.ImportManager.AddStandardImport("encoding/base64", "")
+		}
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/types/basetypes", "")
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/path", "")
 	case properties.ResourceConfig:
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/types/basetypes", "")
 	case properties.ResourceCustom:
+		if len(spec.Locations) > 0 {
+			terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/types/basetypes", "")
+		}
 	}
 
 	names := NewNameProvider(spec, resourceTyp)

--- a/specs/schema/object.schema.json
+++ b/specs/schema/object.schema.json
@@ -59,6 +59,13 @@
       "type": "object",
       "required": ["package"],
       "properties": {
+        "supported_methods": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["create", "read", "list", "update", "delete"]
+          }
+        },
         "generate": { "type": "boolean" },
         "package": {
           "type": "array",

--- a/templates/sdk/service.tmpl
+++ b/templates/sdk/service.tmpl
@@ -108,6 +108,9 @@ func (s *Service) Create(ctx context.Context, loc Location, config *Config) (*Co
   {{- end }}
 
 func (s *Service) {{ $funcDef }} {
+  {{- if not (SupportedMethod "create") }}
+	return errors.UnsupportedMethodError
+  {{- else }}
 	vn := s.client.Versioning()
 	specifier, _, err := Versioning(vn)
 	if err != nil {
@@ -135,6 +138,7 @@ func (s *Service) {{ $funcDef }} {
 	}
 
 	return nil
+  {{- end }}
 }
 
 {{- if .Imports }}
@@ -301,6 +305,9 @@ func (s *Service) UnimportFromLocations(ctx context.Context, loc Location, impor
     {{ $funcDef = "ReadWithXpath(ctx context.Context, xpath string, action string) (*Config, error)" }}
   {{- end }}
 func (s *Service) {{ $funcDef }} {
+{{- if not (SupportedMethod "read") }}
+	return errors.UnsupportedMethodError
+{{- else }}
 	vn := s.client.Versioning()
 	_, normalizer, err := Versioning(vn)
 	if err != nil {
@@ -328,6 +335,7 @@ func (s *Service) {{ $funcDef }} {
 	}
 
 	return list[0], nil
+{{- end }}
 }
 
   {{if .Entry}}
@@ -413,6 +421,9 @@ func (s *Service) UpdateWithXpath(ctx context.Context, xpath string, entry *{{ $
 {{- else }}
 func (s *Service) UpdateWithXpath(ctx context.Context, xpath string, entry *{{ $object }}) error {
 {{- end }}
+{{- if not (SupportedMethod "update") }}
+	return errors.UnsupportedMethodError
+{{- else }}
 	vn := s.client.Versioning()
 	updates := xmlapi.NewMultiConfig(2)
 	specifier, _, err := Versioning(vn)
@@ -496,6 +507,7 @@ func (s *Service) UpdateWithXpath(ctx context.Context, xpath string, entry *{{ $
 	}
 
 	return nil
+{{- end }}
 }
 
 // Delete deletes the given item.
@@ -548,6 +560,9 @@ func (s *Service) UpdateWithXpath(ctx context.Context, xpath string, entry *{{ $
 {{- else}}
     func (s *Service) delete(ctx context.Context, loc Location, config *Config) error {
 {{- end}}
+{{- if not (SupportedMethod "delete") }}
+	return errors.UnsupportedMethodError
+{{- else }}
 {{- if .Entry}}
     {{- if $.Spec.Params.uuid}}
         for _, value := range values {
@@ -676,6 +691,7 @@ return err
     }
     return nil
 {{- end}}
+{{- end }}
 }
 
 {{- if false }}
@@ -721,6 +737,9 @@ func (s *Service) list(ctx context.Context, loc Location, action, filter, quote 
 }
 
 func (s *Service) ListWithXpath(ctx context.Context, xpath string, action, filter, quote string) ([]*Entry, error) {
+{{- if not (SupportedMethod "list") }}
+	return errors.UnsupportedMethodError
+{{- else }}
 	var logic *filtering.Group
 	if filter != "" {
         	var err error
@@ -767,6 +786,7 @@ func (s *Service) ListWithXpath(ctx context.Context, xpath string, action, filte
     	}
 
 	return filtered, nil
+{{- end }}
 }
 
 {{- if $.Spec.Params.uuid}}


### PR DESCRIPTION
Some resources will become read-only even on the SDK side, for example device
certificates. This change allows some SDK CRUD methods (created, updated, read,
delete) to be marked as unimplemented, returning an error when called.