### PR TITLE
feat(gosdk): Add global locks manager to serialize some operations

### DIFF
--- a/assets/pango/locking/locking.go
+++ b/assets/pango/locking/locking.go
@@ -1,0 +1,64 @@
+package locking
+
+import (
+	"sync"
+)
+
+type LockCategory string
+
+const (
+	ImportFileLockCategory LockCategory = "import"
+	XpathLockCategory      LockCategory = "xpath"
+)
+
+type categoryLocks struct {
+	mutex *sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newCategoryLocks() *categoryLocks {
+	return &categoryLocks{
+		mutex: &sync.Mutex{},
+		locks: make(map[string]*sync.Mutex),
+	}
+}
+
+func (o *categoryLocks) getMutex(path string) *sync.Mutex {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	mutex, found := o.locks[path]
+	if !found {
+		mutex = &sync.Mutex{}
+		o.locks[path] = mutex
+	}
+
+	return mutex
+}
+
+type locksManager struct {
+	mutex      *sync.Mutex
+	categories map[LockCategory]*categoryLocks
+}
+
+func newLocksManager() *locksManager {
+	return &locksManager{
+		mutex:      &sync.Mutex{},
+		categories: make(map[LockCategory]*categoryLocks),
+	}
+}
+
+var manager = newLocksManager()
+
+func GetMutex(category LockCategory, path string) *sync.Mutex {
+	manager.mutex.Lock()
+	defer manager.mutex.Unlock()
+
+	categoryLocks, found := manager.categories[category]
+	if !found {
+		categoryLocks = newCategoryLocks()
+		manager.categories[category] = categoryLocks
+	}
+
+	return categoryLocks.getMutex(path)
+}

--- a/assets/terraform/test/resource_ethernet_interface_test.go
+++ b/assets/terraform/test/resource_ethernet_interface_test.go
@@ -12,6 +12,92 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
+func TestAccEthernetInterface_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: ethernetInterface_Concurrent_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+			},
+		},
+	})
+}
+
+const ethernetInterface_Concurrent_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+
+  name = var.prefix
+}
+
+resource "panos_ethernet_interface" "example1" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = "ethernet1/1"
+  layer3 = {}
+}
+
+resource "panos_ethernet_interface" "example2" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = "ethernet1/2"
+  layer3 = {}
+}
+
+resource "panos_ethernet_interface" "example3" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = "ethernet1/3"
+  layer3 = {}
+}
+
+resource "panos_ethernet_interface" "example4" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = "ethernet1/4"
+  layer3 = {}
+}
+
+resource "panos_ethernet_interface" "example5" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = "ethernet1/5"
+  layer3 = {}
+}
+
+resource "panos_ethernet_interface" "example6" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = "ethernet1/6"
+  layer3 = {}
+}
+`
+
 func TestAccPanosEthernetInterface_Layer3(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/translate/imports.go
+++ b/pkg/translate/imports.go
@@ -12,7 +12,7 @@ func RenderImports(spec *properties.Normalization, templateTypes ...string) (str
 	for _, templateType := range templateTypes {
 		switch templateType {
 		case "sync":
-			manager.AddStandardImport("sync", "")
+			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/locking", "")
 		case "config":
 			//manager.AddStandardImport("fmt", "")
 			manager.AddStandardImport("encoding/xml", "")

--- a/templates/sdk/service.tmpl
+++ b/templates/sdk/service.tmpl
@@ -22,28 +22,6 @@ package {{packageName .GoSdkPath}}
     {{- end}}
 {{- end}}
 
-{{- if and $.Imports .Entry }}
-var (
-	importsMutexMap     = make(map[string]*sync.Mutex)
-	importsMutexMapLock = sync.Mutex{}
-)
-
-func (s *Service) getImportMutex(xpath string) *sync.Mutex {
-	importsMutexMapLock.Lock()
-	defer importsMutexMapLock.Unlock()
-
-	var importMutex *sync.Mutex
-	var ok bool
-	importMutex, ok = importsMutexMap[xpath]
-	if !ok {
-		importMutex = &sync.Mutex{}
-		importsMutexMap[xpath] = importMutex
-	}
-
-	return importMutex
-}
-{{- end }}
-
 type Service struct {
 client util.PangoClient
 }
@@ -152,7 +130,7 @@ func (s *Service) ImportToLocations(ctx context.Context, loc Location, importLoc
 			return err
 		}
 
-		mutex := s.getImportMutex(util.AsXpath(xpath))
+		mutex := locking.GetMutex(locking.XpathLockCategory, util.AsXpath(xpath))
                 mutex.Lock()
                 defer mutex.Unlock()
 
@@ -221,7 +199,7 @@ func (s *Service) UnimportFromLocations(ctx context.Context, loc Location, impor
 			return err
 		}
 
-		mutex := s.getImportMutex(util.AsXpath(xpath))
+		mutex := locking.GetMutex(locking.XpathLockCategory, util.AsXpath(xpath))
                 mutex.Lock()
                 defer mutex.Unlock()
 


### PR DESCRIPTION
Some of the operations done across both Go SDK and terraform provider must be serialized in order to ensure consistent state on the device.
Introduce locking package with `locking.GetMutex(locking.LockCategory, string)` signature that allows us to request locks as needed from both Go SDK (e.g. for importing interfaces into virtual systems) and Terraform (e.g. for importing certificates).