### PR TITLE
feat(codegen): Add support for int64 member lists

### DIFF
--- a/assets/pango/util/comparison.go
+++ b/assets/pango/util/comparison.go
@@ -25,7 +25,7 @@ func UnorderedListsMatch(a, b []string) bool {
 	return true
 }
 
-func OrderedListsMatch(a, b []string) bool {
+func OrderedListsMatch[E comparable](a, b []E) bool {
 	if a == nil && b == nil {
 		return true
 	} else if a == nil || b == nil {

--- a/assets/pango/util/member.go
+++ b/assets/pango/util/member.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"encoding/xml"
+	"fmt"
+	"strconv"
 )
 
 // MemberType defines a member config node used for sending and receiving XML
@@ -31,6 +33,26 @@ func MemToStr(e *MemberType) []string {
 	return ans
 }
 
+var ErrEmptyMemberList = fmt.Errorf("a list had no member elements")
+
+// MemToInt64 normalizes a MemberType pointer into a list of int64 values.
+func MemToInt64(e *MemberType) ([]int64, error) {
+	if e == nil {
+		return nil, ErrEmptyMemberList
+	}
+
+	ans := make([]int64, len(e.Members))
+	for idx, elt := range e.Members {
+		if converted, err := strconv.ParseInt(elt.Value, 10, 64); err != nil {
+			return nil, err
+		} else {
+			ans[idx] = converted
+		}
+	}
+
+	return ans, nil
+}
+
 // StrToMem converts a list of strings into a MemberType pointer.
 func StrToMem(e []string) *MemberType {
 	if e == nil {
@@ -40,6 +62,20 @@ func StrToMem(e []string) *MemberType {
 	ans := make([]Member, len(e))
 	for i := range e {
 		ans[i] = Member{Value: e[i]}
+	}
+
+	return &MemberType{ans}
+}
+
+// Int64ToMem converts a list of int64 values into a MemberType pointer
+func Int64ToMem(e []int64) *MemberType {
+	if e == nil {
+		return nil
+	}
+
+	ans := make([]Member, len(e))
+	for idx, elt := range e {
+		ans[idx].Value = strconv.FormatInt(elt, 10)
 	}
 
 	return &MemberType{ans}

--- a/pkg/properties/normalized.go
+++ b/pkg/properties/normalized.go
@@ -1277,6 +1277,56 @@ func (spec *Normalization) ResourceXpathVariableChecks() (string, error) {
 	}
 
 	return buf.String(), nil
+
+}
+
+func hasParametersWithStrconv(spec *SpecParam) bool {
+	if spec.Type == "list" && spec.Items.Type == "int64" {
+		return true
+	}
+
+	if spec.Spec == nil {
+		return false
+	}
+
+	for _, elt := range spec.Spec.Params {
+		if hasParametersWithStrconv(elt) {
+			return true
+		}
+	}
+
+	for _, elt := range spec.Spec.OneOf {
+		if hasParametersWithStrconv(elt) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (spec *Normalization) HasParametersWithStrconv() bool {
+	for _, elt := range spec.Spec.Params {
+		if elt.Type == "list" && elt.Items.Type == "int64" {
+			return true
+		}
+
+		if hasParametersWithStrconv(elt) {
+			return true
+		}
+	}
+
+	for _, elt := range spec.Spec.OneOf {
+		if elt.Type == "list" && elt.Items.Type == "int64" {
+			return true
+		}
+
+		if hasParametersWithStrconv(elt) {
+			return true
+		}
+	}
+
+	return false
+
 }
 
 // Validate validations for specification (normalization) e.g. check if XPath contain /.

--- a/pkg/translate/imports.go
+++ b/pkg/translate/imports.go
@@ -26,6 +26,13 @@ func RenderImports(spec *properties.Normalization, templateTypes ...string) (str
 			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/generic", "")
 			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/util", "")
 			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/version", "")
+
+			if spec.Name == "global-protect-portal" && !spec.HasParametersWithStrconv() {
+				panic("WTF?")
+			}
+			if spec.HasParametersWithStrconv() {
+				manager.AddStandardImport("errors", "")
+			}
 		case "location":
 			manager.AddStandardImport("fmt", "")
 			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/errors", "")

--- a/pkg/translate/structs_test.go
+++ b/pkg/translate/structs_test.go
@@ -313,12 +313,22 @@ var _ = Describe("createEntryXmlStructSpecsForParameter", func() {
 				Profiles: []*properties.SpecParamProfile{{Type: "entry", Xpath: []string{"child-param"}}},
 				Spec: &properties.Spec{
 					Params: map[string]*properties.SpecParam{
-						"child-param": {
-							Name:     properties.NewNameVariant("child-param"),
-							Type:     "list",
-							Profiles: []*properties.SpecParamProfile{{Type: "member", Xpath: []string{"child-param"}}},
+						"child-param-string": {
+							Name:      properties.NewNameVariant("child-param-string"),
+							SpecOrder: 0,
+							Type:      "list",
+							Profiles:  []*properties.SpecParamProfile{{Type: "member", Xpath: []string{"child-param-string"}}},
 							Items: &properties.SpecParamItems{
 								Type: "string",
+							},
+						},
+						"child-param-int64": {
+							Name:      properties.NewNameVariant("child-param-int64"),
+							SpecOrder: 1,
+							Type:      "list",
+							Profiles:  []*properties.SpecParamProfile{{Type: "member", Xpath: []string{"child-param-int64"}}},
+							Items: &properties.SpecParamItems{
+								Type: "int64",
 							},
 						},
 					},
@@ -331,13 +341,22 @@ var _ = Describe("createEntryXmlStructSpecsForParameter", func() {
 			Expect(result[0].StructName()).To(Equal("ParentParam"))
 			Expect(result[0].XmlStructName()).To(Equal("parentParamXml"))
 			Expect(result[0].Fields[0]).To(Equal(entryStructFieldContext{
-				Name:         properties.NewNameVariant("child-param"),
+				Name:         properties.NewNameVariant("child-param-string"),
 				FieldType:    "list-member",
 				Type:         "string",
 				ItemsType:    "[]string",
 				XmlType:      "util.Member",
 				ItemsXmlType: "util.MemberType",
-				Tags:         "`xml:\"child-param,omitempty\"`",
+				Tags:         "`xml:\"child-param-string,omitempty\"`",
+			}))
+			Expect(result[0].Fields[1]).To(Equal(entryStructFieldContext{
+				Name:         properties.NewNameVariant("child-param-int64"),
+				FieldType:    "list-member",
+				Type:         "int64",
+				ItemsType:    "[]int64",
+				XmlType:      "util.Member",
+				ItemsXmlType: "util.MemberType",
+				Tags:         "`xml:\"child-param-int64,omitempty\"`",
 			}))
 		})
 	})


### PR DESCRIPTION
Some resources defined in XML schema describe lists of fundamental int64 types. Improve codegen to properly generate structures and marshalling & unmarshalling for int64 lists and add util helpers to convert from Go types to MemberType objects.