### PR TITLE
fix(codegen): Fix location xpath components for panos_xpath without variables

### DIFF
--- a/templates/sdk/location.tmpl
+++ b/templates/sdk/location.tmpl
@@ -102,9 +102,7 @@ func (o Location) XpathWithComponents(vn version.Number, components ...string) (
 		return nil, err
 	}
 
-	{{- if ge .ResourceXpathVariablesCount 1 }}
   	{{ .ResourceXpathAssignments }}
-        {{- end }}
 
 	return ans, nil
 }


### PR DESCRIPTION
Not all specs have variables within panos_xpath object, for example config specs don't have a name variable, but can have panos_xpath.path elements.