### PR TITLE
fix(terraform): delete config resources by updating them with an empty object

### DIFF
--- a/assets/pango/errors/panos.go
+++ b/assets/pango/errors/panos.go
@@ -15,6 +15,7 @@ var RelativePositionWithRemoveEverythingElseError = stderr.New("cannot do relati
 var UnrecognizedOperatorError = stderr.New("unsupported filter operator")
 var UnsupportedFilterTypeError = stderr.New("unsupported type for filtering")
 var UuidNotSpecifiedError = stderr.New("uuid is not specified")
+var UnsupportedMethodError = stderr.New("method is not supported")
 
 // Panos is an error returned from PAN-OS.
 //

--- a/assets/pango/locking/locking.go
+++ b/assets/pango/locking/locking.go
@@ -1,0 +1,64 @@
+package locking
+
+import (
+	"sync"
+)
+
+type LockCategory string
+
+const (
+	ImportFileLockCategory LockCategory = "import"
+	XpathLockCategory      LockCategory = "xpath"
+)
+
+type categoryLocks struct {
+	mutex *sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newCategoryLocks() *categoryLocks {
+	return &categoryLocks{
+		mutex: &sync.Mutex{},
+		locks: make(map[string]*sync.Mutex),
+	}
+}
+
+func (o *categoryLocks) getMutex(path string) *sync.Mutex {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	mutex, found := o.locks[path]
+	if !found {
+		mutex = &sync.Mutex{}
+		o.locks[path] = mutex
+	}
+
+	return mutex
+}
+
+type locksManager struct {
+	mutex      *sync.Mutex
+	categories map[LockCategory]*categoryLocks
+}
+
+func newLocksManager() *locksManager {
+	return &locksManager{
+		mutex:      &sync.Mutex{},
+		categories: make(map[LockCategory]*categoryLocks),
+	}
+}
+
+var manager = newLocksManager()
+
+func GetMutex(category LockCategory, path string) *sync.Mutex {
+	manager.mutex.Lock()
+	defer manager.mutex.Unlock()
+
+	categoryLocks, found := manager.categories[category]
+	if !found {
+		categoryLocks = newCategoryLocks()
+		manager.categories[category] = categoryLocks
+	}
+
+	return categoryLocks.getMutex(path)
+}

--- a/assets/terraform/test/resource_ethernet_interface_test.go
+++ b/assets/terraform/test/resource_ethernet_interface_test.go
@@ -12,6 +12,92 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
+func TestAccEthernetInterface_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: ethernetInterface_Concurrent_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+			},
+		},
+	})
+}
+
+const ethernetInterface_Concurrent_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+
+  name = var.prefix
+}
+
+resource "panos_ethernet_interface" "example1" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = "ethernet1/1"
+  layer3 = {}
+}
+
+resource "panos_ethernet_interface" "example2" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = "ethernet1/2"
+  layer3 = {}
+}
+
+resource "panos_ethernet_interface" "example3" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = "ethernet1/3"
+  layer3 = {}
+}
+
+resource "panos_ethernet_interface" "example4" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = "ethernet1/4"
+  layer3 = {}
+}
+
+resource "panos_ethernet_interface" "example5" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = "ethernet1/5"
+  layer3 = {}
+}
+
+resource "panos_ethernet_interface" "example6" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = "ethernet1/6"
+  layer3 = {}
+}
+`
+
 func TestAccPanosEthernetInterface_Layer3(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/paloaltonetworks/pan-os-codegen/pkg/naming"
 	"github.com/paloaltonetworks/pan-os-codegen/pkg/properties"
+	"github.com/paloaltonetworks/pan-os-codegen/pkg/schema/object"
 	codegentmpl "github.com/paloaltonetworks/pan-os-codegen/pkg/template"
 	"github.com/paloaltonetworks/pan-os-codegen/pkg/translate"
 	"github.com/paloaltonetworks/pan-os-codegen/pkg/translate/terraform_provider"
@@ -254,6 +255,7 @@ func (c *Creator) parseTemplate(templateName string) (*template.Template, error)
 		"renderImports": func(templateTypes ...string) (string, error) {
 			return translate.RenderImports(c.Spec, templateTypes...)
 		},
+		"SupportedMethod":           func(method object.GoSdkMethod) bool { return c.Spec.SupportedMethod(method) },
 		"RenderEntryImportStructs":  func() (string, error) { return translate.RenderEntryImportStructs(c.Spec) },
 		"packageName":               translate.PackageName,
 		"locationType":              translate.LocationType,

--- a/pkg/properties/normalized.go
+++ b/pkg/properties/normalized.go
@@ -26,6 +26,7 @@ type Normalization struct {
 	TerraformProviderConfig TerraformProviderConfig `json:"terraform_provider_config" yaml:"terraform_provider_config"`
 	GoSdkSkip               bool                    `json:"go_sdk_skip" yaml:"go_sdk_skip"`
 	GoSdkPath               []string                `json:"go_sdk_path" yaml:"go_sdk_path"`
+	GoSdkSupportedMethods   []object.GoSdkMethod    `json:"go_sdk_supported_methods" yaml:"go_sdk_supported_methods"`
 	PanosXpath              PanosXpath              `json:"panos_xpath" yaml:"panos_xpath"`
 	Locations               map[string]*Location    `json:"locations" yaml:"locations"`
 	Entry                   *Entry                  `json:"entry" yaml:"entry"`
@@ -701,11 +702,12 @@ func schemaToSpec(object object.Object) (*Normalization, error) {
 			PluralType:            object.TerraformConfig.PluralType,
 			PluralDescription:     object.TerraformConfig.PluralDescription,
 		},
-		Locations:  make(map[string]*Location),
-		GoSdkSkip:  object.GoSdkConfig.Skip,
-		GoSdkPath:  object.GoSdkConfig.Package,
-		PanosXpath: panosXpath,
-		Version:    object.Version,
+		Locations:             make(map[string]*Location),
+		GoSdkSkip:             object.GoSdkConfig.Skip,
+		GoSdkPath:             object.GoSdkConfig.Package,
+		GoSdkSupportedMethods: object.GoSdkConfig.SupportedMethods,
+		PanosXpath:            panosXpath,
+		Version:               object.Version,
 		Spec: &Spec{
 			Params: make(map[string]*SpecParam),
 			OneOf:  make(map[string]*SpecParam),
@@ -920,6 +922,10 @@ func ParseSpec(input []byte) (*Normalization, error) {
 	}
 
 	return spec, err
+}
+
+func (spec *Normalization) SupportedMethod(method object.GoSdkMethod) bool {
+	return slices.Contains(spec.GoSdkSupportedMethods, method)
 }
 
 func (spec *Normalization) OrderedLocations() []*Location {

--- a/pkg/schema/object/object.go
+++ b/pkg/schema/object/object.go
@@ -51,9 +51,20 @@ type TerraformConfig struct {
 	PluralDescription     string                     `yaml:"plural_description"`
 }
 
+type GoSdkMethod string
+
+const (
+	GoSdkMethodCreate = "create"
+	GoSdkMethodUpdate = "update"
+	GoSdkMethodDelete = "delete"
+	GoSdkMethodRead   = "read"
+	GoSdkMethodList   = "list"
+)
+
 type GoSdkConfig struct {
-	Skip    bool     `yaml:"skip"`
-	Package []string `yaml:"package"`
+	Skip             bool          `yaml:"skip"`
+	SupportedMethods []GoSdkMethod `yaml:"supported_methods"`
+	Package          []string      `yaml:"package"`
 }
 
 type Entry struct {
@@ -111,8 +122,19 @@ func (o *Object) UnmarshalYAML(n *yaml.Node) error {
 	}
 
 	obj := &S{O: (*O)(o)}
+
 	if err := n.Decode(obj); err != nil {
 		return err
+	}
+
+	if o.GoSdkConfig == nil || o.GoSdkConfig.SupportedMethods == nil {
+		o.GoSdkConfig.SupportedMethods = []GoSdkMethod{
+			GoSdkMethodCreate,
+			GoSdkMethodDelete,
+			GoSdkMethodRead,
+			GoSdkMethodList,
+			GoSdkMethodUpdate,
+		}
 	}
 
 	switch obj.TerraformConfig.ResourceType {

--- a/pkg/translate/imports.go
+++ b/pkg/translate/imports.go
@@ -12,7 +12,7 @@ func RenderImports(spec *properties.Normalization, templateTypes ...string) (str
 	for _, templateType := range templateTypes {
 		switch templateType {
 		case "sync":
-			manager.AddStandardImport("sync", "")
+			manager.AddSdkImport("github.com/PaloAltoNetworks/pango/locking", "")
 		case "config":
 			//manager.AddStandardImport("fmt", "")
 			manager.AddStandardImport("encoding/xml", "")

--- a/pkg/translate/terraform_provider/device_group_parent_crud.go
+++ b/pkg/translate/terraform_provider/device_group_parent_crud.go
@@ -4,8 +4,6 @@ const deviceGroupParentImports = `
 import (
   "encoding/xml"
 
-  "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-
   sdkerrors "github.com/PaloAltoNetworks/pango/errors"
   "github.com/PaloAltoNetworks/pango/util"
   "github.com/PaloAltoNetworks/pango/xmlapi"
@@ -15,6 +13,8 @@ import (
 const deviceGroupParentCommon = `
 var _ = tflog.Warn
 type _ = diag.Diagnostics
+var _ = errors.ErrUnsupported
+
 type dgpReq struct {
 	XMLName xml.Name ` + "`" + `xml:"show"` + "`" + `
 	Cmd     string   ` + "`" + `xml:"dg-hierarchy"` + "`" + `

--- a/pkg/translate/terraform_provider/funcs.go
+++ b/pkg/translate/terraform_provider/funcs.go
@@ -3635,8 +3635,7 @@ func RenderResourceFuncMap(names map[string]properties.TerraformProviderSpecMeta
 
 		metadata := names[key]
 
-		// If the spec is either explicitly marked as non-importable, or spec only generates datasource don't generate import code
-		if metadata.Flags&properties.TerraformSpecImportable == 0 || metadata.Flags&properties.TerraformSpecResource == 0 {
+		if metadata.Flags&properties.TerraformSpecImportable == 0 {
 			continue
 		}
 

--- a/pkg/translate/terraform_provider/funcs.go
+++ b/pkg/translate/terraform_provider/funcs.go
@@ -3635,7 +3635,8 @@ func RenderResourceFuncMap(names map[string]properties.TerraformProviderSpecMeta
 
 		metadata := names[key]
 
-		if metadata.Flags&properties.TerraformSpecImportable == 0 {
+		// If the spec is either explicitly marked as non-importable, or spec only generates datasource don't generate import code
+		if metadata.Flags&properties.TerraformSpecImportable == 0 || metadata.Flags&properties.TerraformSpecResource == 0 {
 			continue
 		}
 

--- a/pkg/translate/terraform_provider/terraform_provider_file.go
+++ b/pkg/translate/terraform_provider/terraform_provider_file.go
@@ -377,9 +377,24 @@ func (g *GenerateTerraformProvider) GenerateTerraformDataSource(resourceTyp prop
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/types", "")
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/datasource", "")
 
+		terraformProvider.ImportManager.AddStandardImport("context", "")
+		terraformProvider.ImportManager.AddStandardImport("fmt", "")
+		terraformProvider.ImportManager.AddStandardImport("errors", "")
+		terraformProvider.ImportManager.AddSdkImport("github.com/PaloAltoNetworks/pango", "")
+		if spec.TerraformProviderConfig.ResourceType != properties.TerraformResourceCustom {
+			terraformProvider.ImportManager.AddOtherImport("github.com/PaloAltoNetworks/terraform-provider-panos/internal/manager", "sdkmanager")
+		}
+
 		conditionallyAddValidators(terraformProvider.ImportManager, spec)
 		conditionallyAddModifiers(terraformProvider.ImportManager, spec)
 
+		if !spec.GoSdkSkip {
+			terraformProvider.ImportManager.AddSdkImport(sdkPkgPath(spec), "")
+		}
+
+		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-log/tflog", "")
+		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/attr", "")
+		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/diag", "")
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/resource/schema", "rsschema")
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault", "")
 
@@ -465,12 +480,17 @@ func (g *GenerateTerraformProvider) GenerateCommonCode(resourceTyp properties.Re
 	// Imports required by resources that can be imported into state
 	switch resourceTyp {
 	case properties.ResourceEntry, properties.ResourceEntryPlural, properties.ResourceUuid, properties.ResourceUuidPlural:
-		terraformProvider.ImportManager.AddStandardImport("encoding/base64", "")
+		if !spec.TerraformProviderConfig.SkipResource {
+			terraformProvider.ImportManager.AddStandardImport("encoding/base64", "")
+		}
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/types/basetypes", "")
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/path", "")
 	case properties.ResourceConfig:
 		terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/types/basetypes", "")
 	case properties.ResourceCustom:
+		if len(spec.Locations) > 0 {
+			terraformProvider.ImportManager.AddHashicorpImport("github.com/hashicorp/terraform-plugin-framework/types/basetypes", "")
+		}
 	}
 
 	names := NewNameProvider(spec, resourceTyp)

--- a/specs/schema/object.schema.json
+++ b/specs/schema/object.schema.json
@@ -59,6 +59,13 @@
       "type": "object",
       "required": ["package"],
       "properties": {
+        "supported_methods": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["create", "read", "list", "update", "delete"]
+          }
+        },
         "generate": { "type": "boolean" },
         "package": {
           "type": "array",

--- a/templates/sdk/location.tmpl
+++ b/templates/sdk/location.tmpl
@@ -102,9 +102,7 @@ func (o Location) XpathWithComponents(vn version.Number, components ...string) (
 		return nil, err
 	}
 
-	{{- if ge .ResourceXpathVariablesCount 1 }}
   	{{ .ResourceXpathAssignments }}
-        {{- end }}
 
 	return ans, nil
 }

--- a/templates/sdk/service.tmpl
+++ b/templates/sdk/service.tmpl
@@ -22,28 +22,6 @@ package {{packageName .GoSdkPath}}
     {{- end}}
 {{- end}}
 
-{{- if and $.Imports .Entry }}
-var (
-	importsMutexMap     = make(map[string]*sync.Mutex)
-	importsMutexMapLock = sync.Mutex{}
-)
-
-func (s *Service) getImportMutex(xpath string) *sync.Mutex {
-	importsMutexMapLock.Lock()
-	defer importsMutexMapLock.Unlock()
-
-	var importMutex *sync.Mutex
-	var ok bool
-	importMutex, ok = importsMutexMap[xpath]
-	if !ok {
-		importMutex = &sync.Mutex{}
-		importsMutexMap[xpath] = importMutex
-	}
-
-	return importMutex
-}
-{{- end }}
-
 type Service struct {
 client util.PangoClient
 }
@@ -152,7 +130,7 @@ func (s *Service) ImportToLocations(ctx context.Context, loc Location, importLoc
 			return err
 		}
 
-		mutex := s.getImportMutex(util.AsXpath(xpath))
+		mutex := locking.GetMutex(locking.XpathLockCategory, util.AsXpath(xpath))
                 mutex.Lock()
                 defer mutex.Unlock()
 
@@ -221,7 +199,7 @@ func (s *Service) UnimportFromLocations(ctx context.Context, loc Location, impor
 			return err
 		}
 
-		mutex := s.getImportMutex(util.AsXpath(xpath))
+		mutex := locking.GetMutex(locking.XpathLockCategory, util.AsXpath(xpath))
                 mutex.Lock()
                 defer mutex.Unlock()
 

--- a/templates/sdk/service.tmpl
+++ b/templates/sdk/service.tmpl
@@ -108,6 +108,9 @@ func (s *Service) Create(ctx context.Context, loc Location, config *Config) (*Co
   {{- end }}
 
 func (s *Service) {{ $funcDef }} {
+  {{- if not (SupportedMethod "create") }}
+	return errors.UnsupportedMethodError
+  {{- else }}
 	vn := s.client.Versioning()
 	specifier, _, err := Versioning(vn)
 	if err != nil {
@@ -135,6 +138,7 @@ func (s *Service) {{ $funcDef }} {
 	}
 
 	return nil
+  {{- end }}
 }
 
 {{- if .Imports }}
@@ -301,6 +305,9 @@ func (s *Service) UnimportFromLocations(ctx context.Context, loc Location, impor
     {{ $funcDef = "ReadWithXpath(ctx context.Context, xpath string, action string) (*Config, error)" }}
   {{- end }}
 func (s *Service) {{ $funcDef }} {
+{{- if not (SupportedMethod "read") }}
+	return errors.UnsupportedMethodError
+{{- else }}
 	vn := s.client.Versioning()
 	_, normalizer, err := Versioning(vn)
 	if err != nil {
@@ -328,6 +335,7 @@ func (s *Service) {{ $funcDef }} {
 	}
 
 	return list[0], nil
+{{- end }}
 }
 
   {{if .Entry}}
@@ -413,6 +421,9 @@ func (s *Service) UpdateWithXpath(ctx context.Context, xpath string, entry *{{ $
 {{- else }}
 func (s *Service) UpdateWithXpath(ctx context.Context, xpath string, entry *{{ $object }}) error {
 {{- end }}
+{{- if not (SupportedMethod "update") }}
+	return errors.UnsupportedMethodError
+{{- else }}
 	vn := s.client.Versioning()
 	updates := xmlapi.NewMultiConfig(2)
 	specifier, _, err := Versioning(vn)
@@ -496,6 +507,7 @@ func (s *Service) UpdateWithXpath(ctx context.Context, xpath string, entry *{{ $
 	}
 
 	return nil
+{{- end }}
 }
 
 // Delete deletes the given item.
@@ -548,6 +560,9 @@ func (s *Service) UpdateWithXpath(ctx context.Context, xpath string, entry *{{ $
 {{- else}}
     func (s *Service) delete(ctx context.Context, loc Location, config *Config) error {
 {{- end}}
+{{- if not (SupportedMethod "delete") }}
+	return errors.UnsupportedMethodError
+{{- else }}
 {{- if .Entry}}
     {{- if $.Spec.Params.uuid}}
         for _, value := range values {
@@ -676,6 +691,7 @@ return err
     }
     return nil
 {{- end}}
+{{- end }}
 }
 
 {{- if false }}
@@ -721,6 +737,9 @@ func (s *Service) list(ctx context.Context, loc Location, action, filter, quote 
 }
 
 func (s *Service) ListWithXpath(ctx context.Context, xpath string, action, filter, quote string) ([]*Entry, error) {
+{{- if not (SupportedMethod "list") }}
+	return errors.UnsupportedMethodError
+{{- else }}
 	var logic *filtering.Group
 	if filter != "" {
         	var err error
@@ -767,6 +786,7 @@ func (s *Service) ListWithXpath(ctx context.Context, xpath string, action, filte
     	}
 
 	return filtered, nil
+{{- end }}
 }
 
 {{- if $.Spec.Params.uuid}}


### PR DESCRIPTION
Config resources can be nested within other resources, and can have xml nodes that
are not part of config structures, and deleting single config object from the server
can remove unrelated configuration.

Instead, fetch existing configuration for the given xpath from the device, and send
back an empty objects, keeping only Misc to make sure anything not managed by this object
is kept as-is.