### PR TITLE
feat(specs): Unify locations for dns and ntp specs

### DIFF
--- a/specs/device/dns.yaml
+++ b/specs/device/dns.yaml
@@ -16,7 +16,9 @@ go_sdk_config:
   - services
   - dns
 panos_xpath:
-  path: []
+  path:
+  - deviceconfig
+  - system
   vars: []
 locations:
 - name: system
@@ -24,17 +26,15 @@ locations:
     path:
     - config
     - devices
-    - $ngfw_device
-    - deviceconfig
-    - system
+    - $device
     vars:
-    - name: ngfw_device
-      description: The NGFW device.
+    - name: device
+      description: Device
       required: false
       default: localhost.localdomain
       validators: []
       type: entry
-  description: Located in a system settings.
+  description: System-level configuration
   devices:
   - panorama
   - ngfw
@@ -52,27 +52,25 @@ locations:
     - config
     - devices
     - $ngfw_device
-    - deviceconfig
-    - system
     vars:
     - name: panorama_device
-      description: The panorama device.
+      description: Specific Panorama device
       required: false
       default: localhost.localdomain
       validators: []
       type: entry
     - name: template
-      description: The template.
+      description: Specific Panorama template
       required: true
       validators: []
       type: entry
     - name: ngfw_device
-      description: The NGFW device.
+      description: The NGFW device
       required: false
       default: localhost.localdomain
       validators: []
       type: entry
-  description: Located in a specific template.
+  description: Located in a specific template
   devices:
   - panorama
   validators: []
@@ -89,27 +87,25 @@ locations:
     - config
     - devices
     - $ngfw_device
-    - deviceconfig
-    - system
     vars:
     - name: panorama_device
-      description: The panorama device.
+      description: Specific Panorama device
       required: false
       default: localhost.localdomain
       validators: []
       type: entry
     - name: template_stack
-      description: The template stack.
+      description: Specific Panorama template stack
       required: true
       validators: []
       type: entry
     - name: ngfw_device
-      description: The NGFW device.
+      description: The NGFW device
       required: false
       default: localhost.localdomain
       validators: []
       type: entry
-  description: Located in a specific template stack.
+  description: Located in a specific template stack
   devices:
   - panorama
   validators: []

--- a/specs/device/ntp.yaml
+++ b/specs/device/ntp.yaml
@@ -16,7 +16,9 @@ go_sdk_config:
   - services
   - ntp
 panos_xpath:
-  path: []
+  path:
+  - deviceconfig
+  - system
   vars: []
 locations:
 - name: system
@@ -24,17 +26,15 @@ locations:
     path:
     - config
     - devices
-    - $ngfw_device
-    - deviceconfig
-    - system
+    - $device
     vars:
-    - name: ngfw_device
-      description: The NGFW device.
+    - name: device
+      description: Device
       required: false
       default: localhost.localdomain
       validators: []
       type: entry
-  description: Located in a system settings.
+  description: System-level configuration
   devices:
   - panorama
   - ngfw
@@ -52,27 +52,25 @@ locations:
     - config
     - devices
     - $ngfw_device
-    - deviceconfig
-    - system
     vars:
     - name: panorama_device
-      description: The panorama device.
+      description: Specific Panorama device
       required: false
       default: localhost.localdomain
       validators: []
       type: entry
     - name: template
-      description: The template.
+      description: Specific Panorama template
       required: true
       validators: []
       type: entry
     - name: ngfw_device
-      description: The NGFW device.
+      description: The NGFW device
       required: false
       default: localhost.localdomain
       validators: []
       type: entry
-  description: Located in a specific template.
+  description: Located in a specific template
   devices:
   - panorama
   validators: []
@@ -89,27 +87,25 @@ locations:
     - config
     - devices
     - $ngfw_device
-    - deviceconfig
-    - system
     vars:
     - name: panorama_device
-      description: The panorama device.
+      description: Specific Panorama device
       required: false
       default: localhost.localdomain
       validators: []
       type: entry
     - name: template_stack
-      description: The template stack.
+      description: Specific Panorama template stack
       required: true
       validators: []
       type: entry
     - name: ngfw_device
-      description: The NGFW device.
+      description: The NGFW device
       required: false
       default: localhost.localdomain
       validators: []
       type: entry
-  description: Located in a specific template stack.
+  description: Located in a specific template stack
   devices:
   - panorama
   validators: []


### PR DESCRIPTION
This will put both specs in line with an upcoming general settings spec

---

**Stack**:
- #515
- #514 ⬅
- #513
- #512
- #511
- #510


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*