### PR TITLE
fix(gosdk): change signature of ImportFile to accept content as []byte and set Content-Type during ExportFile

### DIFF
--- a/assets/pango/client.go
+++ b/assets/pango/client.go
@@ -971,7 +971,7 @@ func (c *Client) Communicate(ctx context.Context, cmd util.PangoCommand, strip b
 }
 
 // ImportFile imports the given file into PAN-OS.
-func (c *Client) ImportFile(ctx context.Context, cmd *xmlapi.Import, content, filename, fp string, strip bool, ans any) ([]byte, *http.Response, error) {
+func (c *Client) ImportFile(ctx context.Context, cmd *xmlapi.Import, content []byte, filename, fp string, strip bool, ans any) ([]byte, *http.Response, error) {
 	if cmd == nil {
 		return nil, nil, fmt.Errorf("cmd is nil")
 	}
@@ -1002,7 +1002,7 @@ func (c *Client) ImportFile(ctx context.Context, cmd *xmlapi.Import, content, fi
 		return nil, nil, err
 	}
 
-	if _, err = io.Copy(w2, strings.NewReader(content)); err != nil {
+	if _, err = io.Copy(w2, bytes.NewReader(content)); err != nil {
 		return nil, nil, err
 	}
 
@@ -1037,6 +1037,8 @@ func (c *Client) ExportFile(ctx context.Context, cmd *xmlapi.Export, ans any) (s
 	if err != nil {
 		return "", nil, nil, err
 	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	b, resp, err := c.sendRequest(ctx, req, false, ans)
 	if err != nil {

--- a/assets/pango/util/pangoclient.go
+++ b/assets/pango/util/pangoclient.go
@@ -34,7 +34,7 @@ type PangoClient interface {
 
 	// Specialized communication functions around specific XPI API commands.
 	MultiConfig(context.Context, *xmlapi.MultiConfig, bool, url.Values) ([]byte, *http.Response, *xmlapi.MultiConfigResponse, error)
-	ImportFile(context.Context, *xmlapi.Import, string, string, string, bool, any) ([]byte, *http.Response, error)
+	ImportFile(context.Context, *xmlapi.Import, []byte, string, string, bool, any) ([]byte, *http.Response, error)
 	ExportFile(context.Context, *xmlapi.Export, any) (string, []byte, *http.Response, error)
 
 	// Operational functions in use by one or more resources / data sources / namespaces.


### PR DESCRIPTION
ImportFile signature accepted file content as utf-8 string, which would not work properly for
import binary files (like pkcs12 certificate bundles). Change the signature to take []byte array instead.

ExportFile was not setting Content-Type for HTTP request, which would break exporting of files.

---

**Stack**:
- #519 ⬅
- #518
- #517
- #516


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*