### PR TITLE
fix(terraform): fix type casting panic within ephemeral resources

### DIFF
--- a/assets/terraform/test/ephemeral_vm_auth_key_test.go
+++ b/assets/terraform/test/ephemeral_vm_auth_key_test.go
@@ -1,0 +1,38 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+)
+
+func TestAccEphemeralVmAuthKey_Sanity(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: ephemeralVmAuthKey_Sanity_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{},
+			},
+		},
+	})
+}
+
+const ephemeralVmAuthKey_Sanity_Tmpl = `
+ephemeral "panos_vm_auth_key" "example" {
+  lifetime = 1
+}
+`

--- a/pkg/translate/terraform_provider/template.go
+++ b/pkg/translate/terraform_provider/template.go
@@ -2251,7 +2251,7 @@ func (p *PanosProvider) Configure(ctx context.Context, req provider.ConfigureReq
 
 	resp.DataSourceData = providerData
 	resp.ResourceData = providerData
-	resp.EphemeralResourceData = con
+	resp.EphemeralResourceData = providerData
 
 	// Done.
 	tflog.Info(ctx, "Configured client", map[string]any{"success": true})


### PR DESCRIPTION
Make sure we pass the expected ProviderData object and not the client to ephemeral resources