### PR TITLE
fix(specs): add missing ngfw location to logical router

### DIFF
--- a/specs/network/logical-router.yaml
+++ b/specs/network/logical-router.yaml
@@ -123,6 +123,25 @@ locations:
   validators: []
   required: false
   read_only: false
+- name: ngfw
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific NGFW device
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
 entries:
 - name: name
   description: ''


### PR DESCRIPTION
Closes PaloAltoNetworks/terraform-provider-panos#481