### PR TITLE
feat(codegen): Add MiscAttributes field to gather unprocessed XML attributes

### DIFF
--- a/pkg/translate/structs.go
+++ b/pkg/translate/structs.go
@@ -729,13 +729,22 @@ func createEntryXmlStructSpecsForParameter(structTyp structType, parentPrefix *p
 		processParameter(prefixName, elt)
 	}
 
-	fields = append(fields, entryStructFieldContext{
-		Name:      properties.NewNameVariant("misc"),
-		FieldType: "internal",
-		Type:      "[]generic.Xml",
-		XmlType:   "[]generic.Xml",
-		Tags:      "`xml:\",any\"`",
-	})
+	fields = append(fields, []entryStructFieldContext{
+		{
+			Name:      properties.NewNameVariant("misc"),
+			FieldType: "internal",
+			Type:      "[]generic.Xml",
+			XmlType:   "[]generic.Xml",
+			Tags:      "`xml:\",any\"`",
+		},
+		{
+			Name:      properties.NewNameVariant("misc-attributes"),
+			FieldType: "internal",
+			Type:      "[]xml.Attr",
+			XmlType:   "[]xml.Attr",
+			Tags:      "`xml:\",any,attr\"`",
+		},
+	}...)
 
 	name := parentPrefix.WithSuffix(param.PangoNameVariant())
 	entries = append([]entryStructContext{{
@@ -835,13 +844,22 @@ func creasteStructSpecsForNormalization(structTyp structType, parentPrefix *prop
 		processParameter(parentPrefix, elt)
 	}
 
-	fields = append(fields, entryStructFieldContext{
-		Name:      properties.NewNameVariant("misc"),
-		FieldType: "internal",
-		Type:      "[]generic.Xml",
-		XmlType:   "[]generic.Xml",
-		Tags:      "`xml:\",any\"`",
-	})
+	fields = append(fields, []entryStructFieldContext{
+		{
+			Name:      properties.NewNameVariant("misc"),
+			FieldType: "internal",
+			Type:      "[]generic.Xml",
+			XmlType:   "[]generic.Xml",
+			Tags:      "`xml:\",any\"`",
+		},
+		{
+			Name:      properties.NewNameVariant("misc-attributes"),
+			FieldType: "internal",
+			Type:      "[]xml.Attr",
+			XmlType:   "[]xml.Attr",
+			Tags:      "`xml:\",any,attr\"`",
+		},
+	}...)
 
 	var name *properties.NameVariant
 	switch spec.TerraformProviderConfig.ResourceType {
@@ -1178,6 +1196,7 @@ func (o *{{ .StructName }}) matches(other *{{ .StructName }}) bool {
     {{- if .IsInternal }}{{ continue }}{{ end }}
     {{- if and $spec.TopLevel (eq .Name.CamelCase "Name") }}{{ continue }}{{ end }}
     {{- if eq .Name.CamelCase "Misc" }}{{ continue }}{{ end }}
+    {{- if eq .Name.CamelCase "MiscAttributes" }}{{ continue }}{{ end }}
     {{- if eq .FieldType "object" }}
 	if !o.{{ .Name.CamelCase }}.matches(other.{{ .Name.CamelCase }}) {
 		return false

--- a/pkg/translate/structs_test.go
+++ b/pkg/translate/structs_test.go
@@ -462,6 +462,13 @@ var _ = Describe("createEntryXmlStructSpecsForParameter", func() {
 					XmlType:   "[]generic.Xml",
 					Tags:      "`xml:\",any\"`",
 				},
+				{
+					Name:      properties.NewNameVariant("misc-attributes"),
+					FieldType: "internal",
+					Type:      "[]xml.Attr",
+					XmlType:   "[]xml.Attr",
+					Tags:      "`xml:\",any,attr\"`",
+				},
 			}))
 		})
 	})
@@ -528,6 +535,13 @@ var _ = Describe("createEntryXmlStructSpecsForParameter", func() {
 					Type:      "[]generic.Xml",
 					XmlType:   "[]generic.Xml",
 					Tags:      "`xml:\",any\"`",
+				},
+				{
+					Name:      properties.NewNameVariant("misc-attributes"),
+					FieldType: "internal",
+					Type:      "[]xml.Attr",
+					XmlType:   "[]xml.Attr",
+					Tags:      "`xml:\",any,attr\"`",
 				},
 			}))
 
@@ -600,6 +614,13 @@ var _ = Describe("createEntryXmlStructSpecsForParameter", func() {
 					XmlType:   "[]generic.Xml",
 					Tags:      "`xml:\",any\"`",
 				},
+				{
+					Name:      properties.NewNameVariant("misc-attributes"),
+					FieldType: "internal",
+					Type:      "[]xml.Attr",
+					XmlType:   "[]xml.Attr",
+					Tags:      "`xml:\",any,attr\"`",
+				},
 			}))
 
 			Expect(result[1].StructName()).To(Equal("ParentParamChildParam1"))
@@ -647,6 +668,13 @@ var _ = Describe("createStructSpecs", func() {
 					Type:      "[]generic.Xml",
 					XmlType:   "[]generic.Xml",
 					Tags:      "`xml:\",any\"`",
+				},
+				{
+					Name:      properties.NewNameVariant("misc-attributes"),
+					FieldType: "internal",
+					Type:      "[]xml.Attr",
+					XmlType:   "[]xml.Attr",
+					Tags:      "`xml:\",any,attr\"`",
 				},
 			}))
 		})
@@ -719,6 +747,13 @@ var _ = Describe("createStructSpecs", func() {
 						XmlType:   "[]generic.Xml",
 						Tags:      "`xml:\",any\"`",
 					},
+					{
+						Name:      properties.NewNameVariant("misc-attributes"),
+						FieldType: "internal",
+						Type:      "[]xml.Attr",
+						XmlType:   "[]xml.Attr",
+						Tags:      "`xml:\",any,attr\"`",
+					},
 				}))
 				Expect(result[1].name).To(Equal(properties.NewNameVariant("param-one")))
 				Expect(result[1].Fields).To(Equal([]entryStructFieldContext{
@@ -745,6 +780,13 @@ var _ = Describe("createStructSpecs", func() {
 						Type:      "[]generic.Xml",
 						XmlType:   "[]generic.Xml",
 						Tags:      "`xml:\",any\"`",
+					},
+					{
+						Name:      properties.NewNameVariant("misc-attributes"),
+						FieldType: "internal",
+						Type:      "[]xml.Attr",
+						XmlType:   "[]xml.Attr",
+						Tags:      "`xml:\",any,attr\"`",
 					},
 				}))
 			})
@@ -787,6 +829,13 @@ var _ = Describe("createStructSpecs", func() {
 						Type:      "[]generic.Xml",
 						XmlType:   "[]generic.Xml",
 						Tags:      "`xml:\",any\"`",
+					},
+					{
+						Name:      properties.NewNameVariant("misc-attributes"),
+						FieldType: "internal",
+						Type:      "[]xml.Attr",
+						XmlType:   "[]xml.Attr",
+						Tags:      "`xml:\",any,attr\"`",
 					},
 				}))
 
@@ -835,6 +884,13 @@ var _ = Describe("createStructSpecs", func() {
 						Type:      "[]generic.Xml",
 						XmlType:   "[]generic.Xml",
 						Tags:      "`xml:\",any\"`",
+					},
+					{
+						Name:      properties.NewNameVariant("misc-attributes"),
+						FieldType: "internal",
+						Type:      "[]xml.Attr",
+						XmlType:   "[]xml.Attr",
+						Tags:      "`xml:\",any,attr\"`",
 					},
 				}))
 			})
@@ -966,6 +1022,13 @@ var _ = Describe("createStructSpecs", func() {
 					XmlType:   "[]generic.Xml",
 					Tags:      "`xml:\",any\"`",
 				},
+				{
+					Name:      properties.NewNameVariant("misc-attributes"),
+					FieldType: "internal",
+					Type:      "[]xml.Attr",
+					XmlType:   "[]xml.Attr",
+					Tags:      "`xml:\",any,attr\"`",
+				},
 			}))
 
 			result = createStructSpecs(structXmlType, spec, version11_0_0)
@@ -1004,6 +1067,13 @@ var _ = Describe("createStructSpecs", func() {
 					Type:      "[]generic.Xml",
 					XmlType:   "[]generic.Xml",
 					Tags:      "`xml:\",any\"`",
+				},
+				{
+					Name:      properties.NewNameVariant("misc-attributes"),
+					FieldType: "internal",
+					Type:      "[]xml.Attr",
+					XmlType:   "[]xml.Attr",
+					Tags:      "`xml:\",any,attr\"`",
 				},
 			}))
 		})

--- a/templates/sdk/entry.tmpl
+++ b/templates/sdk/entry.tmpl
@@ -92,6 +92,14 @@
         o.Name = name
     }
 
+    func (o *Entry) GetMiscAttributes() []xml.Attr {
+	return o.MiscAttributes
+    }
+
+    func (o *Entry) SetMiscAttributes(attrs []xml.Attr) {
+	o.MiscAttributes = attrs
+    }
+
   {{- if .Spec.Params.uuid}}
     func (o *Entry) EntryUuid() *string {
         return o.Uuid


### PR DESCRIPTION
This matches existing Misc fields across structures, but instead of unparsed XML
nodes this field will keep all unparsed node attributes.