### PR TITLE
fix(terraform): Handle position attribute within lifecycle.ignore_changes

### DIFF
--- a/pkg/translate/terraform_provider/template.go
+++ b/pkg/translate/terraform_provider/template.go
@@ -971,17 +971,20 @@ for _, elt := range elements {
 }
 
 {{ $exhaustive := "sdkmanager.NonExhaustive" }}
-// {{ .Exhaustive }}
 {{- if .Exhaustive }}
   {{ $exhaustive = "sdkmanager.Exhaustive" }}
 position := movement.PositionFirst{}
 {{- else }}
+var position movement.Position
 var positionAttribute TerraformPositionObject
-resp.Diagnostics.Append(state.Position.As(ctx, &positionAttribute, basetypes.ObjectAsOptions{})...)
-if resp.Diagnostics.HasError() {
-	return
+if !state.Position.IsNull() && !state.Position.IsUnknown() {
+	resp.Diagnostics.Append(state.Position.As(ctx, &positionAttribute, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	position = positionAttribute.CopyToPango()
 }
-position := positionAttribute.CopyToPango()
 {{- end }}
 
 {{- if .Exhaustive }}

--- a/pkg/translate/terraform_provider/terraform_provider_file.go
+++ b/pkg/translate/terraform_provider/terraform_provider_file.go
@@ -269,12 +269,10 @@ func (g *GenerateTerraformProvider) GenerateTerraformResource(resourceTyp proper
 
 			terraformProvider.ImportManager.AddStandardImport("errors", "")
 			switch resourceTyp {
-			case properties.ResourceUuid:
+			case properties.ResourceUuid, properties.ResourceUuidPlural:
 				terraformProvider.ImportManager.AddSdkImport("github.com/PaloAltoNetworks/pango/movement", "")
 				terraformProvider.ImportManager.AddStandardImport("strings", "")
 			case properties.ResourceEntry:
-			case properties.ResourceUuidPlural:
-				terraformProvider.ImportManager.AddStandardImport("strings", "")
 			case properties.ResourceEntryPlural:
 			case properties.ResourceCustom, properties.ResourceConfig:
 			}


### PR DESCRIPTION
When position is included in lifecycle.ignore_changes, it's possible
for the position to become null on refresh - this is due to the fact that
Read() marks position as out of sync by setting it to null value.
Normally, this triggers a plan change which is then applied, but if position
is listed in ignore_changes terraform doesn't generate a plan for it, and
leaves position in state as null.

Closes PaloAltoNetworks/terraform-provider-panos#483