### PR TITLE
fix(codegen): Make audit comment code generation optional based on location

### DIFF
--- a/pkg/properties/normalized.go
+++ b/pkg/properties/normalized.go
@@ -1562,6 +1562,18 @@ func (spec *Normalization) HasEntryName() bool {
 	return spec.Entry != nil
 }
 
+func (spec *Normalization) HasAuditComments() bool {
+	var hasVsysLocation bool
+	for _, location := range spec.Locations {
+		if location.Name.CamelCase == "Vsys" {
+			hasVsysLocation = true
+			break
+		}
+	}
+
+	return hasVsysLocation && spec.HasEntryUuid()
+}
+
 func (spec *Normalization) HasEntryUuid() bool {
 	_, found := spec.Spec.Params["uuid"]
 	return found

--- a/templates/sdk/service.tmpl
+++ b/templates/sdk/service.tmpl
@@ -2,13 +2,21 @@ package {{packageName .GoSdkPath}}
 {{- if .Entry}}
     {{- if $.Imports}}
         {{- if $.Spec.Params.uuid}}
+          {{- if $.HasAuditComments }}
             {{renderImports "service" "filtering" "sync" "audit" "rule" "version" "movement"}}
+          {{- else }}
+            {{renderImports "service" "filtering" "sync" "rule" "version" "movement"}}
+          {{- end }}
         {{- else}}
             {{renderImports "service" "filtering" "sync"}}
         {{- end}}
     {{- else}}
         {{- if $.Spec.Params.uuid}}
+          {{-  if $.HasAuditComments }}
             {{renderImports "service" "filtering" "audit" "movement"}}
+          {{- else }}
+            {{renderImports "service" "filtering" "movement"}}
+          {{- end }}
         {{- else}}
             {{renderImports "service" "filtering"}}
         {{- end}}
@@ -793,7 +801,7 @@ func (s *Service) filterEntriesByLocation(location Location, entries []*Entry) [
 	return filtered
 }
 
-{{- if $.Spec.Params.uuid}}
+{{- if $.Spec.Params.uuid }}
 // MoveGroup arranges the given rules in the order specified.
 // Any rule with a UUID specified is ignored.
 // Only the rule names are considered for the purposes of the rule placement.
@@ -853,7 +861,7 @@ func (s *Service) MoveGroup(ctx context.Context, loc Location, position movement
 	return nil
 }
 
-
+  {{- if $.HasAuditComments }}
         // HITCOUNT returns the hit count for the given rule.
         func (s *Service) HitCount(ctx context.Context, loc Location, rules ...string) ([]util.HitCount, error) {
         switch {
@@ -873,7 +881,7 @@ func (s *Service) MoveGroup(ctx context.Context, loc Location, position movement
 
         return nil, fmt.Errorf("unsupported location")
         }
-
+        
         // SetAuditComment sets the given audit comment for the given rule.
         func (s *Service) SetAuditComment(ctx context.Context, loc Location, name, comment string) error {
         if name == "" {
@@ -989,6 +997,7 @@ func (s *Service) MoveGroup(ctx context.Context, loc Location, position movement
         }
 
         return resp.Comments, nil
-        }
+        }    
     {{- end}}
+  {{- end }}
 {{- end}}


### PR DESCRIPTION
That's still temporary solution, but will allow us to implement panos_default_security_policy resource