### PR TITLE
feat(specs): Add spec, tests and examples for panos_filters_prefix_list_routing_profile

### DIFF
--- a/assets/terraform/examples/resources/panos_filters_prefix_list_routing_profile/resource.tf
+++ b/assets/terraform/examples/resources/panos_filters_prefix_list_routing_profile/resource.tf
@@ -1,0 +1,125 @@
+# Create a template for the prefix list routing profiles
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name     = "prefix-list-template"
+}
+
+# IPv4 Prefix List Routing Profile
+resource "panos_filters_prefix_list_routing_profile" "ipv4_example" {
+  location = {
+    template = {
+      name = panos_template.example.name
+    }
+  }
+
+  name        = "ipv4-prefix-list"
+  description = "IPv4 prefix list for filtering BGP routes"
+
+  type = {
+    ipv4 = {
+      ipv4_entries = [
+        {
+          # Permit any prefix
+          name   = "10"
+          action = "permit"
+          prefix = {
+            network = "any"
+          }
+        },
+        {
+          # Deny specific network block
+          name   = "20"
+          action = "deny"
+          prefix = {
+            entry = {
+              network = "10.0.0.0/8"
+            }
+          }
+        },
+        {
+          # Permit 192.168.0.0/16 with prefix length between /24 and /28
+          name   = "30"
+          action = "permit"
+          prefix = {
+            entry = {
+              network                = "192.168.0.0/16"
+              greater_than_or_equal = 24
+              less_than_or_equal    = 28
+            }
+          }
+        },
+        {
+          # Deny 172.16.0.0/12 with minimum prefix length of /16
+          name   = "40"
+          action = "deny"
+          prefix = {
+            entry = {
+              network                = "172.16.0.0/12"
+              greater_than_or_equal = 16
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+# IPv6 Prefix List Routing Profile
+resource "panos_filters_prefix_list_routing_profile" "ipv6_example" {
+  location = {
+    template = {
+      name = panos_template.example.name
+    }
+  }
+
+  name        = "ipv6-prefix-list"
+  description = "IPv6 prefix list for filtering BGP routes"
+
+  type = {
+    ipv6 = {
+      ipv6_entries = [
+        {
+          # Permit any IPv6 prefix
+          name   = "10"
+          action = "permit"
+          prefix = {
+            network = "any"
+          }
+        },
+        {
+          # Deny documentation prefix 2001:db8::/32
+          name   = "20"
+          action = "deny"
+          prefix = {
+            entry = {
+              network = "2001:db8::/32"
+            }
+          }
+        },
+        {
+          # Permit ULA prefixes fd00::/8 with prefix length between /48 and /64
+          name   = "30"
+          action = "permit"
+          prefix = {
+            entry = {
+              network                = "fd00::/8"
+              greater_than_or_equal = 48
+              less_than_or_equal    = 64
+            }
+          }
+        },
+        {
+          # Deny fc00::/7 with maximum prefix length of /48
+          name   = "40"
+          action = "deny"
+          prefix = {
+            entry = {
+              network             = "fc00::/7"
+              less_than_or_equal = 48
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/assets/terraform/test/resource_filters_prefix_list_routing_profile_ipv4_test.go
+++ b/assets/terraform/test/resource_filters_prefix_list_routing_profile_ipv4_test.go
@@ -1,0 +1,435 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccFiltersPrefixListRoutingProfile_Ipv4_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersPrefixListRoutingProfile_Ipv4_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_prefix_list_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_prefix_list_routing_profile.example",
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Test prefix list description"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_prefix_list_routing_profile.example",
+						tfjsonpath.New("type"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"ipv4": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"ipv4_entries": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"name":   knownvalue.StringExact("10"),
+										"action": knownvalue.StringExact("deny"),
+										"prefix": knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"network": knownvalue.Null(),
+											"entry": knownvalue.ObjectExact(map[string]knownvalue.Check{
+												"network":                knownvalue.StringExact("10.0.0.0/8"),
+												"greater_than_or_equal": knownvalue.Null(),
+												"less_than_or_equal":    knownvalue.Null(),
+											}),
+										}),
+									}),
+								}),
+							}),
+							"ipv6": knownvalue.Null(),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersPrefixListRoutingProfile_Ipv4_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_prefix_list_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  description = "Test prefix list description"
+
+  type = {
+    ipv4 = {
+      ipv4_entries = [
+        {
+          name = "10"
+          action = "deny"
+          prefix = {
+            entry = {
+              network = "10.0.0.0/8"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersPrefixListRoutingProfile_Ipv4_Prefix_Network(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersPrefixListRoutingProfile_Ipv4_Prefix_Network_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_prefix_list_routing_profile.example",
+						tfjsonpath.New("type").AtMapKey("ipv4").AtMapKey("ipv4_entries").AtSliceIndex(0).AtMapKey("prefix"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"network": knownvalue.StringExact("any"),
+							"entry":   knownvalue.Null(),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersPrefixListRoutingProfile_Ipv4_Prefix_Network_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_prefix_list_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  type = {
+    ipv4 = {
+      ipv4_entries = [
+        {
+          name = "10"
+          prefix = {
+            network = "any"
+          }
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersPrefixListRoutingProfile_Ipv4_Prefix_Entry(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersPrefixListRoutingProfile_Ipv4_Prefix_Entry_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_prefix_list_routing_profile.example",
+						tfjsonpath.New("type").AtMapKey("ipv4").AtMapKey("ipv4_entries").AtSliceIndex(0).AtMapKey("prefix"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"network": knownvalue.Null(),
+							"entry": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"network":                knownvalue.StringExact("192.168.0.0/16"),
+								"greater_than_or_equal": knownvalue.Int64Exact(24),
+								"less_than_or_equal":    knownvalue.Int64Exact(28),
+							}),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersPrefixListRoutingProfile_Ipv4_Prefix_Entry_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_prefix_list_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  type = {
+    ipv4 = {
+      ipv4_entries = [
+        {
+          name = "10"
+          prefix = {
+            entry = {
+              network = "192.168.0.0/16"
+              greater_than_or_equal = 24
+              less_than_or_equal = 28
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersPrefixListRoutingProfile_Ipv4_Action_Permit(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersPrefixListRoutingProfile_Ipv4_Action_Permit_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_prefix_list_routing_profile.example",
+						tfjsonpath.New("type").AtMapKey("ipv4").AtMapKey("ipv4_entries").AtSliceIndex(0).AtMapKey("action"),
+						knownvalue.StringExact("permit"),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersPrefixListRoutingProfile_Ipv4_Action_Permit_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_prefix_list_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  type = {
+    ipv4 = {
+      ipv4_entries = [
+        {
+          name = "10"
+          action = "permit"
+          prefix = {
+            network = "any"
+          }
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersPrefixListRoutingProfile_Ipv4_MultipleEntries(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersPrefixListRoutingProfile_Ipv4_MultipleEntries_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_prefix_list_routing_profile.example",
+						tfjsonpath.New("type").AtMapKey("ipv4").AtMapKey("ipv4_entries"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":   knownvalue.StringExact("10"),
+								"action": knownvalue.StringExact("permit"),
+								"prefix": knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"network": knownvalue.StringExact("any"),
+									"entry":   knownvalue.Null(),
+								}),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":   knownvalue.StringExact("20"),
+								"action": knownvalue.StringExact("deny"),
+								"prefix": knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"network": knownvalue.Null(),
+									"entry": knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"network":                knownvalue.StringExact("10.0.0.0/8"),
+										"greater_than_or_equal": knownvalue.Int64Exact(16),
+										"less_than_or_equal":    knownvalue.Null(),
+									}),
+								}),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":   knownvalue.StringExact("30"),
+								"action": knownvalue.StringExact("permit"),
+								"prefix": knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"network": knownvalue.Null(),
+									"entry": knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"network":                knownvalue.StringExact("172.16.0.0/12"),
+										"greater_than_or_equal": knownvalue.Null(),
+										"less_than_or_equal":    knownvalue.Int64Exact(24),
+									}),
+								}),
+							}),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersPrefixListRoutingProfile_Ipv4_MultipleEntries_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_prefix_list_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  type = {
+    ipv4 = {
+      ipv4_entries = [
+        {
+          name = "10"
+          action = "permit"
+          prefix = {
+            network = "any"
+          }
+        },
+        {
+          name = "20"
+          action = "deny"
+          prefix = {
+            entry = {
+              network = "10.0.0.0/8"
+              greater_than_or_equal = 16
+            }
+          }
+        },
+        {
+          name = "30"
+          action = "permit"
+          prefix = {
+            entry = {
+              network = "172.16.0.0/12"
+              less_than_or_equal = 24
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+`
+

--- a/assets/terraform/test/resource_filters_prefix_list_routing_profile_ipv6_test.go
+++ b/assets/terraform/test/resource_filters_prefix_list_routing_profile_ipv6_test.go
@@ -1,0 +1,434 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccFiltersPrefixListRoutingProfile_Ipv6_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersPrefixListRoutingProfile_Ipv6_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_prefix_list_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_prefix_list_routing_profile.example",
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Test IPv6 prefix list"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_prefix_list_routing_profile.example",
+						tfjsonpath.New("type"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"ipv4": knownvalue.Null(),
+							"ipv6": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"ipv6_entries": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"name":   knownvalue.StringExact("10"),
+										"action": knownvalue.StringExact("deny"),
+										"prefix": knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"network": knownvalue.Null(),
+											"entry": knownvalue.ObjectExact(map[string]knownvalue.Check{
+												"network":                knownvalue.StringExact("2001:db8::/32"),
+												"greater_than_or_equal": knownvalue.Null(),
+												"less_than_or_equal":    knownvalue.Null(),
+											}),
+										}),
+									}),
+								}),
+							}),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersPrefixListRoutingProfile_Ipv6_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_prefix_list_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  description = "Test IPv6 prefix list"
+
+  type = {
+    ipv6 = {
+      ipv6_entries = [
+        {
+          name = "10"
+          action = "deny"
+          prefix = {
+            entry = {
+              network = "2001:db8::/32"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersPrefixListRoutingProfile_Ipv6_Prefix_Network(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersPrefixListRoutingProfile_Ipv6_Prefix_Network_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_prefix_list_routing_profile.example",
+						tfjsonpath.New("type").AtMapKey("ipv6").AtMapKey("ipv6_entries").AtSliceIndex(0).AtMapKey("prefix"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"network": knownvalue.StringExact("any"),
+							"entry":   knownvalue.Null(),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersPrefixListRoutingProfile_Ipv6_Prefix_Network_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_prefix_list_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  type = {
+    ipv6 = {
+      ipv6_entries = [
+        {
+          name = "10"
+          prefix = {
+            network = "any"
+          }
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersPrefixListRoutingProfile_Ipv6_Prefix_Entry(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersPrefixListRoutingProfile_Ipv6_Prefix_Entry_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_prefix_list_routing_profile.example",
+						tfjsonpath.New("type").AtMapKey("ipv6").AtMapKey("ipv6_entries").AtSliceIndex(0).AtMapKey("prefix"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"network": knownvalue.Null(),
+							"entry": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"network":                knownvalue.StringExact("fd00::/8"),
+								"greater_than_or_equal": knownvalue.Int64Exact(64),
+								"less_than_or_equal":    knownvalue.Int64Exact(96),
+							}),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersPrefixListRoutingProfile_Ipv6_Prefix_Entry_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_prefix_list_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  type = {
+    ipv6 = {
+      ipv6_entries = [
+        {
+          name = "10"
+          prefix = {
+            entry = {
+              network = "fd00::/8"
+              greater_than_or_equal = 64
+              less_than_or_equal = 96
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersPrefixListRoutingProfile_Ipv6_Action_Permit(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersPrefixListRoutingProfile_Ipv6_Action_Permit_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_prefix_list_routing_profile.example",
+						tfjsonpath.New("type").AtMapKey("ipv6").AtMapKey("ipv6_entries").AtSliceIndex(0).AtMapKey("action"),
+						knownvalue.StringExact("permit"),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersPrefixListRoutingProfile_Ipv6_Action_Permit_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_prefix_list_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  type = {
+    ipv6 = {
+      ipv6_entries = [
+        {
+          name = "10"
+          action = "permit"
+          prefix = {
+            network = "any"
+          }
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersPrefixListRoutingProfile_Ipv6_MultipleEntries(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersPrefixListRoutingProfile_Ipv6_MultipleEntries_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_prefix_list_routing_profile.example",
+						tfjsonpath.New("type").AtMapKey("ipv6").AtMapKey("ipv6_entries"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":   knownvalue.StringExact("10"),
+								"action": knownvalue.StringExact("permit"),
+								"prefix": knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"network": knownvalue.StringExact("any"),
+									"entry":   knownvalue.Null(),
+								}),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":   knownvalue.StringExact("20"),
+								"action": knownvalue.StringExact("deny"),
+								"prefix": knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"network": knownvalue.Null(),
+									"entry": knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"network":                knownvalue.StringExact("2001:db8::/32"),
+										"greater_than_or_equal": knownvalue.Int64Exact(48),
+										"less_than_or_equal":    knownvalue.Null(),
+									}),
+								}),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":   knownvalue.StringExact("30"),
+								"action": knownvalue.StringExact("permit"),
+								"prefix": knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"network": knownvalue.Null(),
+									"entry": knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"network":                knownvalue.StringExact("fc00::/7"),
+										"greater_than_or_equal": knownvalue.Null(),
+										"less_than_or_equal":    knownvalue.Int64Exact(64),
+									}),
+								}),
+							}),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersPrefixListRoutingProfile_Ipv6_MultipleEntries_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_prefix_list_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  type = {
+    ipv6 = {
+      ipv6_entries = [
+        {
+          name = "10"
+          action = "permit"
+          prefix = {
+            network = "any"
+          }
+        },
+        {
+          name = "20"
+          action = "deny"
+          prefix = {
+            entry = {
+              network = "2001:db8::/32"
+              greater_than_or_equal = 48
+            }
+          }
+        },
+        {
+          name = "30"
+          action = "permit"
+          prefix = {
+            entry = {
+              network = "fc00::/7"
+              less_than_or_equal = 64
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+`

--- a/specs/network/routing-profiles/filters-prefix-list-profile.yaml
+++ b/specs/network/routing-profiles/filters-prefix-list-profile.yaml
@@ -1,0 +1,390 @@
+name: filters-prefix-list-routing-profile
+terraform_provider_config:
+  description: Filters Prefix List Routing Profile
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants:
+  - singular
+  suffix: filters_prefix_list_routing_profile
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+go_sdk_config:
+  skip: false
+  package:
+  - network
+  - routing-profile
+  - filters
+  - prefixlist
+panos_xpath:
+  path:
+  - network
+  - routing-profile
+  - filters
+  - prefix-list
+  vars: []
+locations:
+- name: ngfw
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific NGFW device
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: Specific Panorama template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template stack
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+imports: []
+spec:
+  params:
+  - name: description
+    type: string
+    profiles:
+    - xpath:
+      - description
+    validators:
+    - type: length
+      spec:
+        min: 0
+        max: 1024
+    spec: {}
+    description: Describe Prefix-List
+    required: false
+  - name: type
+    type: object
+    profiles:
+    - xpath:
+      - type
+    validators: []
+    spec:
+      params: []
+      variants:
+      - name: ipv4
+        type: object
+        profiles:
+        - xpath:
+          - ipv4
+        validators: []
+        spec:
+          params:
+          - name: ipv4-entry
+            type: list
+            profiles:
+            - xpath:
+              - ipv4-entry
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) this Prefix-List Entry
+                    required: false
+                  - name: prefix
+                    type: object
+                    profiles:
+                    - xpath:
+                      - prefix
+                    validators: []
+                    spec:
+                      params: []
+                      variants:
+                      - name: network
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - network
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - any
+                        spec:
+                          values:
+                          - value: any
+                        description: Select pre-defined Prefix
+                        required: false
+                      - name: entry
+                        type: object
+                        profiles:
+                        - xpath:
+                          - entry
+                        validators: []
+                        spec:
+                          params:
+                          - name: network
+                            type: string
+                            profiles:
+                            - xpath:
+                              - network
+                            validators: []
+                            spec: {}
+                            description: ''
+                            required: false
+                          - name: greater-than-or-equal
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - greater-than-or-equal
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 32
+                            spec: {}
+                            description: Maximum Prefix length to be matched
+                            required: false
+                          - name: less-than-or-equal
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - less-than-or-equal
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 32
+                            spec: {}
+                            description: Minimum Prefix length to be matched
+                            required: false
+                          variants: []
+                        description: Configure IPv4 Prefix-List Network
+                        required: false
+                    description: Configure IPv4 Prefix
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+            codegen_overrides:
+              terraform:
+                name: ipv4-entries
+          variants: []
+        description: Configure IPv4 Prefix-List Entries
+        required: false
+      - name: ipv6
+        type: object
+        profiles:
+        - xpath:
+          - ipv6
+        validators: []
+        spec:
+          params:
+          - name: ipv6-entry
+            type: list
+            profiles:
+            - xpath:
+              - ipv6-entry
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) this Prefix-List Entry
+                    required: false
+                  - name: prefix
+                    type: object
+                    profiles:
+                    - xpath:
+                      - prefix
+                    validators: []
+                    spec:
+                      params: []
+                      variants:
+                      - name: network
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - network
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - any
+                        spec:
+                          values:
+                          - value: any
+                        description: Select pre-defined Prefix
+                        required: false
+                      - name: entry
+                        type: object
+                        profiles:
+                        - xpath:
+                          - entry
+                        validators: []
+                        spec:
+                          params:
+                          - name: network
+                            type: string
+                            profiles:
+                            - xpath:
+                              - network
+                            validators: []
+                            spec: {}
+                            description: ''
+                            required: false
+                          - name: greater-than-or-equal
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - greater-than-or-equal
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 128
+                            spec: {}
+                            description: Maximum Prefix length to be matched
+                            required: false
+                          - name: less-than-or-equal
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - less-than-or-equal
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 128
+                            spec: {}
+                            description: Minimum Prefix length to be matched
+                            required: false
+                          variants: []
+                        description: Configure IPv6 Prefix-List Network
+                        required: false
+                    description: Configure IPv6 Prefix
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+            codegen_overrides:
+              terraform:
+                name: ipv6-entries
+          variants: []
+        description: Configure IPv6 Prefix-List Entries
+        required: false
+    description: Configure Prefix-List Entries
+    required: false
+  variants: []


### PR DESCRIPTION
  ## Terraform Resource Name
  `panos_filters_prefix_list_routing_profile`

  ## Description
  This resource manages Prefix List routing profiles for filtering BGP routes based on IPv4 or IPv6 network prefixes. Prefix lists allow permit or deny actions on specific network ranges with optional prefix length constraints.

  ## Renamed Parameters/Attributes

  | Original Name | Terraform Name | Type | Description |
  |--------------|----------------|------|-------------|
  | `ipv4-entry` | `ipv4_entries` | list | List of IPv4 prefix list entries |
  | `ipv6-entry` | `ipv6_entries` | list | List of IPv6 prefix list entries |

  ## All Other Parameters/Attributes

  | Name | Type | Description |
  |------|------|-------------|
  | `name` | string | Name of the prefix list routing profile |
  | `description` | string | Description of the prefix list (max 1024 characters) |
  | `type` | object | Configure prefix-list entries (mutually exclusive variants: ipv4 or ipv6) |

  ### Type Variants

  #### IPv4 Variant (`type.ipv4`)
  | Name | Type | Description |
  |------|------|-------------|
  | `ipv4_entries` | list | List of IPv4 prefix list entries |
  | `ipv4_entries[].name` | string | Sequence number for the entry (e.g., "10", "20") |
  | `ipv4_entries[].action` | enum | Action to take: `deny` (default) or `permit` |
  | `ipv4_entries[].prefix` | object | Configure IPv4 prefix (mutually exclusive variants: network or entry) |
  | `ipv4_entries[].prefix.network` | enum | Pre-defined prefix value: `any` |
  | `ipv4_entries[].prefix.entry` | object | Configure custom IPv4 prefix-list network |
  | `ipv4_entries[].prefix.entry.network` | string | IPv4 network in CIDR notation (e.g., "10.0.0.0/8") |
  | `ipv4_entries[].prefix.entry.greater_than_or_equal` | int64 | Minimum prefix length to match (0-32) |
  | `ipv4_entries[].prefix.entry.less_than_or_equal` | int64 | Maximum prefix length to match (0-32) |

  #### IPv6 Variant (`type.ipv6`)
  | Name | Type | Description |
  |------|------|-------------|
  | `ipv6_entries` | list | List of IPv6 prefix list entries |
  | `ipv6_entries[].name` | string | Sequence number for the entry (e.g., "10", "20") |
  | `ipv6_entries[].action` | enum | Action to take: `deny` (default) or `permit` |
  | `ipv6_entries[].prefix` | object | Configure IPv6 prefix (mutually exclusive variants: network or entry) |
  | `ipv6_entries[].prefix.network` | enum | Pre-defined prefix value: `any` |
  | `ipv6_entries[].prefix.entry` | object | Configure custom IPv6 prefix-list network |
  | `ipv6_entries[].prefix.entry.network` | string | IPv6 network in CIDR notation (e.g., "2001:db8::/32") |
  | `ipv6_entries[].prefix.entry.greater_than_or_equal` | int64 | Minimum prefix length to match (0-128) |
  | `ipv6_entries[].prefix.entry.less_than_or_equal` | int64 | Maximum prefix length to match (0-128) |

  ## Locations
  - **NGFW**: Located in a specific NGFW device
  - **Template**: Located in a specific Panorama template
  - **Template Stack**: Located in a specific Panorama template stack