### PR TITLE
feat(specs): Add spec, tests and examples for panos_filters_route_map_redistribution_routing_profile

### DIFF
--- a/assets/terraform/examples/resources/panos_filters_route_maps_redistribution_routing_profile/resource.tf
+++ b/assets/terraform/examples/resources/panos_filters_route_maps_redistribution_routing_profile/resource.tf
@@ -1,0 +1,254 @@
+# Create a template
+resource "panos_template" "redistribution_template" {
+  location = { panorama = {} }
+  name     = "redistribution-routing-template"
+}
+
+# BGP to OSPF Redistribution with Match and Set Attributes
+resource "panos_filters_route_maps_redistribution_routing_profile" "bgp_to_ospf" {
+  location = {
+    template = {
+      name = panos_template.redistribution_template.name
+    }
+  }
+
+  name        = "bgp-to-ospf-redistribution"
+  description = "Redistribute BGP routes into OSPF with filtering and metric manipulation"
+
+  bgp = {
+    ospf = {
+      route_map = [
+        {
+          name        = "10"
+          action      = "permit"
+          description = "Permit BGP routes with specific attributes"
+          match = {
+            metric           = 100
+            tag              = 200
+            origin           = "igp"
+            local_preference = 150
+          }
+          set = {
+            metric = {
+              value  = 50
+              action = "set"
+            }
+            metric_type = "type-1"
+            tag         = 300
+          }
+        },
+        {
+          name        = "20"
+          action      = "deny"
+          description = "Deny all other BGP routes"
+        }
+      ]
+    }
+  }
+}
+
+# OSPF to BGP Redistribution with IPv4 Address Matching
+resource "panos_filters_route_maps_redistribution_routing_profile" "ospf_to_bgp" {
+  location = {
+    template = {
+      name = panos_template.redistribution_template.name
+    }
+  }
+
+  name        = "ospf-to-bgp-redistribution"
+  description = "Redistribute OSPF routes into BGP with route filtering"
+
+  ospf = {
+    bgp = {
+      route_map = [
+        {
+          name        = "10"
+          action      = "permit"
+          description = "Permit OSPF routes and set BGP attributes"
+          match = {
+            metric    = 10
+            tag       = 100
+            interface = "ethernet1/1"
+          }
+          set = {
+            metric = {
+              value  = 200
+              action = "set"
+            }
+            as_path_prepend  = "65001 65001"
+            local_preference = 150
+            origin           = "igp"
+          }
+        }
+      ]
+    }
+  }
+}
+
+# Connected/Static to BGP Redistribution
+resource "panos_filters_route_maps_redistribution_routing_profile" "connected_to_bgp" {
+  location = {
+    template = {
+      name = panos_template.redistribution_template.name
+    }
+  }
+
+  name        = "connected-to-bgp-redistribution"
+  description = "Redistribute connected and static routes into BGP"
+
+  connected_static = {
+    bgp = {
+      route_map = [
+        {
+          name        = "10"
+          action      = "permit"
+          description = "Permit connected/static routes"
+          match = {
+            interface = "ethernet1/2"
+            metric    = 0
+          }
+          set = {
+            metric = {
+              value  = 100
+              action = "set"
+            }
+            local_preference = 200
+            origin           = "incomplete"
+          }
+        }
+      ]
+    }
+  }
+}
+
+# BGP to RIP Redistribution with Metric Manipulation
+resource "panos_filters_route_maps_redistribution_routing_profile" "bgp_to_rip" {
+  location = {
+    template = {
+      name = panos_template.redistribution_template.name
+    }
+  }
+
+  name        = "bgp-to-rip-redistribution"
+  description = "Redistribute BGP routes into RIP with hop count control"
+
+  bgp = {
+    rip = {
+      route_map = [
+        {
+          name        = "10"
+          action      = "permit"
+          description = "Set RIP metric for BGP routes"
+          match = {
+            metric = 50
+            tag    = 100
+          }
+          set = {
+            metric = {
+              value  = 5
+              action = "set"
+            }
+            next_hop = "10.0.0.1"
+            tag      = 200
+          }
+        }
+      ]
+    }
+  }
+}
+
+# BGP to OSPFv3 Redistribution (IPv6)
+resource "panos_filters_route_maps_redistribution_routing_profile" "bgp_to_ospfv3" {
+  location = {
+    template = {
+      name = panos_template.redistribution_template.name
+    }
+  }
+
+  name        = "bgp-to-ospfv3-redistribution"
+  description = "Redistribute BGP routes into OSPFv3 for IPv6"
+
+  bgp = {
+    ospfv3 = {
+      route_map = [
+        {
+          name        = "10"
+          action      = "permit"
+          description = "Permit BGP routes for OSPFv3"
+          match = {
+            metric = 100
+            tag    = 50
+          }
+          set = {
+            metric = {
+              value  = 75
+              action = "add"
+            }
+            metric_type = "type-2"
+            tag         = 150
+          }
+        }
+      ]
+    }
+  }
+}
+
+# BGP to RIB Redistribution (Simple)
+resource "panos_filters_route_maps_redistribution_routing_profile" "bgp_to_rib" {
+  location = {
+    template = {
+      name = panos_template.redistribution_template.name
+    }
+  }
+
+  name        = "bgp-to-rib-redistribution"
+  description = "Install BGP routes into routing table"
+
+  bgp = {
+    rib = {
+      route_map = [
+        {
+          name   = "10"
+          action = "permit"
+        }
+      ]
+    }
+  }
+}
+
+# Multi-Protocol Redistribution Example
+resource "panos_filters_route_maps_redistribution_routing_profile" "rip_to_ospf" {
+  location = {
+    template = {
+      name = panos_template.redistribution_template.name
+    }
+  }
+
+  name        = "rip-to-ospf-redistribution"
+  description = "Redistribute RIP routes into OSPF"
+
+  rip = {
+    ospf = {
+      route_map = [
+        {
+          name        = "10"
+          action      = "permit"
+          description = "Convert RIP metrics to OSPF"
+          match = {
+            metric    = 3
+            tag       = 100
+            interface = "ethernet1/3"
+          }
+          set = {
+            metric = {
+              value  = 20
+              action = "set"
+            }
+            metric_type = "type-2"
+            tag         = 200
+          }
+        }
+      ]
+    }
+  }
+}

--- a/assets/terraform/test/resource_filters_route_maps_redistribution_routing_profile_test.go
+++ b/assets/terraform/test/resource_filters_route_maps_redistribution_routing_profile_test.go
@@ -1,0 +1,2014 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Test redistribution routing profile"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("bgp"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"rib": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"route_map": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"name":        knownvalue.StringExact("1"),
+										"action":      knownvalue.StringExact("permit"),
+										"description": knownvalue.Null(),
+										"match":       knownvalue.Null(),
+										"set":         knownvalue.Null(),
+									}),
+								}),
+							}),
+							"ospf":   knownvalue.Null(),
+							"ospfv3": knownvalue.Null(),
+							"rip":    knownvalue.Null(),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  description = "Test redistribution routing profile"
+
+  bgp = {
+    rib = {
+      route_map = [
+        {
+          name = "1"
+          action = "permit"
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Bgp_Ospf(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Bgp_Ospf_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("bgp"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"ospf": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"route_map": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"name":   knownvalue.StringExact("10"),
+										"action": knownvalue.StringExact("permit"),
+										"description": knownvalue.StringExact("Redistribute BGP to OSPF"),
+										"match": knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"metric":              knownvalue.Int64Exact(100),
+											"tag":                 knownvalue.Int64Exact(200),
+											"origin":              knownvalue.StringExact("igp"),
+											"local_preference":    knownvalue.Int64Exact(150),
+											"as_path_access_list": knownvalue.Null(),
+											"regular_communities": knownvalue.Null(),
+											"large_communities":   knownvalue.Null(),
+											"extended_communities": knownvalue.Null(),
+											"interface":           knownvalue.Null(),
+											"peer":                knownvalue.Null(),
+											"ipv4":                knownvalue.Null(),
+										}),
+										"set": knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"metric": knownvalue.ObjectExact(map[string]knownvalue.Check{
+												"value":  knownvalue.Int64Exact(50),
+												"action": knownvalue.StringExact("set"),
+											}),
+											"metric_type": knownvalue.StringExact("type-1"),
+											"tag":         knownvalue.Int64Exact(300),
+										}),
+									}),
+								}),
+							}),
+							"ospfv3": knownvalue.Null(),
+							"rib":    knownvalue.Null(),
+							"rip":    knownvalue.Null(),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Bgp_Ospf_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  bgp = {
+    ospf = {
+      route_map = [
+        {
+          name = "10"
+          action = "permit"
+          description = "Redistribute BGP to OSPF"
+          match = {
+            metric = 100
+            tag = 200
+            origin = "igp"
+            local_preference = 150
+          }
+          set = {
+            metric = {
+              value = 50
+              action = "set"
+            }
+            metric_type = "type-1"
+            tag = 300
+          }
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Bgp_Ospfv3(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Bgp_Ospfv3_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("bgp"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"ospfv3": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"route_map": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"name":        knownvalue.StringExact("20"),
+										"action":      knownvalue.StringExact("deny"),
+										"description": knownvalue.StringExact("Redistribute BGP to OSPFv3"),
+										"match": knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"metric":              knownvalue.Int64Exact(50),
+											"tag":                 knownvalue.Int64Exact(100),
+											"as_path_access_list": knownvalue.Null(),
+											"regular_communities": knownvalue.Null(),
+											"large_communities":   knownvalue.Null(),
+											"extended_communities": knownvalue.Null(),
+											"interface":           knownvalue.Null(),
+											"origin":              knownvalue.Null(),
+											"local_preference":    knownvalue.Null(),
+											"peer":                knownvalue.Null(),
+											"ipv6":                knownvalue.Null(),
+										}),
+										"set": knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"metric": knownvalue.ObjectExact(map[string]knownvalue.Check{
+												"value":  knownvalue.Int64Exact(75),
+												"action": knownvalue.StringExact("add"),
+											}),
+											"metric_type": knownvalue.StringExact("type-2"),
+											"tag":         knownvalue.Int64Exact(150),
+										}),
+									}),
+								}),
+							}),
+							"ospf": knownvalue.Null(),
+							"rib":  knownvalue.Null(),
+							"rip":  knownvalue.Null(),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Bgp_Ospfv3_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  bgp = {
+    ospfv3 = {
+      route_map = [
+        {
+          name = "20"
+          action = "deny"
+          description = "Redistribute BGP to OSPFv3"
+          match = {
+            metric = 50
+            tag = 100
+          }
+          set = {
+            metric = {
+              value = 75
+              action = "add"
+            }
+            metric_type = "type-2"
+            tag = 150
+          }
+        }
+      ]
+    }
+  }
+}
+`
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Bgp_Rib(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Bgp_Rib_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("bgp"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"rib": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"route_map": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"name":        knownvalue.StringExact("30"),
+										"action":      knownvalue.StringExact("permit"),
+										"description": knownvalue.Null(),
+										"match":       knownvalue.Null(),
+										"set":         knownvalue.Null(),
+									}),
+								}),
+							}),
+							"ospf":   knownvalue.Null(),
+							"ospfv3": knownvalue.Null(),
+							"rip":    knownvalue.Null(),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Bgp_Rib_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  bgp = {
+    rib = {
+      route_map = [
+        {
+          name = "30"
+          action = "permit"
+        }
+      ]
+    }
+  }
+}
+`
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Bgp_Rip(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Bgp_Rip_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("bgp"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"rip": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"route_map": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"name":   knownvalue.StringExact("40"),
+										"action": knownvalue.StringExact("permit"),
+										"description": knownvalue.StringExact("Redistribute BGP to RIP"),
+										"match": knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"metric":              knownvalue.Int64Exact(5),
+											"tag":                 knownvalue.Int64Exact(50),
+											"as_path_access_list": knownvalue.Null(),
+											"regular_communities": knownvalue.Null(),
+											"large_communities":   knownvalue.Null(),
+											"extended_communities": knownvalue.Null(),
+											"interface":           knownvalue.Null(),
+											"origin":              knownvalue.Null(),
+											"local_preference":    knownvalue.Null(),
+											"peer":                knownvalue.Null(),
+											"ipv4":                knownvalue.Null(),
+										}),
+										"set": knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"metric": knownvalue.ObjectExact(map[string]knownvalue.Check{
+												"value":  knownvalue.Int64Exact(10),
+												"action": knownvalue.StringExact("set"),
+											}),
+											"next_hop": knownvalue.StringExact("10.0.0.1"),
+											"tag":      knownvalue.Int64Exact(100),
+										}),
+									}),
+								}),
+							}),
+							"ospf":   knownvalue.Null(),
+							"ospfv3": knownvalue.Null(),
+							"rib":    knownvalue.Null(),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Bgp_Rip_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  bgp = {
+    rip = {
+      route_map = [
+        {
+          name = "40"
+          action = "permit"
+          description = "Redistribute BGP to RIP"
+          match = {
+            metric = 5
+            tag = 50
+          }
+          set = {
+            metric = {
+              value = 10
+              action = "set"
+            }
+            next_hop = "10.0.0.1"
+            tag = 100
+          }
+        }
+      ]
+    }
+  }
+}
+`
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Bgp(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Bgp_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("connected_static"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"bgp": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"route_map": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.ObjectExact(map[string]knownvalue.Check{
+										"name":        knownvalue.StringExact("50"),
+										"action":      knownvalue.StringExact("permit"),
+										"description": knownvalue.Null(),
+										"match":       knownvalue.Null(),
+										"set":         knownvalue.Null(),
+									}),
+								}),
+							}),
+							"ospf":   knownvalue.Null(),
+							"ospfv3": knownvalue.Null(),
+							"rib":    knownvalue.Null(),
+							"rip":    knownvalue.Null(),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Bgp_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  connected_static = {
+    bgp = {
+      route_map = [
+        {
+          name = "50"
+          action = "permit"
+        }
+      ]
+    }
+  }
+}
+`
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Ospf(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Ospf_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Ospf_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  connected_static = {
+    ospf = {
+      route_map = [
+        {
+          name = "60"
+          action = "deny"
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Ospfv3(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Ospfv3_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Ospfv3_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  connected_static = {
+    ospfv3 = {
+      route_map = [
+        {
+          name = "70"
+          action = "permit"
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Rib(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Rib_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Rib_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  connected_static = {
+    rib = {
+      route_map = [
+        {
+          name = "80"
+          action = "permit"
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Rip(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Rip_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Rip_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  connected_static = {
+    rip = {
+      route_map = [
+        {
+          name = "90"
+          action = "permit"
+        }
+      ]
+    }
+  }
+}
+`
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Ospf_Bgp(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Ospf_Bgp_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Ospf_Bgp_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  ospf = {
+    bgp = {
+      route_map = [
+        {
+          name = "100"
+          action = "permit"
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Ospf_Rib(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Ospf_Rib_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Ospf_Rib_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  ospf = {
+    rib = {
+      route_map = [
+        {
+          name = "110"
+          action = "deny"
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Ospf_Rip(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Ospf_Rip_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Ospf_Rip_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  ospf = {
+    rip = {
+      route_map = [
+        {
+          name = "120"
+          action = "permit"
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Ospfv3_Bgp(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Ospfv3_Bgp_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Ospfv3_Bgp_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  ospfv3 = {
+    bgp = {
+      route_map = [
+        {
+          name = "130"
+          action = "permit"
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Ospfv3_Rib(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Ospfv3_Rib_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Ospfv3_Rib_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  ospfv3 = {
+    rib = {
+      route_map = [
+        {
+          name = "140"
+          action = "deny"
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Rip_Bgp(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Rip_Bgp_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Rip_Bgp_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  rip = {
+    bgp = {
+      route_map = [
+        {
+          name = "150"
+          action = "permit"
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Rip_Ospf(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Rip_Ospf_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Rip_Ospf_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  rip = {
+    ospf = {
+      route_map = [
+        {
+          name = "160"
+          action = "deny"
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Rip_Rib(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Rip_Rib_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Rip_Rib_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  rip = {
+    rib = {
+      route_map = [
+        {
+          name = "170"
+          action = "permit"
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Bgp_Ospf_Match_Ipv4(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Bgp_Ospf_Match_Ipv4_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("bgp").AtMapKey("ospf").AtMapKey("route_map").AtSliceIndex(0).AtMapKey("match").AtMapKey("ipv4"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"address": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"access_list": knownvalue.StringExact("acl-ipv4-address"),
+								"prefix_list": knownvalue.Null(),
+							}),
+							"next_hop": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"access_list": knownvalue.Null(),
+								"prefix_list": knownvalue.StringExact("pl-ipv4-nexthop"),
+							}),
+							"route_source": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"access_list": knownvalue.StringExact("acl-ipv4-source"),
+								"prefix_list": knownvalue.Null(),
+							}),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Bgp_Ospf_Match_Ipv4_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_access_list_routing_profile" "acl_address" {
+  depends_on = [panos_template.example]
+  location = var.location
+  name = "acl-ipv4-address"
+
+  type = {
+    ipv4 = {
+      ipv4_entries = [
+        {
+          name = "10"
+          action = "permit"
+          source_address = {
+            address = "any"
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource "panos_filters_prefix_list_routing_profile" "pl_nexthop" {
+  depends_on = [panos_template.example]
+  location = var.location
+  name = "pl-ipv4-nexthop"
+
+  type = {
+    ipv4 = {
+      ipv4_entries = [
+        {
+          name = "10"
+          action = "permit"
+          prefix = {
+            entry = {
+              network = "192.168.0.0/16"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource "panos_filters_access_list_routing_profile" "acl_source" {
+  depends_on = [panos_template.example]
+  location = var.location
+  name = "acl-ipv4-source"
+
+  type = {
+    ipv4 = {
+      ipv4_entries = [
+        {
+          name = "10"
+          action = "permit"
+          source_address = {
+            address = "any"
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [
+    panos_template.example,
+    panos_filters_access_list_routing_profile.acl_address,
+    panos_filters_prefix_list_routing_profile.pl_nexthop,
+    panos_filters_access_list_routing_profile.acl_source
+  ]
+  location = var.location
+
+  name = var.prefix
+
+  bgp = {
+    ospf = {
+      route_map = [
+        {
+          name = "180"
+          action = "permit"
+          description = "Test IPv4 match attributes"
+          match = {
+            ipv4 = {
+              address = {
+                access_list = "acl-ipv4-address"
+              }
+              next_hop = {
+                prefix_list = "pl-ipv4-nexthop"
+              }
+              route_source = {
+                access_list = "acl-ipv4-source"
+              }
+            }
+          }
+          set = {
+            metric = {
+              value = 100
+              action = "set"
+            }
+            metric_type = "type-1"
+            tag = 500
+          }
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_Bgp_Ospfv3_Match_Ipv6(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_Bgp_Ospfv3_Match_Ipv6_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("bgp").AtMapKey("ospfv3").AtMapKey("route_map").AtSliceIndex(0).AtMapKey("match").AtMapKey("ipv6"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"address": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"access_list": knownvalue.StringExact("acl-ipv6-address"),
+								"prefix_list": knownvalue.Null(),
+							}),
+							"next_hop": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"access_list": knownvalue.Null(),
+								"prefix_list": knownvalue.StringExact("pl-ipv6-nexthop"),
+							}),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_Bgp_Ospfv3_Match_Ipv6_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_access_list_routing_profile" "acl_address" {
+  depends_on = [panos_template.example]
+  location = var.location
+  name = "acl-ipv6-address"
+
+  type = {
+    ipv6 = {
+      ipv6_entries = [
+        {
+          name = "10"
+          action = "permit"
+          source_address = {
+            address = "any"
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource "panos_filters_prefix_list_routing_profile" "pl_nexthop" {
+  depends_on = [panos_template.example]
+  location = var.location
+  name = "pl-ipv6-nexthop"
+
+  type = {
+    ipv6 = {
+      ipv6_entries = [
+        {
+          name = "10"
+          action = "permit"
+          prefix = {
+            entry = {
+              network = "2001:db8::/32"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [
+    panos_template.example,
+    panos_filters_access_list_routing_profile.acl_address,
+    panos_filters_prefix_list_routing_profile.pl_nexthop
+  ]
+  location = var.location
+
+  name = var.prefix
+
+  bgp = {
+    ospfv3 = {
+      route_map = [
+        {
+          name = "190"
+          action = "permit"
+          description = "Test IPv6 match attributes"
+          match = {
+            ipv6 = {
+              address = {
+                access_list = "acl-ipv6-address"
+              }
+              next_hop = {
+                prefix_list = "pl-ipv6-nexthop"
+              }
+            }
+          }
+          set = {
+            metric = {
+              value = 100
+              action = "set"
+            }
+            metric_type = "type-2"
+            tag = 600
+          }
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Bgp_Set(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Bgp_Set_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("connected_static").AtMapKey("bgp").AtMapKey("route_map").AtSliceIndex(0).AtMapKey("set").AtMapKey("metric"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"value":  knownvalue.Int64Exact(75),
+							"action": knownvalue.StringExact("add"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("connected_static").AtMapKey("bgp").AtMapKey("route_map").AtSliceIndex(0).AtMapKey("set").AtMapKey("origin"),
+						knownvalue.StringExact("incomplete"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("connected_static").AtMapKey("bgp").AtMapKey("route_map").AtSliceIndex(0).AtMapKey("set").AtMapKey("local_preference"),
+						knownvalue.Int64Exact(250),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Bgp_Set_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  connected_static = {
+    bgp = {
+      route_map = [
+        {
+          name = "200"
+          action = "permit"
+          description = "Test ConnectedStatic BGP set attributes"
+          set = {
+            metric = {
+              value = 75
+              action = "add"
+            }
+            origin = "incomplete"
+            local_preference = 250
+          }
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Bgp_Match_Ipv4(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Bgp_Match_Ipv4_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("connected_static").AtMapKey("bgp").AtMapKey("route_map").AtSliceIndex(0).AtMapKey("match").AtMapKey("ipv4"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"address": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"access_list": knownvalue.StringExact("acl-ipv4-address"),
+								"prefix_list": knownvalue.Null(),
+							}),
+							"next_hop": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"access_list": knownvalue.Null(),
+								"prefix_list": knownvalue.StringExact("pl-ipv4-nexthop"),
+							}),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Bgp_Match_Ipv4_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_access_list_routing_profile" "acl_address" {
+  depends_on = [panos_template.example]
+  location = var.location
+  name = "acl-ipv4-address"
+
+  type = {
+    ipv4 = {
+      ipv4_entries = [
+        {
+          name = "10"
+          action = "permit"
+          source_address = {
+            address = "any"
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource "panos_filters_prefix_list_routing_profile" "pl_nexthop" {
+  depends_on = [panos_template.example]
+  location = var.location
+  name = "pl-ipv4-nexthop"
+
+  type = {
+    ipv4 = {
+      ipv4_entries = [
+        {
+          name = "10"
+          action = "permit"
+          prefix = {
+            entry = {
+              network = "192.168.0.0/16"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [
+    panos_template.example,
+    panos_filters_access_list_routing_profile.acl_address,
+    panos_filters_prefix_list_routing_profile.pl_nexthop
+  ]
+  location = var.location
+
+  name = var.prefix
+
+  connected_static = {
+    bgp = {
+      route_map = [
+        {
+          name = "210"
+          action = "permit"
+          description = "Test ConnectedStatic BGP IPv4 match attributes"
+          match = {
+            ipv4 = {
+              address = {
+                access_list = "acl-ipv4-address"
+              }
+              next_hop = {
+                prefix_list = "pl-ipv4-nexthop"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+`
+
+func TestAccFiltersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Bgp_Match_Ipv6(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Bgp_Match_Ipv6_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_filters_route_maps_redistribution_routing_profile.example",
+						tfjsonpath.New("connected_static").AtMapKey("bgp").AtMapKey("route_map").AtSliceIndex(0).AtMapKey("match").AtMapKey("ipv6"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"address": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"access_list": knownvalue.StringExact("acl-ipv6-address"),
+								"prefix_list": knownvalue.Null(),
+							}),
+							"next_hop": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"access_list": knownvalue.Null(),
+								"prefix_list": knownvalue.StringExact("pl-ipv6-nexthop"),
+							}),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const filtersRouteMapsRedistributionRoutingProfile_ConnectedStatic_Bgp_Match_Ipv6_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_filters_access_list_routing_profile" "acl_address" {
+  depends_on = [panos_template.example]
+  location = var.location
+  name = "acl-ipv6-address"
+
+  type = {
+    ipv6 = {
+      ipv6_entries = [
+        {
+          name = "10"
+          action = "permit"
+          source_address = {
+            address = "any"
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource "panos_filters_prefix_list_routing_profile" "pl_nexthop" {
+  depends_on = [panos_template.example]
+  location = var.location
+  name = "pl-ipv6-nexthop"
+
+  type = {
+    ipv6 = {
+      ipv6_entries = [
+        {
+          name = "10"
+          action = "permit"
+          prefix = {
+            entry = {
+              network = "2001:db8::/32"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource "panos_filters_route_maps_redistribution_routing_profile" "example" {
+  depends_on = [
+    panos_template.example,
+    panos_filters_access_list_routing_profile.acl_address,
+    panos_filters_prefix_list_routing_profile.pl_nexthop
+  ]
+  location = var.location
+
+  name = var.prefix
+
+  connected_static = {
+    bgp = {
+      route_map = [
+        {
+          name = "220"
+          action = "permit"
+          description = "Test ConnectedStatic BGP IPv6 match attributes"
+          match = {
+            ipv6 = {
+              address = {
+                access_list = "acl-ipv6-address"
+              }
+              next_hop = {
+                prefix_list = "pl-ipv6-nexthop"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+`

--- a/specs/network/routing-profiles/filters-route-maps-redistribution-profile.yaml
+++ b/specs/network/routing-profiles/filters-route-maps-redistribution-profile.yaml
@@ -1,0 +1,5889 @@
+name: filters-route-maps-redistribution-routing-profile
+terraform_provider_config:
+  description: Filters Route Maps Redistribution Routing Profile
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants:
+  - singular
+  suffix: filters_route_maps_redistribution_routing_profile
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+go_sdk_config:
+  skip: false
+  package:
+  - network
+  - routing-profile
+  - filters
+  - routemapsredistribution
+panos_xpath:
+  path:
+  - network
+  - routing-profile
+  - filters
+  - route-maps
+  - redistribution
+  - redist-entry
+  vars: []
+locations:
+- name: ngfw
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific NGFW device
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: Specific Panorama template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template stack
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+imports: []
+spec:
+  params:
+  - name: description
+    type: string
+    profiles:
+    - xpath:
+      - description
+    validators:
+    - type: length
+      spec:
+        min: 0
+        max: 1024
+    spec: {}
+    description: Describe Redistribution Route Map
+    required: false
+  variants:
+  - name: bgp
+    type: object
+    profiles:
+    - xpath:
+      - bgp
+    validators: []
+    spec:
+      params: []
+      variants:
+      - name: ospf
+        type: object
+        profiles:
+        - xpath:
+          - ospf
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: as-path-access-list
+                        type: string
+                        profiles:
+                        - xpath:
+                          - as-path-access-list
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: AS Path Access List Name
+                        required: false
+                      - name: regular-community
+                        type: string
+                        profiles:
+                        - xpath:
+                          - regular-community
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: Regular Community Name
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: regular-communities
+                      - name: large-community
+                        type: string
+                        profiles:
+                        - xpath:
+                          - large-community
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: Large Community Name
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: large-communities
+                      - name: extended-community
+                        type: string
+                        profiles:
+                        - xpath:
+                          - extended-community
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: Extended Community Name
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: extended-communities
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: origin
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - origin
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - none
+                            - egp
+                            - igp
+                            - incomplete
+                        spec:
+                          values:
+                          - value: none
+                          - value: egp
+                          - value: igp
+                          - value: incomplete
+                        description: Match origin
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Metric (BGP MED) of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Match Tag of route
+                        required: false
+                      - name: local-preference
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - local-preference
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Local Preference of route
+                        required: false
+                      - name: peer
+                        type: string
+                        profiles:
+                        - xpath:
+                          - peer
+                        validators: []
+                        spec: {}
+                        description: Match Peer Address
+                        required: false
+                      - name: ipv4
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv4
+                        validators: []
+                        spec:
+                          params:
+                          - name: address
+                            type: object
+                            profiles:
+                            - xpath:
+                              - address
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Route
+                            required: false
+                          - name: next-hop
+                            type: object
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Next-Hop of Route
+                            required: false
+                          - name: route-source
+                            type: object
+                            profiles:
+                            - xpath:
+                              - route-source
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Advertising Source Address of
+                              route
+                            required: false
+                          variants: []
+                        description: Match IPv4 Details
+                        required: false
+                      variants: []
+                    description: Configure BGP Redistribution Route-Map Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: metric
+                        type: object
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators: []
+                        spec:
+                          params:
+                          - name: value
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - value
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 4294967295
+                            spec: {}
+                            description: Set Metric value of route
+                            required: false
+                          - name: action
+                            type: enum
+                            profiles:
+                            - xpath:
+                              - action
+                            validators:
+                            - type: values
+                              spec:
+                                values:
+                                - set
+                                - add
+                                - subtract
+                            spec:
+                              values:
+                              - value: set
+                              - value: add
+                              - value: subtract
+                            description: Set Metric action of route
+                            required: false
+                          variants: []
+                        description: Set Metric action and value of route
+                        required: false
+                      - name: metric-type
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - metric-type
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - type-1
+                            - type-2
+                        spec:
+                          default: type-2
+                          values:
+                          - value: type-1
+                          - value: type-2
+                        description: Set Metric-Type of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Set Tag of route
+                        required: false
+                      variants: []
+                    description: Configure OSPF Redistribution Route-Map set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as OSPF
+        required: false
+        variant_group_id: 0
+      - name: ospfv3
+        type: object
+        profiles:
+        - xpath:
+          - ospfv3
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: as-path-access-list
+                        type: string
+                        profiles:
+                        - xpath:
+                          - as-path-access-list
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: AS Path Access List Name
+                        required: false
+                      - name: regular-community
+                        type: string
+                        profiles:
+                        - xpath:
+                          - regular-community
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: Regular Community Name
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: regular-communities
+                      - name: large-community
+                        type: string
+                        profiles:
+                        - xpath:
+                          - large-community
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: Large Community Name
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: large-communities
+                      - name: extended-community
+                        type: string
+                        profiles:
+                        - xpath:
+                          - extended-community
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: Extended Community Name
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: extended-communities
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: origin
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - origin
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - none
+                            - egp
+                            - igp
+                            - incomplete
+                        spec:
+                          values:
+                          - value: none
+                          - value: egp
+                          - value: igp
+                          - value: incomplete
+                        description: Match origin
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Metric (BGP MED) of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Match Tag of route
+                        required: false
+                      - name: local-preference
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - local-preference
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Local Preference of route
+                        required: false
+                      - name: peer
+                        type: string
+                        profiles:
+                        - xpath:
+                          - peer
+                        validators: []
+                        spec: {}
+                        description: Match Peer Address
+                        required: false
+                      - name: ipv6
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv6
+                        validators: []
+                        spec:
+                          params:
+                          - name: address
+                            type: object
+                            profiles:
+                            - xpath:
+                              - address
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv6 Route
+                            required: false
+                          - name: next-hop
+                            type: object
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv6 next-hop of Route
+                            required: false
+                          variants: []
+                        description: Match IPv6 Details
+                        required: false
+                      variants: []
+                    description: Configure BGP Redistribution Route-Map Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: metric
+                        type: object
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators: []
+                        spec:
+                          params:
+                          - name: value
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - value
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 4294967295
+                            spec: {}
+                            description: Set Metric value of route
+                            required: false
+                          - name: action
+                            type: enum
+                            profiles:
+                            - xpath:
+                              - action
+                            validators:
+                            - type: values
+                              spec:
+                                values:
+                                - set
+                                - add
+                                - subtract
+                            spec:
+                              values:
+                              - value: set
+                              - value: add
+                              - value: subtract
+                            description: Set Metric action of route
+                            required: false
+                          variants: []
+                        description: Set Metric action and value of route
+                        required: false
+                      - name: metric-type
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - metric-type
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - type-1
+                            - type-2
+                        spec:
+                          default: type-2
+                          values:
+                          - value: type-1
+                          - value: type-2
+                        description: Set Metric-Type of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Set Tag of route
+                        required: false
+                      variants: []
+                    description: Configure OSPFv3 Redistribution Route-Map set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as OSPFv3
+        required: false
+        variant_group_id: 0
+      - name: rib
+        type: object
+        profiles:
+        - xpath:
+          - rib
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: as-path-access-list
+                        type: string
+                        profiles:
+                        - xpath:
+                          - as-path-access-list
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: AS Path Access List Name
+                        required: false
+                      - name: regular-community
+                        type: string
+                        profiles:
+                        - xpath:
+                          - regular-community
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: Regular Community Name
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: regular-communities
+                      - name: large-community
+                        type: string
+                        profiles:
+                        - xpath:
+                          - large-community
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: Large Community Name
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: large-communities
+                      - name: extended-community
+                        type: string
+                        profiles:
+                        - xpath:
+                          - extended-community
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: Extended Community Name
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: extended-communities
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: origin
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - origin
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - none
+                            - egp
+                            - igp
+                            - incomplete
+                        spec:
+                          values:
+                          - value: none
+                          - value: egp
+                          - value: igp
+                          - value: incomplete
+                        description: Match origin
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Metric (BGP MED) of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Match Tag of route
+                        required: false
+                      - name: local-preference
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - local-preference
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Local Preference of route
+                        required: false
+                      - name: peer
+                        type: string
+                        profiles:
+                        - xpath:
+                          - peer
+                        validators: []
+                        spec: {}
+                        description: Match Peer Address
+                        required: false
+                      - name: ipv4
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv4
+                        validators: []
+                        spec:
+                          params:
+                          - name: address
+                            type: object
+                            profiles:
+                            - xpath:
+                              - address
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Route
+                            required: false
+                          - name: next-hop
+                            type: object
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Next-Hop of Route
+                            required: false
+                          - name: route-source
+                            type: object
+                            profiles:
+                            - xpath:
+                              - route-source
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Advertising Source Address of
+                              route
+                            required: false
+                          variants: []
+                        description: Match IPv4 Details
+                        required: false
+                      - name: ipv6
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv6
+                        validators: []
+                        spec:
+                          params:
+                          - name: address
+                            type: object
+                            profiles:
+                            - xpath:
+                              - address
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv6 Route
+                            required: false
+                          - name: next-hop
+                            type: object
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv6 next-hop of Route
+                            required: false
+                          variants: []
+                        description: Match IPv6 Details
+                        required: false
+                      variants: []
+                    description: Configure BGP Redistribution Route-Map Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: source-address
+                        type: string
+                        profiles:
+                        - xpath:
+                          - source-address
+                        validators:
+                        - type: length
+                          spec:
+                            max: 128
+                        spec: {}
+                        description: Set Source IPv4 or IPv6 address
+                        required: false
+                      variants: []
+                    description: Configure RIB (Routing Table) Redistribution Route-Map
+                      set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as RIB (Routing Table)
+        required: false
+        variant_group_id: 0
+      - name: rip
+        type: object
+        profiles:
+        - xpath:
+          - rip
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: as-path-access-list
+                        type: string
+                        profiles:
+                        - xpath:
+                          - as-path-access-list
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: AS Path Access List Name
+                        required: false
+                      - name: regular-community
+                        type: string
+                        profiles:
+                        - xpath:
+                          - regular-community
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: Regular Community Name
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: regular-communities
+                      - name: large-community
+                        type: string
+                        profiles:
+                        - xpath:
+                          - large-community
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: Large Community Name
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: large-communities
+                      - name: extended-community
+                        type: string
+                        profiles:
+                        - xpath:
+                          - extended-community
+                        validators:
+                        - type: length
+                          spec:
+                            max: 63
+                        spec: {}
+                        description: Extended Community Name
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: extended-communities
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: origin
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - origin
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - none
+                            - egp
+                            - igp
+                            - incomplete
+                        spec:
+                          values:
+                          - value: none
+                          - value: egp
+                          - value: igp
+                          - value: incomplete
+                        description: Match origin
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Metric (BGP MED) of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Match Tag of route
+                        required: false
+                      - name: local-preference
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - local-preference
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Local Preference of route
+                        required: false
+                      - name: peer
+                        type: string
+                        profiles:
+                        - xpath:
+                          - peer
+                        validators: []
+                        spec: {}
+                        description: Match Peer Address
+                        required: false
+                      - name: ipv4
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv4
+                        validators: []
+                        spec:
+                          params:
+                          - name: address
+                            type: object
+                            profiles:
+                            - xpath:
+                              - address
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Route
+                            required: false
+                          - name: next-hop
+                            type: object
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Next-Hop of Route
+                            required: false
+                          - name: route-source
+                            type: object
+                            profiles:
+                            - xpath:
+                              - route-source
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Advertising Source Address of
+                              route
+                            required: false
+                          variants: []
+                        description: Match IPv4 Details
+                        required: false
+                      variants: []
+                    description: Configure BGP Redistribution Route-Map Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: metric
+                        type: object
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators: []
+                        spec:
+                          params:
+                          - name: value
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - value
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 16
+                            spec: {}
+                            description: Set Metric value of route
+                            required: false
+                          - name: action
+                            type: enum
+                            profiles:
+                            - xpath:
+                              - action
+                            validators:
+                            - type: values
+                              spec:
+                                values:
+                                - set
+                                - add
+                                - subtract
+                            spec:
+                              values:
+                              - value: set
+                              - value: add
+                              - value: subtract
+                            description: Set Metric action of route
+                            required: false
+                          variants: []
+                        description: Set Metric action and value of route
+                        required: false
+                      - name: next-hop
+                        type: string
+                        profiles:
+                        - xpath:
+                          - next-hop
+                        validators: []
+                        spec: {}
+                        description: Set IPv4 Next-Hop Address
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Set Tag of route
+                        required: false
+                      variants: []
+                    description: Configure RIP Redistribution Route-Map set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as RIP
+        required: false
+        variant_group_id: 0
+    description: Select Redistribution Route-Map Source as BGP
+    required: false
+    variant_group_id: 0
+  - name: connected-static
+    type: object
+    profiles:
+    - xpath:
+      - connected-static
+    validators: []
+    spec:
+      params: []
+      variants:
+      - name: bgp
+        type: object
+        profiles:
+        - xpath:
+          - bgp
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Metric of route
+                        required: false
+                      - name: ipv4
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv4
+                        validators: []
+                        spec:
+                          params:
+                          - name: address
+                            type: object
+                            profiles:
+                            - xpath:
+                              - address
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Route
+                            required: false
+                          - name: next-hop
+                            type: object
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Next-Hop of Route
+                            required: false
+                          variants: []
+                        description: Match IPv4 Details
+                        required: false
+                      - name: ipv6
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv6
+                        validators: []
+                        spec:
+                          params:
+                          - name: address
+                            type: object
+                            profiles:
+                            - xpath:
+                              - address
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv6 Route
+                            required: false
+                          - name: next-hop
+                            type: object
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv6 next-hop of Route
+                            required: false
+                          variants: []
+                        description: Match IPv6 Details
+                        required: false
+                      variants: []
+                    description: Configure Static or Connected Redistribution Route-Map
+                      Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: aggregator
+                        type: object
+                        profiles:
+                        - xpath:
+                          - aggregator
+                        validators: []
+                        spec:
+                          params:
+                          - name: as
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - as
+                            validators:
+                            - type: length
+                              spec:
+                                min: 1
+                                max: 4294967295
+                            spec: {}
+                            description: Set BGP Aggregator AS <1-4294967295>
+                            required: false
+                          - name: router-id
+                            type: string
+                            profiles:
+                            - xpath:
+                              - router-id
+                            validators: []
+                            spec: {}
+                            description: Set BGP Aggregator Router ID
+                            required: false
+                          variants: []
+                        description: Set Aggregator AS Number and Router ID
+                        required: false
+                      - name: metric
+                        type: object
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators: []
+                        spec:
+                          params:
+                          - name: value
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - value
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 4294967295
+                            spec: {}
+                            description: Set Metric value (BGP MED) of route
+                            required: false
+                          - name: action
+                            type: enum
+                            profiles:
+                            - xpath:
+                              - action
+                            validators:
+                            - type: values
+                              spec:
+                                values:
+                                - set
+                                - add
+                                - subtract
+                            spec:
+                              values:
+                              - value: set
+                              - value: add
+                              - value: subtract
+                            description: Set Metric action (BGP MED) of route
+                            required: false
+                          variants: []
+                        description: Set Metric action and value (BGP MED) of route
+                        required: false
+                      - name: ipv4
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv4
+                        validators: []
+                        spec:
+                          params:
+                          - name: source-address
+                            type: string
+                            profiles:
+                            - xpath:
+                              - source-address
+                            validators:
+                            - type: length
+                              spec:
+                                max: 128
+                            spec: {}
+                            description: Set Source IPv4 Address
+                            required: false
+                          - name: next-hop
+                            type: string
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec: {}
+                            description: Set IPv4 Next-Hop Address
+                            required: false
+                          variants: []
+                        description: Set IPv4 Address Details
+                        required: false
+                      - name: ipv6
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv6
+                        validators: []
+                        spec:
+                          params:
+                          - name: source-address
+                            type: string
+                            profiles:
+                            - xpath:
+                              - source-address
+                            validators:
+                            - type: length
+                              spec:
+                                max: 128
+                            spec: {}
+                            description: Set Source IPv6 Address
+                            required: false
+                          - name: next-hop
+                            type: string
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec: {}
+                            description: Set IPv6 Next-Hop Address
+                            required: false
+                          variants: []
+                        description: Set IPv6 Address Details
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Set Tag of route
+                        required: false
+                      - name: local-preference
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - local-preference
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Set Local Preference of route
+                        required: false
+                      - name: weight
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - weight
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Set BGP weight of the route
+                        required: false
+                      - name: origin
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - origin
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - none
+                            - egp
+                            - igp
+                            - incomplete
+                        spec:
+                          values:
+                          - value: none
+                          - value: egp
+                          - value: igp
+                          - value: incomplete
+                        description: Set BGP origin
+                        required: false
+                      - name: atomic-aggregate
+                        type: bool
+                        profiles:
+                        - xpath:
+                          - atomic-aggregate
+                        validators: []
+                        spec: {}
+                        description: Enable BGP atomic aggregate
+                        required: false
+                      - name: originator-id
+                        type: string
+                        profiles:
+                        - xpath:
+                          - originator-id
+                        validators: []
+                        spec: {}
+                        description: Set BGP Originator Id
+                        required: false
+                      - name: aspath-prepend
+                        type: list
+                        profiles:
+                        - xpath:
+                          - aspath-prepend
+                          type: member
+                        validators: []
+                        spec:
+                          type: int64
+                          items:
+                            type: int64
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: aspath-prepends
+                      - name: regular-community
+                        type: list
+                        profiles:
+                        - xpath:
+                          - regular-community
+                          type: member
+                        validators: []
+                        spec:
+                          type: string
+                          items:
+                            type: string
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: regular-communities
+                      - name: large-community
+                        type: list
+                        profiles:
+                        - xpath:
+                          - large-community
+                          type: member
+                        validators: []
+                        spec:
+                          type: string
+                          items:
+                            type: string
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: large-communities
+                      - name: extended-community
+                        type: list
+                        profiles:
+                        - xpath:
+                          - extended-community
+                          type: member
+                          min_version: 11.0.2
+                          max_version: 11.0.3
+                        validators: []
+                        spec:
+                          type: string
+                          items:
+                            type: string
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: extended-communities
+                      variants: []
+                    description: Configure BGP Redistribution Route-Map set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as BGP
+        required: false
+        variant_group_id: 0
+      - name: ospf
+        type: object
+        profiles:
+        - xpath:
+          - ospf
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Metric of route
+                        required: false
+                      - name: ipv4
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv4
+                        validators: []
+                        spec:
+                          params:
+                          - name: address
+                            type: object
+                            profiles:
+                            - xpath:
+                              - address
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Route
+                            required: false
+                          - name: next-hop
+                            type: object
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Next-Hop of Route
+                            required: false
+                          variants: []
+                        description: Match IPv4 Details
+                        required: false
+                      variants: []
+                    description: Configure Static/Connected Redistribution Route-Map
+                      Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: metric
+                        type: object
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators: []
+                        spec:
+                          params:
+                          - name: value
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - value
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 4294967295
+                            spec: {}
+                            description: Set Metric value of route
+                            required: false
+                          - name: action
+                            type: enum
+                            profiles:
+                            - xpath:
+                              - action
+                            validators:
+                            - type: values
+                              spec:
+                                values:
+                                - set
+                                - add
+                                - subtract
+                            spec:
+                              values:
+                              - value: set
+                              - value: add
+                              - value: subtract
+                            description: Set Metric action of route
+                            required: false
+                          variants: []
+                        description: Set Metric action and value of route
+                        required: false
+                      - name: metric-type
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - metric-type
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - type-1
+                            - type-2
+                        spec:
+                          default: type-2
+                          values:
+                          - value: type-1
+                          - value: type-2
+                        description: Set Metric-Type of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Set Tag of route
+                        required: false
+                      variants: []
+                    description: Configure OSPF Redistribution Route-Map Set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as OSPF
+        required: false
+        variant_group_id: 0
+      - name: ospfv3
+        type: object
+        profiles:
+        - xpath:
+          - ospfv3
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Metric of route
+                        required: false
+                      - name: ipv6
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv6
+                        validators: []
+                        spec:
+                          params:
+                          - name: address
+                            type: object
+                            profiles:
+                            - xpath:
+                              - address
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv6 Route
+                            required: false
+                          - name: next-hop
+                            type: object
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv6 next-hop of Route
+                            required: false
+                          variants: []
+                        description: Match IPv6 Details
+                        required: false
+                      variants: []
+                    description: Configure Static/Connected Redistribution Route-Map
+                      Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: metric
+                        type: object
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators: []
+                        spec:
+                          params:
+                          - name: value
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - value
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 4294967295
+                            spec: {}
+                            description: Set Metric value of route
+                            required: false
+                          - name: action
+                            type: enum
+                            profiles:
+                            - xpath:
+                              - action
+                            validators:
+                            - type: values
+                              spec:
+                                values:
+                                - set
+                                - add
+                                - subtract
+                            spec:
+                              values:
+                              - value: set
+                              - value: add
+                              - value: subtract
+                            description: Set Metric action of route
+                            required: false
+                          variants: []
+                        description: Set Metric action and value of route
+                        required: false
+                      - name: metric-type
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - metric-type
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - type-1
+                            - type-2
+                        spec:
+                          default: type-2
+                          values:
+                          - value: type-1
+                          - value: type-2
+                        description: Set Metric-Type of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Set Tag of route
+                        required: false
+                      variants: []
+                    description: Configure OSPFv3 Redistribution Route-Map Set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as OSPFv3
+        required: false
+        variant_group_id: 0
+      - name: rib
+        type: object
+        profiles:
+        - xpath:
+          - rib
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Metric of route
+                        required: false
+                      - name: ipv4
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv4
+                        validators: []
+                        spec:
+                          params:
+                          - name: address
+                            type: object
+                            profiles:
+                            - xpath:
+                              - address
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Route
+                            required: false
+                          - name: next-hop
+                            type: object
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Next-Hop of Route
+                            required: false
+                          variants: []
+                        description: Match IPv4 Details
+                        required: false
+                      - name: ipv6
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv6
+                        validators: []
+                        spec:
+                          params:
+                          - name: address
+                            type: object
+                            profiles:
+                            - xpath:
+                              - address
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv6 Route
+                            required: false
+                          - name: next-hop
+                            type: object
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv6 next-hop of Route
+                            required: false
+                          variants: []
+                        description: Match IPv6 Details
+                        required: false
+                      variants: []
+                    description: Configure Static or Connected Redistribution Route-Map
+                      Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: source-address
+                        type: string
+                        profiles:
+                        - xpath:
+                          - source-address
+                        validators:
+                        - type: length
+                          spec:
+                            max: 128
+                        spec: {}
+                        description: Set Source IPv4 or IPv6 address
+                        required: false
+                      variants: []
+                    description: Configure Routing Table (RIB) Redistribution Route-Map
+                      set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as RIB (Routing Table)
+        required: false
+        variant_group_id: 0
+      - name: rip
+        type: object
+        profiles:
+        - xpath:
+          - rip
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Metric of route
+                        required: false
+                      - name: ipv4
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv4
+                        validators: []
+                        spec:
+                          params:
+                          - name: address
+                            type: object
+                            profiles:
+                            - xpath:
+                              - address
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Route
+                            required: false
+                          - name: next-hop
+                            type: object
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec:
+                              params:
+                              - name: access-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - access-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Access-List Name
+                                required: false
+                              - name: prefix-list
+                                type: string
+                                profiles:
+                                - xpath:
+                                  - prefix-list
+                                validators:
+                                - type: length
+                                  spec:
+                                    max: 63
+                                spec: {}
+                                description: Prefix-List Name
+                                required: false
+                              variants: []
+                            description: Match IPv4 Next-Hop of Route
+                            required: false
+                          variants: []
+                        description: Match IPv4 Details
+                        required: false
+                      variants: []
+                    description: Configure Static/Connected Redistribution Route-Map
+                      Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: metric
+                        type: object
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators: []
+                        spec:
+                          params:
+                          - name: value
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - value
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 16
+                            spec: {}
+                            description: Set Metric value of route
+                            required: false
+                          - name: action
+                            type: enum
+                            profiles:
+                            - xpath:
+                              - action
+                            validators:
+                            - type: values
+                              spec:
+                                values:
+                                - set
+                                - add
+                                - subtract
+                            spec:
+                              values:
+                              - value: set
+                              - value: add
+                              - value: subtract
+                            description: Set Metric action of route
+                            required: false
+                          variants: []
+                        description: Set Metric action and value of route
+                        required: false
+                      - name: next-hop
+                        type: string
+                        profiles:
+                        - xpath:
+                          - next-hop
+                        validators: []
+                        spec: {}
+                        description: Set IPv4 Next-Hop Address
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Set Tag of route
+                        required: false
+                      variants: []
+                    description: Configure RIP Redistribution Route-Map Set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as RIP
+        required: false
+        variant_group_id: 0
+    description: Select Redistribution Route-Map Source as Static or Connected Routes
+    required: false
+    variant_group_id: 0
+  - name: ospf
+    type: object
+    profiles:
+    - xpath:
+      - ospf
+    validators: []
+    spec:
+      params: []
+      variants:
+      - name: bgp
+        type: object
+        profiles:
+        - xpath:
+          - bgp
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Metric of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Match Tag of route
+                        required: false
+                      - name: address
+                        type: object
+                        profiles:
+                        - xpath:
+                          - address
+                        validators: []
+                        spec:
+                          params:
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv4 Route
+                        required: false
+                      - name: next-hop
+                        type: object
+                        profiles:
+                        - xpath:
+                          - next-hop
+                        validators: []
+                        spec:
+                          params:
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv4 Next-Hop of Route
+                        required: false
+                      variants: []
+                    description: Configure OSPF Redistribution Route-Map Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: aggregator
+                        type: object
+                        profiles:
+                        - xpath:
+                          - aggregator
+                        validators: []
+                        spec:
+                          params:
+                          - name: as
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - as
+                            validators:
+                            - type: length
+                              spec:
+                                min: 1
+                                max: 4294967295
+                            spec: {}
+                            description: Set BGP Aggregator AS <1-4294967295>
+                            required: false
+                          - name: router-id
+                            type: string
+                            profiles:
+                            - xpath:
+                              - router-id
+                            validators: []
+                            spec: {}
+                            description: Set BGP Aggregator Router ID
+                            required: false
+                          variants: []
+                        description: Set Aggregator AS Number and Router ID
+                        required: false
+                      - name: metric
+                        type: object
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators: []
+                        spec:
+                          params:
+                          - name: value
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - value
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 4294967295
+                            spec: {}
+                            description: Set Metric value (BGP MED) of route
+                            required: false
+                          - name: action
+                            type: enum
+                            profiles:
+                            - xpath:
+                              - action
+                            validators:
+                            - type: values
+                              spec:
+                                values:
+                                - set
+                                - add
+                                - subtract
+                            spec:
+                              values:
+                              - value: set
+                              - value: add
+                              - value: subtract
+                            description: Set Metric action (BGP MED) of route
+                            required: false
+                          variants: []
+                        description: Set Metric action and value (BGP MED) of route
+                        required: false
+                      - name: ipv4
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv4
+                        validators: []
+                        spec:
+                          params:
+                          - name: source-address
+                            type: string
+                            profiles:
+                            - xpath:
+                              - source-address
+                            validators:
+                            - type: length
+                              spec:
+                                max: 128
+                            spec: {}
+                            description: Set Source IPv4 Address
+                            required: false
+                          - name: next-hop
+                            type: string
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec: {}
+                            description: Set IPv4 Next-Hop Address
+                            required: false
+                          variants: []
+                        description: Set IPv4 Address Details
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Set Tag of route
+                        required: false
+                      - name: local-preference
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - local-preference
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Set Local Preference of route
+                        required: false
+                      - name: weight
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - weight
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Set BGP weight of the route
+                        required: false
+                      - name: origin
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - origin
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - none
+                            - egp
+                            - igp
+                            - incomplete
+                        spec:
+                          values:
+                          - value: none
+                          - value: egp
+                          - value: igp
+                          - value: incomplete
+                        description: Set BGP origin
+                        required: false
+                      - name: atomic-aggregate
+                        type: bool
+                        profiles:
+                        - xpath:
+                          - atomic-aggregate
+                        validators: []
+                        spec: {}
+                        description: Enable BGP atomic aggregate
+                        required: false
+                      - name: originator-id
+                        type: string
+                        profiles:
+                        - xpath:
+                          - originator-id
+                        validators: []
+                        spec: {}
+                        description: Set BGP Originator Id
+                        required: false
+                      - name: aspath-prepend
+                        type: list
+                        profiles:
+                        - xpath:
+                          - aspath-prepend
+                          type: member
+                        validators: []
+                        spec:
+                          type: int64
+                          items:
+                            type: int64
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: aspath-prepends
+                      - name: regular-community
+                        type: list
+                        profiles:
+                        - xpath:
+                          - regular-community
+                          type: member
+                        validators: []
+                        spec:
+                          type: string
+                          items:
+                            type: string
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: regular-communities
+                      - name: large-community
+                        type: list
+                        profiles:
+                        - xpath:
+                          - large-community
+                          type: member
+                        validators: []
+                        spec:
+                          type: string
+                          items:
+                            type: string
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: large-communities
+                      - name: extended-community
+                        type: list
+                        profiles:
+                        - xpath:
+                          - extended-community
+                          type: member
+                          min_version: 11.0.2
+                          max_version: 11.0.3
+                        validators: []
+                        spec:
+                          type: string
+                          items:
+                            type: string
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: extended-communities
+                      variants: []
+                    description: Configure BGP Redistribution Route-Map set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as BGP
+        required: false
+        variant_group_id: 0
+      - name: rib
+        type: object
+        profiles:
+        - xpath:
+          - rib
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Metric of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Match Tag of route
+                        required: false
+                      - name: address
+                        type: object
+                        profiles:
+                        - xpath:
+                          - address
+                        validators: []
+                        spec:
+                          params:
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv4 Route
+                        required: false
+                      - name: next-hop
+                        type: object
+                        profiles:
+                        - xpath:
+                          - next-hop
+                        validators: []
+                        spec:
+                          params:
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv4 Next-Hop of Route
+                        required: false
+                      variants: []
+                    description: Configure OSPF Redistribution Route-Map Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: source-address
+                        type: string
+                        profiles:
+                        - xpath:
+                          - source-address
+                        validators:
+                        - type: length
+                          spec:
+                            max: 128
+                        spec: {}
+                        description: Set Source IPv4 or IPv6 address
+                        required: false
+                      variants: []
+                    description: Configure Routing Table (RIB) Redistribution Route-Map
+                      set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as RIB (Routing Table)
+        required: false
+        variant_group_id: 0
+      - name: rip
+        type: object
+        profiles:
+        - xpath:
+          - rip
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Metric of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Match Tag of route
+                        required: false
+                      - name: address
+                        type: object
+                        profiles:
+                        - xpath:
+                          - address
+                        validators: []
+                        spec:
+                          params:
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv4 Route
+                        required: false
+                      - name: next-hop
+                        type: object
+                        profiles:
+                        - xpath:
+                          - next-hop
+                        validators: []
+                        spec:
+                          params:
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv4 Next-Hop of Route
+                        required: false
+                      variants: []
+                    description: Configure OSPF Redistribution Route-Map Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: metric
+                        type: object
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators: []
+                        spec:
+                          params:
+                          - name: value
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - value
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 16
+                            spec: {}
+                            description: Set Metric value of route
+                            required: false
+                          - name: action
+                            type: enum
+                            profiles:
+                            - xpath:
+                              - action
+                            validators:
+                            - type: values
+                              spec:
+                                values:
+                                - set
+                                - add
+                                - subtract
+                            spec:
+                              values:
+                              - value: set
+                              - value: add
+                              - value: subtract
+                            description: Set Metric action of route
+                            required: false
+                          variants: []
+                        description: Set Metric action and value of route
+                        required: false
+                      - name: next-hop
+                        type: string
+                        profiles:
+                        - xpath:
+                          - next-hop
+                        validators: []
+                        spec: {}
+                        description: Set IPv4 Next-Hop Address
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Set Tag of route
+                        required: false
+                      variants: []
+                    description: Configure RIP Redistribution Route-Map set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as RIP
+        required: false
+        variant_group_id: 0
+    description: Select Redistribution Route-Map Source as OSPF
+    required: false
+    variant_group_id: 0
+  - name: ospfv3
+    type: object
+    profiles:
+    - xpath:
+      - ospfv3
+    validators: []
+    spec:
+      params: []
+      variants:
+      - name: bgp
+        type: object
+        profiles:
+        - xpath:
+          - bgp
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Metric of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Match Tag of route
+                        required: false
+                      - name: address
+                        type: object
+                        profiles:
+                        - xpath:
+                          - address
+                        validators: []
+                        spec:
+                          params:
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv6 Route
+                        required: false
+                      - name: next-hop
+                        type: object
+                        profiles:
+                        - xpath:
+                          - next-hop
+                        validators: []
+                        spec:
+                          params:
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv6 next-hop of Route
+                        required: false
+                      variants: []
+                    description: Configure OSPFv3 Redistribution Route-Map Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: aggregator
+                        type: object
+                        profiles:
+                        - xpath:
+                          - aggregator
+                        validators: []
+                        spec:
+                          params:
+                          - name: as
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - as
+                            validators:
+                            - type: length
+                              spec:
+                                min: 1
+                                max: 4294967295
+                            spec: {}
+                            description: Set BGP Aggregator AS <1-4294967295>
+                            required: false
+                          - name: router-id
+                            type: string
+                            profiles:
+                            - xpath:
+                              - router-id
+                            validators: []
+                            spec: {}
+                            description: Set BGP Aggregator Router ID
+                            required: false
+                          variants: []
+                        description: Set Aggregator AS Number and Router ID
+                        required: false
+                      - name: metric
+                        type: object
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators: []
+                        spec:
+                          params:
+                          - name: value
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - value
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 4294967295
+                            spec: {}
+                            description: Set Metric value (BGP MED) of route
+                            required: false
+                          - name: action
+                            type: enum
+                            profiles:
+                            - xpath:
+                              - action
+                            validators:
+                            - type: values
+                              spec:
+                                values:
+                                - set
+                                - add
+                                - subtract
+                            spec:
+                              values:
+                              - value: set
+                              - value: add
+                              - value: subtract
+                            description: Set Metric action (BGP MED) of route
+                            required: false
+                          variants: []
+                        description: Set Metric action and value (BGP MED) of route
+                        required: false
+                      - name: ipv6
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv6
+                        validators: []
+                        spec:
+                          params:
+                          - name: source-address
+                            type: string
+                            profiles:
+                            - xpath:
+                              - source-address
+                            validators:
+                            - type: length
+                              spec:
+                                max: 128
+                            spec: {}
+                            description: Set Source IPv6 Address
+                            required: false
+                          - name: next-hop
+                            type: string
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec: {}
+                            description: Set IPv6 Next-Hop Address
+                            required: false
+                          variants: []
+                        description: Set IPv6 Address Details
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Set Tag of route
+                        required: false
+                      - name: local-preference
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - local-preference
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Set Local Preference of route
+                        required: false
+                      - name: weight
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - weight
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Set BGP weight of the route
+                        required: false
+                      - name: origin
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - origin
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - none
+                            - egp
+                            - igp
+                            - incomplete
+                        spec:
+                          values:
+                          - value: none
+                          - value: egp
+                          - value: igp
+                          - value: incomplete
+                        description: Set BGP origin
+                        required: false
+                      - name: atomic-aggregate
+                        type: bool
+                        profiles:
+                        - xpath:
+                          - atomic-aggregate
+                        validators: []
+                        spec: {}
+                        description: Enable BGP atomic aggregate
+                        required: false
+                      - name: originator-id
+                        type: string
+                        profiles:
+                        - xpath:
+                          - originator-id
+                        validators: []
+                        spec: {}
+                        description: Set BGP Originator Id
+                        required: false
+                      - name: aspath-prepend
+                        type: list
+                        profiles:
+                        - xpath:
+                          - aspath-prepend
+                          type: member
+                        validators: []
+                        spec:
+                          type: int64
+                          items:
+                            type: int64
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: aspath-prepends
+                      - name: regular-community
+                        type: list
+                        profiles:
+                        - xpath:
+                          - regular-community
+                          type: member
+                        validators: []
+                        spec:
+                          type: string
+                          items:
+                            type: string
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: regular-communities
+                      - name: large-community
+                        type: list
+                        profiles:
+                        - xpath:
+                          - large-community
+                          type: member
+                        validators: []
+                        spec:
+                          type: string
+                          items:
+                            type: string
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: large-communities
+                      - name: extended-community
+                        type: list
+                        profiles:
+                        - xpath:
+                          - extended-community
+                          type: member
+                          min_version: 11.0.2
+                          max_version: 11.0.3
+                        validators: []
+                        spec:
+                          type: string
+                          items:
+                            type: string
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: extended-communities
+                      variants: []
+                    description: Configure BGP Redistribution Route-Map set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as BGP
+        required: false
+        variant_group_id: 0
+      - name: rib
+        type: object
+        profiles:
+        - xpath:
+          - rib
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Match Metric of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Match Tag of route
+                        required: false
+                      - name: address
+                        type: object
+                        profiles:
+                        - xpath:
+                          - address
+                        validators: []
+                        spec:
+                          params:
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv6 Route
+                        required: false
+                      - name: next-hop
+                        type: object
+                        profiles:
+                        - xpath:
+                          - next-hop
+                        validators: []
+                        spec:
+                          params:
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv6 next-hop of Route
+                        required: false
+                      variants: []
+                    description: Configure OSPFv3 Redistribution Route-Map Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: source-address
+                        type: string
+                        profiles:
+                        - xpath:
+                          - source-address
+                        validators:
+                        - type: length
+                          spec:
+                            max: 128
+                        spec: {}
+                        description: Set Source IPv4 or IPv6 address
+                        required: false
+                      variants: []
+                    description: Configure Routing Table (RIB) Redistribution Route-Map
+                      set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as RIB (Routing Table)
+        required: false
+        variant_group_id: 0
+    description: Select Redistribution Route-Map Source as OSPFv3
+    required: false
+    variant_group_id: 0
+  - name: rip
+    type: object
+    profiles:
+    - xpath:
+      - rip
+    validators: []
+    spec:
+      params: []
+      variants:
+      - name: bgp
+        type: object
+        profiles:
+        - xpath:
+          - bgp
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 16
+                        spec: {}
+                        description: Match Metric of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Match Tag of route
+                        required: false
+                      - name: address
+                        type: object
+                        profiles:
+                        - xpath:
+                          - address
+                        validators: []
+                        spec:
+                          params:
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv4 Route
+                        required: false
+                      - name: next-hop
+                        type: object
+                        profiles:
+                        - xpath:
+                          - next-hop
+                        validators: []
+                        spec:
+                          params:
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv4 Next-Hop of Route
+                        required: false
+                      variants: []
+                    description: Configure RIP Redistribution Route-Map Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: aggregator
+                        type: object
+                        profiles:
+                        - xpath:
+                          - aggregator
+                        validators: []
+                        spec:
+                          params:
+                          - name: as
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - as
+                            validators:
+                            - type: length
+                              spec:
+                                min: 1
+                                max: 4294967295
+                            spec: {}
+                            description: Set BGP Aggregator AS <1-4294967295>
+                            required: false
+                          - name: router-id
+                            type: string
+                            profiles:
+                            - xpath:
+                              - router-id
+                            validators: []
+                            spec: {}
+                            description: Set BGP Aggregator Router ID
+                            required: false
+                          variants: []
+                        description: Set Aggregator AS Number and Router ID
+                        required: false
+                      - name: metric
+                        type: object
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators: []
+                        spec:
+                          params:
+                          - name: value
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - value
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 4294967295
+                            spec: {}
+                            description: Set Metric value (BGP MED) of route
+                            required: false
+                          - name: action
+                            type: enum
+                            profiles:
+                            - xpath:
+                              - action
+                            validators:
+                            - type: values
+                              spec:
+                                values:
+                                - set
+                                - add
+                                - subtract
+                            spec:
+                              values:
+                              - value: set
+                              - value: add
+                              - value: subtract
+                            description: Set Metric action (BGP MED) of route
+                            required: false
+                          variants: []
+                        description: Set Metric action and value (BGP MED) of route
+                        required: false
+                      - name: ipv4
+                        type: object
+                        profiles:
+                        - xpath:
+                          - ipv4
+                        validators: []
+                        spec:
+                          params:
+                          - name: source-address
+                            type: string
+                            profiles:
+                            - xpath:
+                              - source-address
+                            validators:
+                            - type: length
+                              spec:
+                                max: 128
+                            spec: {}
+                            description: Set Source IPv4 Address
+                            required: false
+                          - name: next-hop
+                            type: string
+                            profiles:
+                            - xpath:
+                              - next-hop
+                            validators: []
+                            spec: {}
+                            description: Set IPv4 Next-Hop Address
+                            required: false
+                          variants: []
+                        description: Set IPv4 Address Details
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Set Tag of route
+                        required: false
+                      - name: local-preference
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - local-preference
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Set Local Preference of route
+                        required: false
+                      - name: weight
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - weight
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 4294967295
+                        spec: {}
+                        description: Set BGP weight of the route
+                        required: false
+                      - name: origin
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - origin
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - none
+                            - egp
+                            - igp
+                            - incomplete
+                        spec:
+                          values:
+                          - value: none
+                          - value: egp
+                          - value: igp
+                          - value: incomplete
+                        description: Set BGP origin
+                        required: false
+                      - name: atomic-aggregate
+                        type: bool
+                        profiles:
+                        - xpath:
+                          - atomic-aggregate
+                        validators: []
+                        spec: {}
+                        description: Enable BGP atomic aggregate
+                        required: false
+                      - name: originator-id
+                        type: string
+                        profiles:
+                        - xpath:
+                          - originator-id
+                        validators: []
+                        spec: {}
+                        description: Set BGP Originator Id
+                        required: false
+                      - name: aspath-prepend
+                        type: list
+                        profiles:
+                        - xpath:
+                          - aspath-prepend
+                          type: member
+                        validators: []
+                        spec:
+                          type: int64
+                          items:
+                            type: int64
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: aspath-prepends
+                      - name: regular-community
+                        type: list
+                        profiles:
+                        - xpath:
+                          - regular-community
+                          type: member
+                        validators: []
+                        spec:
+                          type: string
+                          items:
+                            type: string
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: regular-communities
+                      - name: large-community
+                        type: list
+                        profiles:
+                        - xpath:
+                          - large-community
+                          type: member
+                        validators: []
+                        spec:
+                          type: string
+                          items:
+                            type: string
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: large-communities
+                      - name: extended-community
+                        type: list
+                        profiles:
+                        - xpath:
+                          - extended-community
+                          type: member
+                          min_version: 11.0.2
+                          max_version: 11.0.3
+                        validators: []
+                        spec:
+                          type: string
+                          items:
+                            type: string
+                        description: ''
+                        required: false
+                        codegen_overrides:
+                          terraform:
+                            name: extended-communities
+                      variants: []
+                    description: Configure BGP Redistribution Route-Map set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as BGP
+        required: false
+        variant_group_id: 0
+      - name: ospf
+        type: object
+        profiles:
+        - xpath:
+          - ospf
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 16
+                        spec: {}
+                        description: Match Metric of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Match Tag of route
+                        required: false
+                      - name: address
+                        type: object
+                        profiles:
+                        - xpath:
+                          - address
+                        validators: []
+                        spec:
+                          params:
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv4 Route
+                        required: false
+                      - name: next-hop
+                        type: object
+                        profiles:
+                        - xpath:
+                          - next-hop
+                        validators: []
+                        spec:
+                          params:
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv4 Next-Hop of Route
+                        required: false
+                      variants: []
+                    description: Configure RIP Redistribution Route-Map Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: metric
+                        type: object
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators: []
+                        spec:
+                          params:
+                          - name: value
+                            type: int64
+                            profiles:
+                            - xpath:
+                              - value
+                            validators:
+                            - type: length
+                              spec:
+                                min: 0
+                                max: 4294967295
+                            spec: {}
+                            description: Set Metric value of route
+                            required: false
+                          - name: action
+                            type: enum
+                            profiles:
+                            - xpath:
+                              - action
+                            validators:
+                            - type: values
+                              spec:
+                                values:
+                                - set
+                                - add
+                                - subtract
+                            spec:
+                              values:
+                              - value: set
+                              - value: add
+                              - value: subtract
+                            description: Set Metric action of route
+                            required: false
+                          variants: []
+                        description: Set Metric action and value of route
+                        required: false
+                      - name: metric-type
+                        type: enum
+                        profiles:
+                        - xpath:
+                          - metric-type
+                        validators:
+                        - type: values
+                          spec:
+                            values:
+                            - type-1
+                            - type-2
+                        spec:
+                          default: type-2
+                          values:
+                          - value: type-1
+                          - value: type-2
+                        description: Set Metric-Type of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Set Tag of route
+                        required: false
+                      variants: []
+                    description: Configure OSPF Redistribution Route-Map set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as OSPFv2
+        required: false
+        variant_group_id: 0
+      - name: rib
+        type: object
+        profiles:
+        - xpath:
+          - rib
+        validators: []
+        spec:
+          params:
+          - name: route-map
+            type: list
+            profiles:
+            - xpath:
+              - route-map
+              - entry
+              type: entry
+            validators: []
+            spec:
+              type: object
+              items:
+                type: object
+                spec:
+                  params:
+                  - name: action
+                    type: enum
+                    profiles:
+                    - xpath:
+                      - action
+                    validators:
+                    - type: values
+                      spec:
+                        values:
+                        - deny
+                        - permit
+                    spec:
+                      default: deny
+                      values:
+                      - value: deny
+                      - value: permit
+                    description: Permit or Deny (default) Route Map
+                    required: false
+                  - name: description
+                    type: string
+                    profiles:
+                    - xpath:
+                      - description
+                    validators:
+                    - type: length
+                      spec:
+                        min: 0
+                        max: 1024
+                    spec: {}
+                    description: Describe Route Map
+                    required: false
+                  - name: match
+                    type: object
+                    profiles:
+                    - xpath:
+                      - match
+                    validators: []
+                    spec:
+                      params:
+                      - name: interface
+                        type: string
+                        profiles:
+                        - xpath:
+                          - interface
+                        validators:
+                        - type: length
+                          spec:
+                            max: 64
+                        spec: {}
+                        description: Match Interface of the route
+                        required: false
+                      - name: metric
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - metric
+                        validators:
+                        - type: length
+                          spec:
+                            min: 0
+                            max: 16
+                        spec: {}
+                        description: Match Metric of route
+                        required: false
+                      - name: tag
+                        type: int64
+                        profiles:
+                        - xpath:
+                          - tag
+                        validators:
+                        - type: length
+                          spec:
+                            min: 1
+                            max: 4294967295
+                        spec: {}
+                        description: Match Tag of route
+                        required: false
+                      - name: address
+                        type: object
+                        profiles:
+                        - xpath:
+                          - address
+                        validators: []
+                        spec:
+                          params:
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv4 Route
+                        required: false
+                      - name: next-hop
+                        type: object
+                        profiles:
+                        - xpath:
+                          - next-hop
+                        validators: []
+                        spec:
+                          params:
+                          - name: access-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - access-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Access-List Name
+                            required: false
+                          - name: prefix-list
+                            type: string
+                            profiles:
+                            - xpath:
+                              - prefix-list
+                            validators:
+                            - type: length
+                              spec:
+                                max: 63
+                            spec: {}
+                            description: Prefix-List Name
+                            required: false
+                          variants: []
+                        description: Match IPv4 Next-Hop of Route
+                        required: false
+                      variants: []
+                    description: Configure RIP Redistribution Route-Map Match attributes
+                    required: false
+                  - name: set
+                    type: object
+                    profiles:
+                    - xpath:
+                      - set
+                    validators: []
+                    spec:
+                      params:
+                      - name: source-address
+                        type: string
+                        profiles:
+                        - xpath:
+                          - source-address
+                        validators:
+                        - type: length
+                          spec:
+                            max: 128
+                        spec: {}
+                        description: Set Source IPv4 or IPv6 address
+                        required: false
+                      variants: []
+                    description: Configure Routing Table (RIB) Redistribution Route-Map
+                      set attributes
+                    required: false
+                  variants: []
+            description: ''
+            required: false
+          variants: []
+        description: Select Redistribution Route-Map Destination as RIB (Routing Table)
+        required: false
+        variant_group_id: 0
+    description: Select Redistribution Route-Map Source as RIP
+    required: false
+    variant_group_id: 0


### PR DESCRIPTION
  Terraform Resource: panos_filters_route_maps_redistribution_routing_profile

  This resource manages Filters Route Maps Redistribution Routing Profiles in PAN-OS, which control route redistribution between routing protocols (BGP, OSPF, OSPFv3, RIP) and the RIB (Routing Information Base).

  Parameters with Codegen Overrides (Renamed)

  | PAN-OS Name        | Terraform Name       | Description             | Type   |
  |--------------------|----------------------|-------------------------|--------|
  | regular-community  | regular_communities  | Regular Community Name  | string |
  | large-community    | large_communities    | Large Community Name    | string |
  | extended-community | extended_communities | Extended Community Name | string |
  | as-path-prepend    | aspath_prepends      | AS Path Prepend values  | object |

  Main Structure

  Top-Level Variants (Source Protocols)

  | Variant          | Description                                     |
  |------------------|-------------------------------------------------|
  | bgp              | Routes from BGP to be redistributed             |
  | connected_static | Connected and static routes to be redistributed |
  | ospf             | Routes from OSPF to be redistributed            |
  | ospfv3           | Routes from OSPFv3 to be redistributed          |
  | rip              | Routes from RIP to be redistributed             |

  Destination Protocols (Nested under source variants)

  Each source protocol variant contains one or more destination protocol objects:

  | Destination | Description            |
  |-------------|------------------------|
  | bgp         | Redistribute to BGP    |
  | ospf        | Redistribute to OSPF   |
  | ospfv3      | Redistribute to OSPFv3 |
  | rib         | Redistribute to RIB    |
  | rip         | Redistribute to RIP    |

  Route Map Parameters

  Each destination protocol contains a route_map list with the following attributes:

  Common Parameters:
  | Parameter   | Type   | Description                                |
  |-------------|--------|--------------------------------------------|
  | name        | string | Route map entry name (required, entry key) |
  | action      | enum   | Permit or Deny (default: deny)             |
  | description | string | Describe Route Map (max 1024 chars)        |

  Match Conditions:
  | Parameter            | Type    | Description                                             |
  |----------------------|---------|---------------------------------------------------------|
  | as_path_access_list  | string  | AS Path Access List Name (max 63 chars)                 |
  | regular_communities  | string  | Regular Community Name (max 63 chars)                   |
  | large_communities    | string  | Large Community Name (max 63 chars)                     |
  | extended_communities | string  | Extended Community Name (max 63 chars)                  |
  | interface            | string  | Interface Name (max 63 chars)                           |
  | origin               | enum    | BGP origin (igp, egp, incomplete)                       |
  | metric               | integer | Route metric (0-4294967295)                             |
  | tag                  | integer | Route tag (0-4294967295)                                |
  | local_preference     | integer | Local preference (0-4294967295)                         |
  | peer                 | string  | Peer IP address or name (max 63 chars)                  |
  | ipv4                 | object  | IPv4 address matching (address, next-hop, route-source) |
  | ipv6                 | object  | IPv6 address matching (address, next-hop)               |

  IPv4/IPv6 Match Object:
  | Parameter                | Type   | Description                                   |
  |--------------------------|--------|-----------------------------------------------|
  | address.access_list      | string | Access list name for address matching         |
  | address.prefix_list      | string | Prefix list name for address matching         |
  | next_hop.access_list     | string | Access list name for next-hop matching        |
  | next_hop.prefix_list     | string | Prefix list name for next-hop matching        |
  | route_source.access_list | string | Access list name for route source (IPv4 only) |
  | route_source.prefix_list | string | Prefix list name for route source (IPv4 only) |

  Set Actions (varies by destination protocol):

  For BGP destinations:
  | Parameter            | Type    | Description                                              |
  |----------------------|---------|----------------------------------------------------------|
  | metric.value         | integer | Metric value (0-4294967295)                              |
  | metric.action        | enum    | add, subtract, set                                       |
  | origin               | enum    | BGP origin (igp, egp, incomplete)                        |
  | local_preference     | integer | Local preference (0-4294967295)                          |
  | as_path_limit        | integer | AS path limit (1-255)                                    |
  | as_path_type         | enum    | AS path type (none, remove, prepend, remove-and-prepend) |
  | aspath_prepends      | object  | AS path prepend configuration                            |
  | regular_communities  | object  | Regular community action and values                      |
  | large_communities    | object  | Large community action and values                        |
  | extended_communities | object  | Extended community action and values                     |
  | weight               | integer | BGP weight (0-65535)                                     |
  | aggregator           | object  | BGP aggregator settings                                  |
  | atomic_aggregate     | boolean | Set atomic aggregate                                     |
  | originator_id        | string  | Originator ID                                            |
  | ipv4.next_hop        | string  | IPv4 next-hop address                                    |
  | ipv6.next_hop        | string  | IPv6 next-hop address                                    |
  | tag                  | integer | Route tag (BGP-to-RIB only)                              |

  For OSPF/OSPFv3 destinations:
  | Parameter     | Type    | Description                 |
  |---------------|---------|-----------------------------|
  | metric.value  | integer | Metric value (0-4294967295) |
  | metric.action | enum    | add, subtract, set          |
  | metric_type   | enum    | type-1, type-2              |
  | tag           | integer | Route tag (0-4294967295)    |

  For RIP destinations:
  | Parameter     | Type    | Description                 |
  |---------------|---------|-----------------------------|
  | metric.value  | integer | Metric value (0-4294967295) |
  | metric.action | enum    | add, subtract, set          |
  | next_hop      | string  | Next-hop IP address         |
  | tag           | integer | Route tag (0-4294967295)    |

  Locations

  - ngfw: Configured on NGFW devices
  - template: Configured in Panorama templates
  - template-stack: Configured in Panorama template stacks