### PR TITLE
feat(specs): Add spec, tests and examples for panos_monitor_profile

### DIFF
--- a/assets/terraform/examples/resources/panos_monitor_profile/resource.tf
+++ b/assets/terraform/examples/resources/panos_monitor_profile/resource.tf
@@ -1,0 +1,48 @@
+provider "panos" {}
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name     = "example-template"
+}
+
+# Example 1: Monitor profile with default values (minimal configuration)
+resource "panos_monitor_profile" "minimal" {
+  depends_on = [panos_template.example]
+  location = {
+    template = {
+      name = panos_template.example.name
+    }
+  }
+
+  name = "minimal-monitor-profile"
+}
+
+# Example 2: Monitor profile with fail-over action
+resource "panos_monitor_profile" "failover" {
+  depends_on = [panos_template.example]
+  location = {
+    template = {
+      name = panos_template.example.name
+    }
+  }
+
+  name      = "failover-monitor-profile"
+  action    = "fail-over"
+  interval  = 5
+  threshold = 3
+}
+
+# Example 3: Monitor profile with wait-recover action and custom settings
+resource "panos_monitor_profile" "custom" {
+  depends_on = [panos_template.example]
+  location = {
+    template = {
+      name = panos_template.example.name
+    }
+  }
+
+  name      = "custom-monitor-profile"
+  action    = "wait-recover"
+  interval  = 10
+  threshold = 7
+}

--- a/assets/terraform/test/resource_monitor_profile_test.go
+++ b/assets/terraform/test/resource_monitor_profile_test.go
@@ -1,0 +1,205 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccMonitorProfile_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: monitorProfile_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_monitor_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_monitor_profile.example",
+						tfjsonpath.New("action"),
+						knownvalue.StringExact("fail-over"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_monitor_profile.example",
+						tfjsonpath.New("interval"),
+						knownvalue.Int64Exact(10),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_monitor_profile.example",
+						tfjsonpath.New("threshold"),
+						knownvalue.Int64Exact(7),
+					),
+				},
+			},
+		},
+	})
+}
+
+const monitorProfile_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_monitor_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  action = "fail-over"
+  interval = 10
+  threshold = 7
+}
+`
+
+func TestAccMonitorProfile_Action_WaitRecover(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: monitorProfile_Action_WaitRecover_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_monitor_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_monitor_profile.example",
+						tfjsonpath.New("action"),
+						knownvalue.StringExact("wait-recover"),
+					),
+				},
+			},
+		},
+	})
+}
+
+const monitorProfile_Action_WaitRecover_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_monitor_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  action = "wait-recover"
+}
+`
+
+func TestAccMonitorProfile_MinimalConfig(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: monitorProfile_MinimalConfig_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_monitor_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_monitor_profile.example",
+						tfjsonpath.New("action"),
+						knownvalue.StringExact("wait-recover"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_monitor_profile.example",
+						tfjsonpath.New("interval"),
+						knownvalue.Int64Exact(3),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_monitor_profile.example",
+						tfjsonpath.New("threshold"),
+						knownvalue.Int64Exact(5),
+					),
+				},
+			},
+		},
+	})
+}
+
+const monitorProfile_MinimalConfig_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_monitor_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+}
+`

--- a/specs/network/profiles/monitoring.yaml
+++ b/specs/network/profiles/monitoring.yaml
@@ -1,0 +1,168 @@
+name: monitor-profile
+terraform_provider_config:
+  description: Monitor Network Profile
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants:
+  - singular
+  suffix: monitor_profile
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+go_sdk_config:
+  skip: false
+  package:
+  - network
+  - profiles
+  - monitor
+panos_xpath:
+  path:
+  - network
+  - profiles
+  - monitor-profile
+  vars: []
+locations:
+- name: ngfw
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific NGFW device
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: Specific Panorama template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template stack
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+imports: []
+spec:
+  params:
+  - name: action
+    type: enum
+    profiles:
+    - xpath:
+      - action
+    validators:
+    - type: values
+      spec:
+        values:
+        - wait-recover
+        - fail-over
+    spec:
+      default: wait-recover
+      values:
+      - value: wait-recover
+      - value: fail-over
+    description: configure action triggered when tunnel status change
+    required: false
+  - name: interval
+    type: int64
+    profiles:
+    - xpath:
+      - interval
+    validators:
+    - type: length
+      spec:
+        min: 2
+        max: 100
+    spec:
+      default: 3
+    description: probing interval in seconds
+    required: false
+  - name: threshold
+    type: int64
+    profiles:
+    - xpath:
+      - threshold
+    validators:
+    - type: length
+      spec:
+        min: 2
+        max: 10
+    spec:
+      default: 5
+    description: number of failed probe to determine tunnel is down
+    required: false
+  variants: []


### PR DESCRIPTION
  Terraform Resource Name

  panos_monitor_profile

  Description

  Monitor network profiles configure tunnel health monitoring for VPN tunnels in PAN-OS. These profiles define how the firewall monitors tunnel status through periodic probing and what action to take when a tunnel failure is detected.

  Parameters

  This resource has no renamed parameters or variants. All parameters use their original PAN-OS names:

  | Parameter | Type   | Required | Default      | Description                                                                        |
  |-----------|--------|----------|--------------|------------------------------------------------------------------------------------|
  | name      | string | Yes      | -            | Monitor profile name                                                               |
  | action    | string | No       | wait-recover | Action triggered when tunnel status changes. Valid values: wait-recover, fail-over |
  | interval  | number | No       | 3            | Probing interval in seconds (range: 2-100)                                         |
  | threshold | number | No       | 5            | Number of failed probes to determine tunnel is down (range: 2-10)                  |

  Supported Locations

  - NGFW device
  - Panorama template
  - Panorama template stack

Closes: #642