### PR TITLE
feat(specs): Add spec, tests and examples for panos_multicast_ipv4_pim_interface_timer_routing_profile

### DIFF
--- a/assets/terraform/examples/resources/panos_multicast_pim_interface_timer_routing_profile/import.sh
+++ b/assets/terraform/examples/resources/panos_multicast_pim_interface_timer_routing_profile/import.sh
@@ -1,0 +1,13 @@
+# A multicast PIM interface timer routing profile can be imported by providing the following base64 encoded object as the ID
+# {
+#   location = {
+#     template = {
+#       name            = "my-template"
+#       panorama_device = "localhost.localdomain"
+#       ngfw_device     = "localhost.localdomain"
+#     }
+#   }
+#
+#   name = "example-pim-timer-profile"
+# }
+terraform import panos_multicast_pim_interface_timer_routing_profile.example $(echo '{"location":{"template":{"name":"my-template","panorama_device":"localhost.localdomain","ngfw_device":"localhost.localdomain"}},"name":"example-pim-timer-profile"}' | base64)

--- a/assets/terraform/examples/resources/panos_multicast_pim_interface_timer_routing_profile/resource.tf
+++ b/assets/terraform/examples/resources/panos_multicast_pim_interface_timer_routing_profile/resource.tf
@@ -1,0 +1,12 @@
+resource "panos_multicast_pim_interface_timer_routing_profile" "example" {
+  location = {
+    template = {
+      name = "my-template"
+    }
+  }
+
+  name                = "example-pim-timer-profile"
+  assert_interval     = 200
+  hello_interval      = 60
+  join_prune_interval = 120
+}

--- a/assets/terraform/test/resource_multicast_pim_interface_timer_routing_profile_test.go
+++ b/assets/terraform/test/resource_multicast_pim_interface_timer_routing_profile_test.go
@@ -1,0 +1,82 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccMulticastPimInterfaceTimerRoutingProfile_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: multicastPimInterfaceTimerRoutingProfile_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_multicast_pim_interface_timer_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_pim_interface_timer_routing_profile.example",
+						tfjsonpath.New("assert_interval"),
+						knownvalue.Int64Exact(200),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_pim_interface_timer_routing_profile.example",
+						tfjsonpath.New("hello_interval"),
+						knownvalue.Int64Exact(60),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_pim_interface_timer_routing_profile.example",
+						tfjsonpath.New("join_prune_interval"),
+						knownvalue.Int64Exact(120),
+					),
+				},
+			},
+		},
+	})
+}
+
+const multicastPimInterfaceTimerRoutingProfile_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_multicast_pim_interface_timer_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  assert_interval = 200
+  hello_interval = 60
+  join_prune_interval = 120
+}
+`

--- a/specs/network/routing-profiles/multicast-pim-interface-timer-profile.yaml
+++ b/specs/network/routing-profiles/multicast-pim-interface-timer-profile.yaml
@@ -1,0 +1,166 @@
+name: multicast-pim-interface-timer-routing-profile
+terraform_provider_config:
+  description: Multicast IPv4 PIM Interface Timer Routing Profile
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants:
+  - singular
+  suffix: multicast_pim_interface_timer_routing_profile
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+go_sdk_config:
+  skip: false
+  package:
+  - network
+  - routing-profile
+  - multicast
+  - ipv4
+  - piminterfacetimer
+panos_xpath:
+  path:
+  - network
+  - routing-profile
+  - multicast
+  - pim-interface-timer-profile
+  vars: []
+locations:
+- name: ngfw
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific NGFW device
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: Specific Panorama template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template stack
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+spec:
+  params:
+  - name: assert-interval
+    type: int64
+    profiles:
+    - xpath:
+      - assert-interval
+    validators:
+    - type: length
+      spec:
+        min: 1
+        max: 65534
+    spec:
+      default: 177
+    description: interval between PIM Assert messages, in seconds
+    required: false
+  - name: hello-interval
+    type: int64
+    profiles:
+    - xpath:
+      - hello-interval
+    validators:
+    - type: length
+      spec:
+        min: 1
+        max: 180
+    spec:
+      default: 30
+    description: interval between PIM Hello messages, in seconds
+    required: false
+  - name: join-prune-interval
+    type: int64
+    profiles:
+    - xpath:
+      - join-prune-interval
+    validators:
+    - type: length
+      spec:
+        min: 60
+        max: 600
+    spec:
+      default: 60
+    description: interval between PIM Join/Prune messages, in seconds
+    required: false
+  variants: []


### PR DESCRIPTION
  Multicast PIM Interface Timer Routing Profile

  Terraform Resource Name

  panos_multicast_pim_interface_timer_routing_profile

  Parameters

  Standard Parameters

  | Name                | Type  | Description                                          | Default | Range/Validation |
  |---------------------|-------|------------------------------------------------------|---------|------------------|
  | assert-interval     | int64 | Interval between PIM Assert messages, in seconds     | 177     | 1-65534          |
  | hello-interval      | int64 | Interval between PIM Hello messages, in seconds      | 30      | 1-180            |
  | join-prune-interval | int64 | Interval between PIM Join/Prune messages, in seconds | 60      | 60-600           |