### PR TITLE
feat(specs): Add spec, tests and examples for panos_multicast_ipv4_igmp_interface_query_routing_profile

### DIFF
--- a/assets/terraform/examples/resources/panos_multicast_igmp_interface_query_routing_profile/import.sh
+++ b/assets/terraform/examples/resources/panos_multicast_igmp_interface_query_routing_profile/import.sh
@@ -1,0 +1,12 @@
+# A multicast IGMP interface query routing profile can be imported by providing the following base64 encoded object as the ID
+# {
+#   location = {
+#     template = {
+#       name            = "example-template"
+#       panorama_device = "localhost.localdomain"
+#     }
+#   }
+#
+#   name = "igmp-query-profile1"
+# }
+terraform import panos_multicast_igmp_interface_query_routing_profile.example $(echo '{"location":{"template":{"name":"example-template","panorama_device":"localhost.localdomain"}},"name":"igmp-query-profile1"}' | base64)

--- a/assets/terraform/examples/resources/panos_multicast_igmp_interface_query_routing_profile/resource.tf
+++ b/assets/terraform/examples/resources/panos_multicast_igmp_interface_query_routing_profile/resource.tf
@@ -1,0 +1,38 @@
+resource "panos_multicast_igmp_interface_query_routing_profile" "example" {
+  location = {
+    template = {
+      name = panos_template.example.name
+    }
+  }
+
+  for_each = tomap({
+    "igmp-query-profile1" = {
+      description                = "IGMP query profile with immediate leave"
+      immediate_leave            = true
+      last_member_query_interval = 5
+      max_query_response_time    = 15
+      query_interval             = 200
+    }
+    "igmp-query-profile2" = {
+      description                = "IGMP query profile with default values"
+      immediate_leave            = false
+      last_member_query_interval = 1
+      max_query_response_time    = 10
+      query_interval             = 125
+    }
+  })
+
+  name                       = each.key
+  immediate_leave            = each.value.immediate_leave
+  last_member_query_interval = each.value.last_member_query_interval
+  max_query_response_time    = each.value.max_query_response_time
+  query_interval             = each.value.query_interval
+}
+
+resource "panos_template" "example" {
+  location = {
+    panorama = {}
+  }
+
+  name = "example-template"
+}

--- a/assets/terraform/test/resource_multicast_igmp_interface_query_routing_profile_test.go
+++ b/assets/terraform/test/resource_multicast_igmp_interface_query_routing_profile_test.go
@@ -1,0 +1,88 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccMulticastIgmpInterfaceQueryRoutingProfile_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: multicastIgmpInterfaceQueryRoutingProfile_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_multicast_igmp_interface_query_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_igmp_interface_query_routing_profile.example",
+						tfjsonpath.New("immediate_leave"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_igmp_interface_query_routing_profile.example",
+						tfjsonpath.New("last_member_query_interval"),
+						knownvalue.Int64Exact(5),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_igmp_interface_query_routing_profile.example",
+						tfjsonpath.New("max_query_response_time"),
+						knownvalue.Int64Exact(15),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_igmp_interface_query_routing_profile.example",
+						tfjsonpath.New("query_interval"),
+						knownvalue.Int64Exact(200),
+					),
+				},
+			},
+		},
+	})
+}
+
+const multicastIgmpInterfaceQueryRoutingProfile_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_multicast_igmp_interface_query_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  immediate_leave = true
+  last_member_query_interval = 5
+  max_query_response_time = 15
+  query_interval = 200
+}
+`

--- a/specs/network/routing-profiles/multicast-ipv4-igmp-interface-query-profile.yaml
+++ b/specs/network/routing-profiles/multicast-ipv4-igmp-interface-query-profile.yaml
@@ -1,0 +1,177 @@
+name: multicast-igmp-interface-query-routing-profile
+terraform_provider_config:
+  description: Multicast IGMP Interface Query Routing Profile
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants:
+  - singular
+  suffix: multicast_igmp_interface_query_routing_profile
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+go_sdk_config:
+  skip: false
+  package:
+  - network
+  - routing-profile
+  - multicast
+  - ipv4
+  - igmpinterfacequery
+panos_xpath:
+  path:
+  - network
+  - routing-profile
+  - multicast
+  - igmp-interface-query-profile
+  vars: []
+locations:
+- name: ngfw
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific NGFW device
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: Specific Panorama template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template stack
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+spec:
+  params:
+  - name: immediate-leave
+    type: bool
+    profiles:
+    - xpath:
+      - immediate-leave
+    validators: []
+    spec: {}
+    description: leave group immediately when a leave message is received
+    required: false
+  - name: last-member-query-interval
+    type: int64
+    profiles:
+    - xpath:
+      - last-member-query-interval
+    validators:
+    - type: length
+      spec:
+        min: 1
+        max: 25
+    spec:
+      default: 1
+    description: interval between group/source specific query messages (including
+      those sent in response of leave group messages)
+    required: false
+  - name: max-query-response-time
+    type: int64
+    profiles:
+    - xpath:
+      - max-query-response-time
+    validators:
+    - type: length
+      spec:
+        min: 1
+        max: 25
+    spec:
+      default: 10
+    description: maximum query response time for general group membership queries
+      in seconds
+    required: false
+  - name: query-interval
+    type: int64
+    profiles:
+    - xpath:
+      - query-interval
+    validators:
+    - type: length
+      spec:
+        min: 1
+        max: 1800
+    spec:
+      default: 125
+    description: interval between group/source specific query messages
+    required: false
+  variants: []


### PR DESCRIPTION
  Multicast IGMP Interface Query Routing Profile

  Terraform Resource Name

  panos_multicast_igmp_interface_query_routing_profile

  Parameters

  Standard Parameters

  | Name                       | Type  | Description                                                                                                      | Default | Range/Validation |
  |----------------------------|-------|------------------------------------------------------------------------------------------------------------------|---------|------------------|
  | immediate-leave            | bool  | Leave group immediately when a leave message is received                                                         | -       | -                |
  | last-member-query-interval | int64 | Interval between group/source specific query messages (including those sent in response of leave group messages) | 1       | 1-25             |
  | max-query-response-time    | int64 | Maximum query response time for general group membership queries in seconds                                      | 10      | 1-25             |
  | query-interval             | int64 | Interval between group/source specific query messages                                                            | 125     | 1-1800           |

  Notes

  - No parameter or variant overrides required
  - No top-level variants defined
  - All parameters use standard naming conventions aligned with IGMP protocol terminology
  - Supports NGFW, Template, and Template Stack locations