### PR TITLE
feat(specs): Add spec, tests and examples for panos_multicast_msdp_authentication_routing_profile

### DIFF
--- a/assets/terraform/examples/resources/panos_multicast_msdp_authentication_routing_profile/import.sh
+++ b/assets/terraform/examples/resources/panos_multicast_msdp_authentication_routing_profile/import.sh
@@ -1,0 +1,12 @@
+# A multicast MSDP authentication routing profile can be imported by providing the following base64 encoded object as the ID
+# {
+#   location = {
+#     template = {
+#       name            = "multicast-routing-template"
+#       panorama_device = "localhost.localdomain"
+#     }
+#   }
+#
+#   name = "msdp-auth-profile"
+# }
+terraform import panos_multicast_msdp_authentication_routing_profile.example $(echo '{"location":{"template":{"name":"multicast-routing-template","panorama_device":"localhost.localdomain"}},"name":"msdp-auth-profile"}' | base64)

--- a/assets/terraform/examples/resources/panos_multicast_msdp_authentication_routing_profile/resource.tf
+++ b/assets/terraform/examples/resources/panos_multicast_msdp_authentication_routing_profile/resource.tf
@@ -1,0 +1,28 @@
+# Create a template
+resource "panos_template" "multicast_template" {
+  location = { panorama = {} }
+  name     = "multicast-routing-template"
+}
+
+# MSDP Authentication Profile with secret
+resource "panos_multicast_msdp_authentication_routing_profile" "with_secret" {
+  location = {
+    template = {
+      name = panos_template.multicast_template.name
+    }
+  }
+
+  name   = "msdp-auth-profile"
+  secret = "mySecretKey123!"
+}
+
+# MSDP Authentication Profile without secret
+resource "panos_multicast_msdp_authentication_routing_profile" "without_secret" {
+  location = {
+    template = {
+      name = panos_template.multicast_template.name
+    }
+  }
+
+  name = "msdp-auth-profile-no-secret"
+}

--- a/assets/terraform/test/resource_multicast_msdp_authentication_routing_profile_test.go
+++ b/assets/terraform/test/resource_multicast_msdp_authentication_routing_profile_test.go
@@ -1,0 +1,188 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccMulticastMsdpAuthenticationRoutingProfile_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: multicastMsdpAuthenticationRoutingProfile_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_authentication_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_authentication_routing_profile.example",
+						tfjsonpath.New("secret"),
+						knownvalue.StringExact("mySecret123!"),
+					),
+				},
+			},
+		},
+	})
+}
+
+const multicastMsdpAuthenticationRoutingProfile_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_multicast_msdp_authentication_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  secret = "mySecret123!"
+}
+`
+
+func TestAccMulticastMsdpAuthenticationRoutingProfile_NoSecret(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: multicastMsdpAuthenticationRoutingProfile_NoSecret_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_authentication_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_authentication_routing_profile.example",
+						tfjsonpath.New("secret"),
+						knownvalue.Null(),
+					),
+				},
+			},
+		},
+	})
+}
+
+const multicastMsdpAuthenticationRoutingProfile_NoSecret_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_multicast_msdp_authentication_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+}
+`
+
+func TestAccMulticastMsdpAuthenticationRoutingProfile_MaxLengthSecret(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	// Generate a 63-character secret (max allowed length)
+	maxLengthSecret := acctest.RandStringFromCharSet(63, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#%^")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: multicastMsdpAuthenticationRoutingProfile_MaxLengthSecret_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":            config.StringVariable(prefix),
+					"location":          location,
+					"max_length_secret": config.StringVariable(maxLengthSecret),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_authentication_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_authentication_routing_profile.example",
+						tfjsonpath.New("secret"),
+						knownvalue.StringExact(maxLengthSecret),
+					),
+				},
+			},
+		},
+	})
+}
+
+const multicastMsdpAuthenticationRoutingProfile_MaxLengthSecret_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+variable "max_length_secret" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_multicast_msdp_authentication_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  secret = var.max_length_secret
+}
+`

--- a/specs/network/routing-profiles/multicast-msdp-authentication-profile.yaml
+++ b/specs/network/routing-profiles/multicast-msdp-authentication-profile.yaml
@@ -1,0 +1,138 @@
+name: multicast-msdp-authentication-routing-profile
+terraform_provider_config:
+  description: Multicast MSDP Authentication Routing Profile
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants:
+  - singular
+  suffix: multicast_msdp_authentication_routing_profile
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+go_sdk_config:
+  skip: false
+  package:
+  - network
+  - routing-profile
+  - multicast
+  - msdp
+  - auth
+panos_xpath:
+  path:
+  - network
+  - routing-profile
+  - multicast
+  - msdp-auth-profile
+  vars: []
+locations:
+- name: ngfw
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific NGFW device
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: Specific Panorama template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template stack
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+spec:
+  params:
+  - name: secret
+    type: string
+    profiles:
+    - xpath:
+      - secret
+    validators:
+    - type: length
+      spec:
+        max: 63
+    spec: {}
+    description: shared secret for the TCP MD5 authentication, [a-zA-Z0-9!@#%^]
+    required: false
+    hashing:
+      type: solo
+  variants: []


### PR DESCRIPTION
  Add Multicast MSDP Authentication Routing Profile

  Terraform Resource Name

  panos_multicast_msdp_authentication_routing_profile

  Description

  Multicast MSDP Authentication Routing Profile

  Parameters with Overrides

  No parameters or variants have been renamed (no codegen_overrides.terraform.name present).

  Parameters and Attributes

  | Parameter | Type   | Required | Description                                                                                |
  |-----------|--------|----------|--------------------------------------------------------------------------------------------|
  | name      | string | Yes      | Profile name (entry identifier)                                                            |
  | secret    | string | No       | Shared secret for the TCP MD5 authentication, [a-zA-Z0-9!@#%^] (max length: 63 characters) |

  Supported Locations

  - NGFW: Located in a specific NGFW device
  - Template: Located in a specific Panorama template
  - Template Stack: Located in a specific Panorama template stack