### PR TITLE
feat(specs): Add spec, tests and examples for panos_multicast_msdp_timer_routing_profile

### DIFF
--- a/assets/terraform/examples/resources/panos_multicast_msdp_timer_routing_profile/import.sh
+++ b/assets/terraform/examples/resources/panos_multicast_msdp_timer_routing_profile/import.sh
@@ -1,0 +1,12 @@
+# A multicast MSDP timer routing profile can be imported by providing the following base64 encoded object as the ID
+# {
+#   location = {
+#     template = {
+#       name            = "multicast-routing-template"
+#       panorama_device = "localhost.localdomain"
+#     }
+#   }
+#
+#   name = "msdp-timer-profile-custom"
+# }
+terraform import panos_multicast_msdp_timer_routing_profile.example $(echo '{"location":{"template":{"name":"multicast-routing-template","panorama_device":"localhost.localdomain"}},"name":"msdp-timer-profile-custom"}' | base64)

--- a/assets/terraform/examples/resources/panos_multicast_msdp_timer_routing_profile/resource.tf
+++ b/assets/terraform/examples/resources/panos_multicast_msdp_timer_routing_profile/resource.tf
@@ -1,0 +1,62 @@
+# Create a template
+resource "panos_template" "multicast_template" {
+  location = { panorama = {} }
+  name     = "multicast-routing-template"
+}
+
+# MSDP Timer Profile with custom values
+resource "panos_multicast_msdp_timer_routing_profile" "custom_timers" {
+  location = {
+    template = {
+      name = panos_template.multicast_template.name
+    }
+  }
+
+  name                      = "msdp-timer-profile-custom"
+  connection_retry_interval = 15
+  keep_alive_interval       = 30
+  message_timeout           = 45
+}
+
+# MSDP Timer Profile with default values
+resource "panos_multicast_msdp_timer_routing_profile" "default_timers" {
+  location = {
+    template = {
+      name = panos_template.multicast_template.name
+    }
+  }
+
+  name = "msdp-timer-profile-default"
+  # Uses default values:
+  # connection_retry_interval = 30
+  # keep_alive_interval = 60
+  # message_timeout = 75
+}
+
+# MSDP Timer Profile with maximum values
+resource "panos_multicast_msdp_timer_routing_profile" "max_timers" {
+  location = {
+    template = {
+      name = panos_template.multicast_template.name
+    }
+  }
+
+  name                      = "msdp-timer-profile-max"
+  connection_retry_interval = 60
+  keep_alive_interval       = 60
+  message_timeout           = 75
+}
+
+# MSDP Timer Profile with minimum values
+resource "panos_multicast_msdp_timer_routing_profile" "min_timers" {
+  location = {
+    template = {
+      name = panos_template.multicast_template.name
+    }
+  }
+
+  name                      = "msdp-timer-profile-min"
+  connection_retry_interval = 1
+  keep_alive_interval       = 1
+  message_timeout           = 1
+}

--- a/assets/terraform/test/resource_multicast_msdp_timer_routing_profile_test.go
+++ b/assets/terraform/test/resource_multicast_msdp_timer_routing_profile_test.go
@@ -1,0 +1,286 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccMulticastMsdpTimerRoutingProfile_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: multicastMsdpTimerRoutingProfile_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("connection_retry_interval"),
+						knownvalue.Int64Exact(15),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("keep_alive_interval"),
+						knownvalue.Int64Exact(30),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("message_timeout"),
+						knownvalue.Int64Exact(45),
+					),
+				},
+			},
+		},
+	})
+}
+
+const multicastMsdpTimerRoutingProfile_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_multicast_msdp_timer_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  connection_retry_interval = 15
+  keep_alive_interval = 30
+  message_timeout = 45
+}
+`
+
+func TestAccMulticastMsdpTimerRoutingProfile_MinValues(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: multicastMsdpTimerRoutingProfile_MinValues_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("connection_retry_interval"),
+						knownvalue.Int64Exact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("keep_alive_interval"),
+						knownvalue.Int64Exact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("message_timeout"),
+						knownvalue.Int64Exact(1),
+					),
+				},
+			},
+		},
+	})
+}
+
+const multicastMsdpTimerRoutingProfile_MinValues_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_multicast_msdp_timer_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  connection_retry_interval = 1
+  keep_alive_interval = 1
+  message_timeout = 1
+}
+`
+
+func TestAccMulticastMsdpTimerRoutingProfile_MaxValues(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: multicastMsdpTimerRoutingProfile_MaxValues_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("connection_retry_interval"),
+						knownvalue.Int64Exact(60),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("keep_alive_interval"),
+						knownvalue.Int64Exact(60),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("message_timeout"),
+						knownvalue.Int64Exact(75),
+					),
+				},
+			},
+		},
+	})
+}
+
+const multicastMsdpTimerRoutingProfile_MaxValues_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_multicast_msdp_timer_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  connection_retry_interval = 60
+  keep_alive_interval = 60
+  message_timeout = 75
+}
+`
+
+func TestAccMulticastMsdpTimerRoutingProfile_Defaults(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: multicastMsdpTimerRoutingProfile_Defaults_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("connection_retry_interval"),
+						knownvalue.Int64Exact(30),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("keep_alive_interval"),
+						knownvalue.Int64Exact(60),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_multicast_msdp_timer_routing_profile.example",
+						tfjsonpath.New("message_timeout"),
+						knownvalue.Int64Exact(75),
+					),
+				},
+			},
+		},
+	})
+}
+
+const multicastMsdpTimerRoutingProfile_Defaults_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_multicast_msdp_timer_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+}
+`

--- a/specs/network/routing-profiles/multicast-msdp-timer-profile.yaml
+++ b/specs/network/routing-profiles/multicast-msdp-timer-profile.yaml
@@ -1,0 +1,166 @@
+name: multicast-msdp-timer-routing-profile
+terraform_provider_config:
+  description: Multicast MSDP Timer Routing Profile
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants:
+  - singular
+  suffix: multicast_msdp_timer_routing_profile
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+go_sdk_config:
+  skip: false
+  package:
+  - network
+  - routing-profile
+  - multicast
+  - msdp
+  - timer
+panos_xpath:
+  path:
+  - network
+  - routing-profile
+  - multicast
+  - msdp-timer-profile
+  vars: []
+locations:
+- name: ngfw
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific NGFW device
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: Specific Panorama template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template stack
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+spec:
+  params:
+  - name: connection-retry-interval
+    type: int64
+    profiles:
+    - xpath:
+      - connection-retry-interval
+    validators:
+    - type: length
+      spec:
+        min: 1
+        max: 60
+    spec:
+      default: 30
+    description: Max retry count
+    required: false
+  - name: keep-alive-interval
+    type: int64
+    profiles:
+    - xpath:
+      - keep-alive-interval
+    validators:
+    - type: length
+      spec:
+        min: 1
+        max: 60
+    spec:
+      default: 60
+    description: Interval (in seconds) to send keep alive packets
+    required: false
+  - name: message-timeout
+    type: int64
+    profiles:
+    - xpath:
+      - message-timeout
+    validators:
+    - type: length
+      spec:
+        min: 1
+        max: 75
+    spec:
+      default: 75
+    description: number of lost hello packets to declare router down
+    required: false
+  variants: []


### PR DESCRIPTION
  Terraform Resource: panos_multicast_msdp_timer_routing_profile

  This PR adds support for managing Multicast MSDP Timer Routing Profiles in PAN-OS.

  Parameters

  No parameters have been renamed or overridden in this resource.

  Standard Parameters

  | Parameter                 | Type   | Required    | Default | Description                                                |
  |---------------------------|--------|-------------|---------|------------------------------------------------------------|
  | name                      | string | Yes (entry) | -       | Profile name                                               |
  | connection_retry_interval | int64  | No          | 30      | Max retry count (1-60)                                     |
  | keep_alive_interval       | int64  | No          | 60      | Interval (in seconds) to send keep alive packets (1-60)    |
  | message_timeout           | int64  | No          | 75      | Number of lost hello packets to declare router down (1-75) |

  Supported Locations

  - NGFW: ngfw_device (default: localhost.localdomain)
  - Panorama Template: panorama_device, template, ngfw_device
  - Panorama Template Stack: panorama_device, template_stack, ngfw_device