### PR TITLE
feat(specs): Add spec, tests and examples for panos_bfd_routing_profile

### DIFF
--- a/assets/terraform/examples/resources/panos_bfd_routing_profile/resource.tf
+++ b/assets/terraform/examples/resources/panos_bfd_routing_profile/resource.tf
@@ -1,0 +1,40 @@
+# Create a template
+resource "panos_template" "bfd_template" {
+  location = { panorama = {} }
+  name     = "bfd-routing-template"
+}
+
+# BFD Profile with custom timing values
+resource "panos_bfd_routing_profile" "custom_timers" {
+  location = {
+    template = {
+      name = panos_template.bfd_template.name
+    }
+  }
+
+  name                 = "custom-bfd-profile"
+  detection_multiplier = 5
+  hold_time            = 1000
+  min_rx_interval      = 500
+  min_tx_interval      = 500
+  mode                 = "active"
+}
+
+# BFD Profile with multihop configuration
+resource "panos_bfd_routing_profile" "multihop" {
+  location = {
+    template = {
+      name = panos_template.bfd_template.name
+    }
+  }
+
+  name                 = "multihop-bfd-profile"
+  detection_multiplier = 3
+  min_rx_interval      = 300
+  min_tx_interval      = 300
+  mode                 = "passive"
+
+  multihop = {
+    min_received_ttl = 128
+  }
+}

--- a/assets/terraform/test/resource_bfd_routing_profile_test.go
+++ b/assets/terraform/test/resource_bfd_routing_profile_test.go
@@ -1,0 +1,212 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccBfdRoutingProfile_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: bfdRoutingProfile_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_bfd_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_bfd_routing_profile.example",
+						tfjsonpath.New("detection_multiplier"),
+						knownvalue.Int64Exact(5),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_bfd_routing_profile.example",
+						tfjsonpath.New("hold_time"),
+						knownvalue.Int64Exact(1000),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_bfd_routing_profile.example",
+						tfjsonpath.New("min_rx_interval"),
+						knownvalue.Int64Exact(500),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_bfd_routing_profile.example",
+						tfjsonpath.New("min_tx_interval"),
+						knownvalue.Int64Exact(500),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_bfd_routing_profile.example",
+						tfjsonpath.New("mode"),
+						knownvalue.StringExact("active"),
+					),
+				},
+			},
+		},
+	})
+}
+
+const bfdRoutingProfile_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_bfd_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  detection_multiplier = 5
+  hold_time = 1000
+  min_rx_interval = 500
+  min_tx_interval = 500
+  mode = "active"
+}
+`
+
+func TestAccBfdRoutingProfile_Mode_Passive(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: bfdRoutingProfile_Mode_Passive_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_bfd_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_bfd_routing_profile.example",
+						tfjsonpath.New("mode"),
+						knownvalue.StringExact("passive"),
+					),
+				},
+			},
+		},
+	})
+}
+
+const bfdRoutingProfile_Mode_Passive_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_bfd_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  mode = "passive"
+}
+`
+
+func TestAccBfdRoutingProfile_Multihop(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: bfdRoutingProfile_Multihop_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_bfd_routing_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_bfd_routing_profile.example",
+						tfjsonpath.New("multihop"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"min_received_ttl": knownvalue.Int64Exact(128),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const bfdRoutingProfile_Multihop_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_bfd_routing_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  multihop = {
+    min_received_ttl = 128
+  }
+}
+`

--- a/specs/network/routing-profiles/bfd-profile.yaml
+++ b/specs/network/routing-profiles/bfd-profile.yaml
@@ -1,0 +1,219 @@
+name: bfd-routing-profile
+terraform_provider_config:
+  description: BFD Routing Profile
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants:
+  - singular
+  suffix: bfd_routing_profile
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+go_sdk_config:
+  skip: false
+  package:
+  - network
+  - routing-profile
+  - bfd
+panos_xpath:
+  path:
+  - network
+  - routing-profile
+  - bfd
+  vars: []
+locations:
+- name: ngfw
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific NGFW device
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: Specific Panorama template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template stack
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+spec:
+  params:
+  - name: detection-multiplier
+    type: int64
+    profiles:
+    - xpath:
+      - detection-multiplier
+    validators:
+    - type: length
+      spec:
+        min: 2
+        max: 255
+    spec:
+      default: 3
+    description: multiplier sent to remote system
+    required: false
+  - name: hold-time
+    type: int64
+    profiles:
+    - xpath:
+      - hold-time
+    validators:
+    - type: length
+      spec:
+        min: 0
+        max: 120000
+    spec:
+      default: 0
+    description: delay transmission and reception of control packets in ms
+    required: false
+  - name: min-rx-interval
+    type: int64
+    profiles:
+    - xpath:
+      - min-rx-interval
+    validators:
+    - type: length
+      spec:
+        min: 50
+        max: 10000
+    spec:
+      default: 1000
+    description: required minimum rx interval in ms
+    required: false
+  - name: min-tx-interval
+    type: int64
+    profiles:
+    - xpath:
+      - min-tx-interval
+    validators:
+    - type: length
+      spec:
+        min: 50
+        max: 10000
+    spec:
+      default: 1000
+    description: desired minimum tx interval in ms
+    required: false
+  - name: mode
+    type: enum
+    profiles:
+    - xpath:
+      - mode
+    validators:
+    - type: values
+      spec:
+        values:
+        - active
+        - passive
+    spec:
+      default: active
+      values:
+      - value: active
+      - value: passive
+    description: BFD operation mode
+    required: false
+  - name: multihop
+    type: object
+    profiles:
+    - xpath:
+      - multihop
+    validators: []
+    spec:
+      params:
+      - name: min-received-ttl
+        type: int64
+        profiles:
+        - xpath:
+          - min-received-ttl
+        validators:
+        - type: length
+          spec:
+            min: 1
+            max: 254
+        spec: {}
+        description: minimum accepted ttl on received BFD packet
+        required: false
+      variants: []
+    description: enable multihop
+    required: false
+  variants: []


### PR DESCRIPTION
  Terraform Resource Name

  panos_bfd_routing_profile

  Overview

  This PR adds support for BFD (Bidirectional Forwarding Detection) Routing Profile configuration in PAN-OS.

  Parameters with Terraform Overrides

  This resource has no renamed parameters - all parameter names match their PAN-OS XML counterparts (converted from kebab-case to snake_case following Terraform conventions).

  Standard Parameters

  | Parameter                 | Type   | Description                                               | Default | Range/Values    |
  |---------------------------|--------|-----------------------------------------------------------|---------|-----------------|
  | name                      | string | Profile name                                              | -       | -               |
  | detection_multiplier      | int64  | Multiplier sent to remote system                          | 3       | 2-255           |
  | hold_time                 | int64  | Delay transmission and reception of control packets in ms | 0       | 0-120000        |
  | min_rx_interval           | int64  | Required minimum rx interval in ms                        | 1000    | 50-10000        |
  | min_tx_interval           | int64  | Desired minimum tx interval in ms                         | 1000    | 50-10000        |
  | mode                      | string | BFD operation mode                                        | active  | active, passive |
  | multihop                  | object | Enable multihop                                           | -       | -               |
  | multihop.min_received_ttl | int64  | Minimum accepted TTL on received BFD packet               | -       | 1-254           |

  Variants

  This resource has no variants.

  Locations

  - ngfw - Located in a specific NGFW device
  - template - Located in a specific Panorama template
  - template-stack - Located in a specific Panorama template stack