### PR TITLE
feat(specs): Add spec, tests and examples for panos_tacacs_plus_profile

### DIFF
--- a/assets/terraform/examples/resources/panos_tacacs_plus_profile/import.sh
+++ b/assets/terraform/examples/resources/panos_tacacs_plus_profile/import.sh
@@ -1,0 +1,12 @@
+# A TACACS+ profile can be imported by providing the following base64 encoded object as the ID
+# {
+#   location = {
+#     template = {
+#       name            = "example-template"
+#       panorama_device = "localhost.localdomain"
+#     }
+#   }
+#
+#   name = "example-tacacs-profile"
+# }
+terraform import panos_tacacs_plus_profile.example $(echo '{"location":{"template":{"name":"example-template","panorama_device":"localhost.localdomain"}},"name":"example-tacacs-profile"}' | base64)

--- a/assets/terraform/examples/resources/panos_tacacs_plus_profile/resource.tf
+++ b/assets/terraform/examples/resources/panos_tacacs_plus_profile/resource.tf
@@ -1,0 +1,36 @@
+resource "panos_tacacs_plus_profile" "example" {
+  location = {
+    template = {
+      name = panos_template.example.name
+    }
+  }
+
+  name     = "example-tacacs-profile"
+  protocol = "CHAP"
+
+  servers = [
+    {
+      name    = "tacacs-server-1"
+      address = "192.168.1.10"
+      secret  = "shared-secret-1"
+      port    = 49
+    },
+    {
+      name    = "tacacs-server-2"
+      address = "192.168.1.11"
+      secret  = "shared-secret-2"
+      port    = 49
+    }
+  ]
+
+  timeout               = 5
+  use_single_connection = true
+}
+
+resource "panos_template" "example" {
+  location = {
+    panorama = {}
+  }
+
+  name = "example-template"
+}

--- a/assets/terraform/test/resource_tacacs_plus_profile_test.go
+++ b/assets/terraform/test/resource_tacacs_plus_profile_test.go
@@ -1,0 +1,341 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccTacacsPlusProfile_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: tacacsPlusProfile_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_tacacs_plus_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_tacacs_plus_profile.example",
+						tfjsonpath.New("protocol"),
+						knownvalue.StringExact("CHAP"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_tacacs_plus_profile.example",
+						tfjsonpath.New("servers"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":    knownvalue.StringExact("server1"),
+								"address": knownvalue.StringExact("192.168.1.10"),
+								"secret":  knownvalue.StringExact("secret123"),
+								"port":    knownvalue.Int64Exact(49),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_tacacs_plus_profile.example",
+						tfjsonpath.New("timeout"),
+						knownvalue.Int64Exact(5),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_tacacs_plus_profile.example",
+						tfjsonpath.New("use_single_connection"),
+						knownvalue.Bool(true),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestAccTacacsPlusProfile_Protocol_PAP(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: tacacsPlusProfile_Protocol_PAP_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_tacacs_plus_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_tacacs_plus_profile.example",
+						tfjsonpath.New("protocol"),
+						knownvalue.StringExact("PAP"),
+					),
+				},
+			},
+		},
+	})
+}
+
+const tacacsPlusProfile_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_tacacs_plus_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name     = var.prefix
+  protocol = "CHAP"
+
+  servers = [
+    {
+      name    = "server1"
+      address = "192.168.1.10"
+      secret  = "secret123"
+      port    = 49
+    }
+  ]
+
+  timeout               = 5
+  use_single_connection = true
+}
+`
+
+func TestAccTacacsPlusProfile_MultipleServers(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: tacacsPlusProfile_MultipleServers_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_tacacs_plus_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_tacacs_plus_profile.example",
+						tfjsonpath.New("servers"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":    knownvalue.StringExact("server1"),
+								"address": knownvalue.StringExact("192.168.1.10"),
+								"secret":  knownvalue.StringExact("secret123"),
+								"port":    knownvalue.Int64Exact(49),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":    knownvalue.StringExact("server2"),
+								"address": knownvalue.StringExact("192.168.1.11"),
+								"secret":  knownvalue.StringExact("secret456"),
+								"port":    knownvalue.Int64Exact(50),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":    knownvalue.StringExact("server3"),
+								"address": knownvalue.StringExact("tacacs.example.com"),
+								"secret":  knownvalue.StringExact("secret789"),
+								"port":    knownvalue.Int64Exact(49),
+							}),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const tacacsPlusProfile_Protocol_PAP_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_tacacs_plus_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name     = var.prefix
+  protocol = "PAP"
+
+  servers = [
+    {
+      name    = "server1"
+      address = "192.168.1.10"
+      secret  = "secret123"
+    }
+  ]
+}
+`
+
+func TestAccTacacsPlusProfile_ServerDefaults(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: tacacsPlusProfile_ServerDefaults_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_tacacs_plus_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_tacacs_plus_profile.example",
+						tfjsonpath.New("servers"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":    knownvalue.StringExact("server1"),
+								"address": knownvalue.StringExact("192.168.1.10"),
+								"secret":  knownvalue.StringExact("secret123"),
+								"port":    knownvalue.Int64Exact(49),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_tacacs_plus_profile.example",
+						tfjsonpath.New("timeout"),
+						knownvalue.Int64Exact(3),
+					),
+				},
+			},
+		},
+	})
+}
+
+const tacacsPlusProfile_MultipleServers_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_tacacs_plus_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  servers = [
+    {
+      name    = "server1"
+      address = "192.168.1.10"
+      secret  = "secret123"
+      port    = 49
+    },
+    {
+      name    = "server2"
+      address = "192.168.1.11"
+      secret  = "secret456"
+      port    = 50
+    },
+    {
+      name    = "server3"
+      address = "tacacs.example.com"
+      secret  = "secret789"
+      port    = 49
+    }
+  ]
+}
+`
+
+const tacacsPlusProfile_ServerDefaults_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_tacacs_plus_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+
+  servers = [
+    {
+      name    = "server1"
+      address = "192.168.1.10"
+      secret  = "secret123"
+    }
+  ]
+}
+`

--- a/specs/device/profiles/tacacs-plus-profile.yaml
+++ b/specs/device/profiles/tacacs-plus-profile.yaml
@@ -1,0 +1,338 @@
+name: tacacs-plus-profile
+terraform_provider_config:
+  description: TACACS+ Profile
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants:
+  - singular
+  suffix: tacacs_plus_profile
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+go_sdk_config:
+  skip: false
+  package:
+  - device
+  - profiles
+  - tacacsplus
+panos_xpath:
+  path:
+  - server-profile
+  - tacplus
+  vars: []
+locations:
+- name: panorama
+  xpath:
+    path:
+    - config
+    - panorama
+    vars: []
+  description: Located in a panorama.
+  validators: []
+  required: false
+  read_only: false
+- name: shared
+  xpath:
+    path:
+    - config
+    - shared
+    vars: []
+  description: Panorama shared object
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: ngfw_device
+      description: The NGFW device name
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The Virtual System name
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys name cannot be "shared". Use the "shared" location instead
+      type: entry
+  description: Located in a specific Virtual System
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - shared
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+  description: A shared resource located within a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The vsys.
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys cannot be "shared".
+      type: entry
+  description: Located in a specific template, device and vsys.
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - shared
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: The template stack
+      required: true
+      validators: []
+      type: entry
+  description: Located in a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack-vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: The template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The vsys.
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys cannot be "shared".
+      type: entry
+  description: Located in a specific template, device and vsys.
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+spec:
+  params:
+  - name: protocol
+    type: enum
+    profiles:
+    - xpath:
+      - protocol
+    validators:
+    - type: values
+      spec:
+        values:
+        - CHAP
+        - PAP
+    spec:
+      default: CHAP
+      values:
+      - value: CHAP
+      - value: PAP
+    description: Select authentication protocol
+    required: false
+  - name: server
+    type: list
+    profiles:
+    - xpath:
+      - server
+      - entry
+      type: entry
+    validators: []
+    spec:
+      type: object
+      items:
+        type: object
+        spec:
+          params:
+          - name: address
+            type: string
+            profiles:
+            - xpath:
+              - address
+            validators: []
+            spec: {}
+            description: TACACS+ server ip or host name.
+            required: false
+          - name: secret
+            type: string
+            profiles:
+            - xpath:
+              - secret
+            validators:
+            - type: length
+              spec:
+                max: 64
+            spec: {}
+            description: Shared secret for TACACS+ communication
+            required: false
+            hashing:
+              type: solo
+          - name: port
+            type: int64
+            profiles:
+            - xpath:
+              - port
+            validators:
+            - type: length
+              spec:
+                min: 1
+                max: 65535
+            spec:
+              default: 49
+            description: TACACS+ server port
+            required: false
+          variants: []
+    description: ''
+    required: false
+    codegen_overrides:
+      terraform:
+        name: servers
+  - name: timeout
+    type: int64
+    profiles:
+    - xpath:
+      - timeout
+    validators:
+    - type: length
+      spec:
+        min: 1
+        max: 30
+    spec:
+      default: 3
+    description: number of seconds to wait for when performing authentication
+    required: false
+  - name: use-single-connection
+    type: bool
+    profiles:
+    - xpath:
+      - use-single-connection
+    validators: []
+    spec: {}
+    description: Use single connection for all authentication
+    required: false
+  variants: []


### PR DESCRIPTION
  Add TACACS+ Profile Resource

  Terraform Resource Name

  panos_tacacs_plus_profile

  Parameters with Codegen Overrides (Renamed)

  | Parameter Name (YAML) | Terraform Name | Type | Description            |
  |-----------------------|----------------|------|------------------------|
  | server                | servers        | list | TACACS+ server entries |

  Standard Parameters

  | Parameter Name        | Type   | Required | Default | Description                                                                |
  |-----------------------|--------|----------|---------|----------------------------------------------------------------------------|
  | name                  | string | Yes      | -       | Resource name                                                              |
  | protocol              | enum   | No       | CHAP    | Select authentication protocol (values: CHAP, PAP)                         |
  | timeout               | int64  | No       | 3       | Number of seconds to wait for when performing authentication (range: 1-30) |
  | use-single-connection | bool   | No       | -       | Use single connection for all authentication                               |

  Server Object Parameters

  | Parameter Name | Type   | Required | Default | Description                                              |
  |----------------|--------|----------|---------|----------------------------------------------------------|
  | address        | string | No       | -       | TACACS+ server IP or hostname                            |
  | secret         | string | No       | -       | Shared secret for TACACS+ communication (max length: 64) |
  | port           | int64  | No       | 49      | TACACS+ server port (range: 1-65535)                     |

  Supported Locations

  - panorama - Located in Panorama
  - shared - Panorama shared object (Panorama/NGFW)
  - vsys - Located in a specific Virtual System (NGFW)
  - template - Shared resource within a specific template (Panorama)
  - template-vsys - Located in a specific template, device and vsys (Panorama/NGFW)
  - template-stack - Located in a specific template stack (Panorama)
  - template-stack-vsys - Located in a specific template stack, device and vsys (Panorama/NGFW)