### PR TITLE
feat(specs): Add spec, tests and examples for panos_local_user

### DIFF
--- a/assets/terraform/examples/resources/panos_local_user/import.sh
+++ b/assets/terraform/examples/resources/panos_local_user/import.sh
@@ -1,0 +1,12 @@
+# A local user can be imported by providing the following base64 encoded object as the ID
+# {
+#   location = {
+#     template_vsys = {
+#       template        = "example-template"
+#       panorama_device = "localhost.localdomain"
+#     }
+#   }
+#
+#   name = "example-user"
+# }
+terraform import panos_local_user.example $(echo '{"location":{"template_vsys":{"template":"example-template","panorama_device":"localhost.localdomain"}},"name":"example-user"}' | base64)

--- a/assets/terraform/examples/resources/panos_local_user/resource.tf
+++ b/assets/terraform/examples/resources/panos_local_user/resource.tf
@@ -1,0 +1,19 @@
+resource "panos_local_user" "example" {
+  location = {
+    template_vsys = {
+      template = panos_template.example.name
+    }
+  }
+
+  name     = "example-user"
+  password = "SecurePassword123!"
+  disabled = false
+}
+
+resource "panos_template" "example" {
+  location = {
+    panorama = {}
+  }
+
+  name = "example-template"
+}

--- a/assets/terraform/test/resource_local_user_test.go
+++ b/assets/terraform/test/resource_local_user_test.go
@@ -1,0 +1,78 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccLocalUser_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template_vsys": config.ObjectVariable(map[string]config.Variable{
+			"template": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: localUser_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_local_user.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_local_user.example",
+						tfjsonpath.New("disabled"),
+						knownvalue.Bool(false),
+					),
+					// Note: password is hashed, so we cannot verify exact value
+					// We just verify it's not null
+					statecheck.ExpectKnownValue(
+						"panos_local_user.example",
+						tfjsonpath.New("password"),
+						knownvalue.NotNull(),
+					),
+				},
+			},
+		},
+	})
+}
+
+const localUser_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_local_user" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  password = "SecurePassword123!"
+  disabled = false
+}
+`

--- a/specs/device/local-database-user.yaml
+++ b/specs/device/local-database-user.yaml
@@ -1,0 +1,269 @@
+name: local-user
+terraform_provider_config:
+  description: Local User
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants: []
+  suffix: local_user
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+go_sdk_config:
+  skip: false
+  package:
+  - device
+  - localdb
+  - user
+panos_xpath:
+  path:
+  - local-user-database
+  - user
+  vars: []
+locations:
+- name: shared
+  xpath:
+    path:
+    - config
+    - shared
+    vars: []
+  description: Panorama shared object
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: ngfw_device
+      description: The NGFW device name
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The Virtual System name
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys name cannot be "shared". Use the "shared" location instead
+      type: entry
+  description: Located in a specific Virtual System
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The vsys.
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys cannot be "shared".
+      type: entry
+  description: Located in a specific template, device and vsys.
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: Specific Panorama template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template stack
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack-vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: The template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The vsys.
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys cannot be "shared".
+      type: entry
+  description: Located in a specific template, device and vsys.
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+spec:
+  params:
+  - name: disabled
+    type: bool
+    profiles:
+    - xpath:
+      - disabled
+    validators: []
+    spec: {}
+    description: ''
+    required: false
+  - name: phash
+    type: string
+    profiles:
+    - xpath:
+      - phash
+    validators:
+    - type: length
+      spec:
+        max: 63
+    spec: {}
+    description: User password
+    required: false
+    codegen_overrides:
+      terraform:
+        name: password
+    hashing:
+      type: solo
+  variants: []


### PR DESCRIPTION
  Add panos_local_user Resource

  This PR adds support for managing local database users in PAN-OS.

  Terraform Resource Name

  panos_local_user

  Parameters with Terraform Overrides

  | PAN-OS Parameter | Terraform Parameter | Type   | Description            |
  |------------------|---------------------|--------|------------------------|
  | phash            | password            | string | User password |

  Standard Parameters

  | Parameter | Type   | Description                  |
  |-----------|--------|------------------------------|
  | name      | string | User name (entry identifier) |
  | disabled  | bool   | Disable the user account     |

  Variants

  This resource has no variants.

  Locations

  - shared - Panorama shared object
  - vsys - Located in a specific Virtual System (NGFW)
  - template - Located in a specific template (Panorama)
  - template_vsys - Located in a specific template and vsys (Panorama)
  - template_stack - Located in a specific template stack (Panorama)
  - template_stack_vsys - Located in a specific template stack and vsys (Panorama)

  Notes

  - The password parameter is hashed using PAN-OS solo hashing algorithm
  - Password field has a maximum length of 63 characters