### PR TITLE
feat(specs): Add spec, tests and examples for panos_local_user_group

### DIFF
--- a/assets/terraform/examples/resources/panos_local_user_group/import.sh
+++ b/assets/terraform/examples/resources/panos_local_user_group/import.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Import a local user group from template_vsys location
+terraform import panos_local_user_group.example 'template_vsys:{"template":"example-template"}:example-group'
+
+# Import a local user group from shared location
+# terraform import panos_local_user_group.example 'shared::example-group'
+
+# Import a local user group from vsys location
+# terraform import panos_local_user_group.example 'vsys:{"vsys":"vsys1"}:example-group'

--- a/assets/terraform/examples/resources/panos_local_user_group/resource.tf
+++ b/assets/terraform/examples/resources/panos_local_user_group/resource.tf
@@ -1,0 +1,40 @@
+resource "panos_local_user" "user1" {
+  location = {
+    template_vsys = {
+      template = panos_template.example.name
+    }
+  }
+
+  name     = "user1"
+  password = "SecurePassword123!"
+}
+
+resource "panos_local_user" "user2" {
+  location = {
+    template_vsys = {
+      template = panos_template.example.name
+    }
+  }
+
+  name     = "user2"
+  password = "SecurePassword123!"
+}
+
+resource "panos_local_user_group" "example" {
+  location = {
+    template_vsys = {
+      template = panos_template.example.name
+    }
+  }
+
+  name  = "example-group"
+  users = [panos_local_user.user1.name, panos_local_user.user2.name]
+}
+
+resource "panos_template" "example" {
+  location = {
+    panorama = {}
+  }
+
+  name = "example-template"
+}

--- a/assets/terraform/test/resource_local_user_group_test.go
+++ b/assets/terraform/test/resource_local_user_group_test.go
@@ -1,0 +1,135 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccLocalUserGroup_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template_vsys": config.ObjectVariable(map[string]config.Variable{
+			"template": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			// Step 1: Create with initial users
+			{
+				Config: localUserGroup_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+					"users":    config.ListVariable(config.StringVariable("user1"), config.StringVariable("user2")),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_local_user_group.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_local_user_group.example",
+						tfjsonpath.New("users"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("user1"),
+							knownvalue.StringExact("user2"),
+						}),
+					),
+				},
+			},
+			// Step 2: Update users list - add user3
+			{
+				Config: localUserGroup_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+					"users":    config.ListVariable(config.StringVariable("user1"), config.StringVariable("user2"), config.StringVariable("user3")),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_local_user_group.example",
+						tfjsonpath.New("users"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("user1"),
+							knownvalue.StringExact("user2"),
+							knownvalue.StringExact("user3"),
+						}),
+					),
+				},
+			},
+			// Step 3: Update users list - remove user1
+			{
+				Config: localUserGroup_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+					"users":    config.ListVariable(config.StringVariable("user2"), config.StringVariable("user3")),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_local_user_group.example",
+						tfjsonpath.New("users"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("user2"),
+							knownvalue.StringExact("user3"),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const localUserGroup_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+variable "users" { type = list(string) }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_local_user" "user1" {
+  depends_on = [panos_template.example]
+  location = var.location
+  name     = "user1"
+  password = "Password123!"
+}
+
+resource "panos_local_user" "user2" {
+  depends_on = [panos_template.example]
+  location = var.location
+  name     = "user2"
+  password = "Password123!"
+}
+
+resource "panos_local_user" "user3" {
+  depends_on = [panos_template.example]
+  location = var.location
+  name     = "user3"
+  password = "Password123!"
+}
+
+resource "panos_local_user_group" "example" {
+  depends_on = [panos_local_user.user1, panos_local_user.user2, panos_local_user.user3]
+  location = var.location
+  name     = var.prefix
+  users    = var.users
+}
+`

--- a/specs/device/local-database-group.yaml
+++ b/specs/device/local-database-group.yaml
@@ -1,0 +1,259 @@
+name: local-user-group
+terraform_provider_config:
+  description: Local User Group
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants: []
+  suffix: local_user_group
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+go_sdk_config:
+  skip: false
+  package:
+  - device
+  - localdb
+  - group
+panos_xpath:
+  path:
+  - local-user-database
+  - user-group
+  vars: []
+locations:
+- name: shared
+  xpath:
+    path:
+    - config
+    - shared
+    vars: []
+  description: Panorama shared object
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: ngfw_device
+      description: The NGFW device name
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The Virtual System name
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys name cannot be "shared". Use the "shared" location instead
+      type: entry
+  description: Located in a specific Virtual System
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The vsys.
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys cannot be "shared".
+      type: entry
+  description: Located in a specific template, device and vsys.
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: Specific Panorama template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template stack
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack-vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: The template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The vsys.
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys cannot be "shared".
+      type: entry
+  description: Located in a specific template, device and vsys.
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+spec:
+  params:
+  - name: user
+    type: list
+    profiles:
+    - xpath:
+      - user
+      type: member
+    validators: []
+    spec:
+      type: string
+      items:
+        type: string
+    description: ''
+    required: false
+    codegen_overrides:
+      terraform:
+        name: users
+  variants: []


### PR DESCRIPTION
  Add Local User Group Resource

  This PR adds support for the Local User Group resource to the Terraform provider.

  Terraform Resource Name

  panos_local_user_group

  Parameters with Codegen Overrides

  | Parameter | Renamed To | Type | Required | Description |
  |-----------|------------|------|----------|-------------|
  | user      | users      | list | No       | User list   |

  Standard Parameters

  | Parameter | Type   | Required    | Description              |
  |-----------|--------|-------------|--------------------------|
  | name      | string | Yes (entry) | Resource name identifier |

  Locations

  This resource supports the following locations:

  - shared - Panorama shared object (Panorama, NGFW)
  - vsys - Located in a specific Virtual System (NGFW)
  - template - Located in a specific template (Panorama)
  - template-vsys - Located in a specific template, device and vsys (Panorama, NGFW)
  - template-stack - Located in a specific template stack (Panorama)
  - template-stack-vsys - Located in a specific template, device and vsys (Panorama, NGFW)