### PR TITLE
feat(specs): Add spec, tests and examples for panos_log_export_schedule

### DIFF
--- a/assets/terraform/examples/resources/panos_log_export_schedule/import.sh
+++ b/assets/terraform/examples/resources/panos_log_export_schedule/import.sh
@@ -1,0 +1,12 @@
+# A log export schedule can be imported by providing the following base64 encoded object as the ID
+# {
+#   location = {
+#     template = {
+#       name            = "example-template"
+#       panorama_device = "localhost.localdomain"
+#     }
+#   }
+#
+#   name = "ftp-export-schedule"
+# }
+terraform import panos_log_export_schedule.ftp_example $(echo '{"location":{"template":{"name":"example-template","panorama_device":"localhost.localdomain"}},"name":"ftp-export-schedule"}' | base64)

--- a/assets/terraform/examples/resources/panos_log_export_schedule/resource.tf
+++ b/assets/terraform/examples/resources/panos_log_export_schedule/resource.tf
@@ -1,0 +1,80 @@
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name     = "example-template"
+}
+
+# Example 1: Basic log export schedule with FTP protocol
+resource "panos_log_export_schedule" "ftp_example" {
+  location = {
+    template = {
+      name = panos_template.example.name
+    }
+  }
+
+  name        = "ftp-export-schedule"
+  description = "Export traffic logs via FTP"
+  enable      = true
+  log_type    = "traffic"
+  start_time  = "03:30"
+
+  protocol = {
+    ftp = {
+      hostname     = "ftp.example.com"
+      passive_mode = true
+      password     = "secure-password"
+      path         = "/logs/export"
+      port         = 21
+      username     = "ftpuser"
+    }
+  }
+}
+
+# Example 2: Log export schedule with SCP protocol
+resource "panos_log_export_schedule" "scp_example" {
+  location = {
+    template = {
+      name = panos_template.example.name
+    }
+  }
+
+  name        = "scp-export-schedule"
+  description = "Export wildfire logs via SCP"
+  enable      = true
+  log_type    = "wildfire"
+  start_time  = "02:00"
+
+  protocol = {
+    scp = {
+      hostname = "scp.example.com"
+      password = "secure-scp-password"
+      path     = "/var/logs/wildfire"
+      port     = 22
+      username = "scpuser"
+    }
+  }
+}
+
+# Example 3: Multiple log export schedules for different log types
+resource "panos_log_export_schedule" "threat_export" {
+  location = {
+    template = {
+      name = panos_template.example.name
+    }
+  }
+
+  name        = "threat-export"
+  description = "Daily export of threat logs"
+  enable      = true
+  log_type    = "threat"
+  start_time  = "01:00"
+
+  protocol = {
+    ftp = {
+      hostname = "logs.example.com"
+      username = "loguser"
+      password = "logpass"
+      path     = "/threat-logs"
+      port     = 21
+    }
+  }
+}

--- a/assets/terraform/test/resource_log_export_schedule_test.go
+++ b/assets/terraform/test/resource_log_export_schedule_test.go
@@ -1,0 +1,246 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccLogExportSchedule_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: logExportSchedule_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_log_export_schedule.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_log_export_schedule.example",
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Basic log export schedule"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_log_export_schedule.example",
+						tfjsonpath.New("enable"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_log_export_schedule.example",
+						tfjsonpath.New("log_type"),
+						knownvalue.StringExact("traffic"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_log_export_schedule.example",
+						tfjsonpath.New("start_time"),
+						knownvalue.StringExact("03:30"),
+					),
+				},
+			},
+		},
+	})
+}
+
+const logExportSchedule_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_log_export_schedule" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  description = "Basic log export schedule"
+  enable = true
+  log_type = "traffic"
+  start_time = "03:30"
+}
+`
+
+func TestAccLogExportSchedule_Protocol_Ftp(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: logExportSchedule_Protocol_Ftp_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_log_export_schedule.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_log_export_schedule.example",
+						tfjsonpath.New("protocol"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"ftp": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"hostname":     knownvalue.StringExact("ftp.example.com"),
+								"passive_mode": knownvalue.Bool(true),
+								"password":     knownvalue.StringExact("ftppass123"),
+								"path":         knownvalue.StringExact("/logs/export"),
+								"port":         knownvalue.Int64Exact(21),
+								"username":     knownvalue.StringExact("ftpuser"),
+							}),
+							"scp": knownvalue.Null(),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const logExportSchedule_Protocol_Ftp_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_log_export_schedule" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  log_type = "threat"
+  enable = true
+  start_time = "02:00"
+
+  protocol = {
+    ftp = {
+      hostname = "ftp.example.com"
+      passive_mode = true
+      password = "ftppass123"
+      path = "/logs/export"
+      port = 21
+      username = "ftpuser"
+    }
+  }
+}
+`
+
+func TestAccLogExportSchedule_Protocol_Scp(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: logExportSchedule_Protocol_Scp_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_log_export_schedule.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_log_export_schedule.example",
+						tfjsonpath.New("protocol"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"scp": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"hostname": knownvalue.StringExact("scp.example.com"),
+								"password": knownvalue.StringExact("scppass123"),
+								"path":     knownvalue.StringExact("/var/logs/export"),
+								"port":     knownvalue.Int64Exact(22),
+								"username": knownvalue.StringExact("scpuser"),
+							}),
+							"ftp": knownvalue.Null(),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const logExportSchedule_Protocol_Scp_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_log_export_schedule" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  log_type = "wildfire"
+  enable = true
+  start_time = "04:15"
+
+  protocol = {
+    scp = {
+      hostname = "scp.example.com"
+      password = "scppass123"
+      path = "/var/logs/export"
+      port = 22
+      username = "scpuser"
+    }
+  }
+}
+`

--- a/specs/device/log-export-schedule.yaml
+++ b/specs/device/log-export-schedule.yaml
@@ -1,0 +1,369 @@
+name: log-export-schedule
+terraform_provider_config:
+  description: Log Export Schedule configuration
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants: []
+  suffix: log_export_schedule
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+go_sdk_config:
+  skip: false
+  package:
+  - device
+  - services
+  - logexport
+panos_xpath:
+  path:
+  - deviceconfig
+  - system
+  - log-export-schedule
+  vars: []
+locations:
+- name: system
+  xpath:
+    path:
+    - config
+    - devices
+    - $device
+    vars:
+    - name: device
+      description: Device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: System-level configuration
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: Specific Panorama template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+  description: Located in a specific template stack
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+spec:
+  params:
+  - name: description
+    type: string
+    profiles:
+    - xpath:
+      - description
+    validators:
+    - type: length
+      spec:
+        min: 0
+        max: 255
+    spec: {}
+    description: ''
+    required: false
+  - name: enable
+    type: bool
+    profiles:
+    - xpath:
+      - enable
+    validators: []
+    spec: {}
+    description: ''
+    required: false
+  - name: log-type
+    type: enum
+    profiles:
+    - xpath:
+      - log-type
+    validators:
+    - type: values
+      spec:
+        values:
+        - traffic
+        - threat
+        - gtp
+        - sctp
+        - tunnel
+        - userid
+        - iptag
+        - auth
+        - url
+        - data
+        - hipmatch
+        - wildfire
+        - decryption
+        - globalprotect
+    spec:
+      values:
+      - value: traffic
+      - value: threat
+      - value: gtp
+      - value: sctp
+      - value: tunnel
+      - value: userid
+      - value: iptag
+      - value: auth
+      - value: url
+      - value: data
+      - value: hipmatch
+      - value: wildfire
+      - value: decryption
+      - value: globalprotect
+    description: ''
+    required: false
+  - name: protocol
+    type: object
+    profiles:
+    - xpath:
+      - protocol
+    validators: []
+    spec:
+      params: []
+      variants:
+      - name: ftp
+        type: object
+        profiles:
+        - xpath:
+          - ftp
+        validators: []
+        spec:
+          params:
+          - name: hostname
+            type: string
+            profiles:
+            - xpath:
+              - hostname
+            validators:
+            - type: length
+              spec:
+                max: 63
+            spec: {}
+            description: ftp hostname
+            required: false
+          - name: passive-mode
+            type: bool
+            profiles:
+            - xpath:
+              - passive-mode
+            validators: []
+            spec: {}
+            description: Enable FTP Passive Mode
+            required: false
+          - name: password
+            type: string
+            profiles:
+            - xpath:
+              - password
+            validators:
+            - type: length
+              spec:
+                min: 0
+                max: 255
+            spec: {}
+            description: ftp password
+            required: false
+            hashing:
+              type: solo
+          - name: path
+            type: string
+            profiles:
+            - xpath:
+              - path
+            validators:
+            - type: length
+              spec:
+                max: 255
+            spec: {}
+            description: ftp server path
+            required: false
+          - name: port
+            type: int64
+            profiles:
+            - xpath:
+              - port
+            validators:
+            - type: length
+              spec:
+                min: 1
+                max: 65535
+            spec: {}
+            description: ftp port
+            required: false
+          - name: username
+            type: string
+            profiles:
+            - xpath:
+              - username
+            validators:
+            - type: length
+              spec:
+                min: 1
+                max: 255
+            spec: {}
+            description: ftp username
+            required: false
+          variants: []
+        description: use ftp protocol for export
+        required: false
+      - name: scp
+        type: object
+        profiles:
+        - xpath:
+          - scp
+        validators: []
+        spec:
+          params:
+          - name: hostname
+            type: string
+            profiles:
+            - xpath:
+              - hostname
+            validators:
+            - type: length
+              spec:
+                max: 63
+            spec: {}
+            description: ftp hostname
+            required: false
+          - name: password
+            type: string
+            profiles:
+            - xpath:
+              - password
+            validators:
+            - type: length
+              spec:
+                min: 0
+                max: 255
+            spec: {}
+            description: scp password
+            required: false
+            hashing:
+              type: solo
+          - name: path
+            type: string
+            profiles:
+            - xpath:
+              - path
+            validators:
+            - type: length
+              spec:
+                max: 255
+            spec: {}
+            description: scp server path
+            required: false
+          - name: port
+            type: int64
+            profiles:
+            - xpath:
+              - port
+            validators:
+            - type: length
+              spec:
+                min: 1
+                max: 65535
+            spec: {}
+            description: scp port
+            required: false
+          - name: username
+            type: string
+            profiles:
+            - xpath:
+              - username
+            validators:
+            - type: length
+              spec:
+                min: 1
+                max: 255
+            spec: {}
+            description: scp username
+            required: false
+          variants: []
+        description: use ssh protocol for export
+        required: false
+    description: ''
+    required: false
+  - name: start-time
+    type: string
+    profiles:
+    - xpath:
+      - start-time
+    validators:
+    - type: length
+      spec:
+        min: 5
+        max: 5
+    spec: {}
+    description: Time to start the scheduled export hh:mm (e.g. 03:30)
+    required: false
+  variants: []


### PR DESCRIPTION
  Add panos_log_export_schedule Resource

  This PR adds support for the panos_log_export_schedule resource, which allows configuration of scheduled log exports to external servers via FTP or SCP protocols.

  Terraform Resource Name

  panos_log_export_schedule

  Parameters and Variants

  Since there are no renamed parameters or variants (no codegen_overrides.terraform.name found), all parameters use their original names:

  | Parameter                 | Type   | Description                                                                                                                                             | Required    |
  |---------------------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
  | name                      | string | Resource identifier                                                                                                                                     | Yes (entry) |
  | description               | string | Description of the log export schedule (max 255 chars)                                                                                                  | No          |
  | enable                    | bool   | Enable or disable the log export schedule                                                                                                               | No          |
  | log_type                  | string | Type of logs to export. Valid values: traffic, threat, gtp, sctp, tunnel, userid, iptag, auth, url, data, hipmatch, wildfire, decryption, globalprotect | No          |
  | start_time                | string | Time to start the scheduled export in hh:mm format (e.g., "03:30")                                                                                      | No          |
  | protocol                  | object | Protocol configuration (choose one variant)                                                                                                             | No          |
  | protocol.ftp              | object | Use FTP protocol for export                                                                                                                             | No          |
  | protocol.ftp.hostname     | string | FTP hostname (max 63 chars)                                                                                                                             | No          |
  | protocol.ftp.passive_mode | bool   | Enable FTP Passive Mode                                                                                                                                 | No          |
  | protocol.ftp.password     | string | FTP password (max 255 chars, hashed)                                                                                                                    | No          |
  | protocol.ftp.path         | string | FTP server path (max 255 chars)                                                                                                                         | No          |
  | protocol.ftp.port         | int64  | FTP port (1-65535)                                                                                                                                      | No          |
  | protocol.ftp.username     | string | FTP username (1-255 chars)                                                                                                                              | No          |
  | protocol.scp              | object | Use SSH/SCP protocol for export                                                                                                                         | No          |
  | protocol.scp.hostname     | string | SCP hostname (max 63 chars)                                                                                                                             | No          |
  | protocol.scp.password     | string | SCP password (max 255 chars, hashed)                                                                                                                    | No          |
  | protocol.scp.path         | string | SCP server path (max 255 chars)                                                                                                                         | No          |
  | protocol.scp.port         | int64  | SCP port (1-65535)                                                                                                                                      | No          |
  | protocol.scp.username     | string | SCP username (1-255 chars)                                                                                                                              | No          |

  Supported Locations

  - system (Panorama and NGFW)
  - template (Panorama)
  - template-stack (Panorama)

  Tests

  All acceptance tests pass:
  - ✅ TestAccLogExportSchedule_Basic - Basic parameters
  - ✅ TestAccLogExportSchedule_Protocol_Ftp - FTP protocol variant
  - ✅ TestAccLogExportSchedule_Protocol_Scp - SCP protocol variant

  Examples

  Examples include:
  - FTP-based traffic log export
  - SCP-based wildfire log export
  - Multiple log export schedules for different log types