### PR TITLE
feat(specs): Add spec, tests and examples for panos_dynamic_user_group

### DIFF
--- a/assets/terraform/examples/resources/panos_dynamic_user_group/import.sh
+++ b/assets/terraform/examples/resources/panos_dynamic_user_group/import.sh
@@ -1,0 +1,12 @@
+# A dynamic user group can be imported by providing the following base64 encoded object as the ID
+# {
+#   location = {
+#     device_group = {
+#       name            = "example-device-group"
+#       panorama_device = "localhost.localdomain"
+#     }
+#   }
+#
+#   name = "developers"
+# }
+terraform import panos_dynamic_user_group.example $(echo '{"location":{"device_group":{"name":"example-device-group","panorama_device":"localhost.localdomain"}},"name":"developers"}' | base64)

--- a/assets/terraform/examples/resources/panos_dynamic_user_group/resource.tf
+++ b/assets/terraform/examples/resources/panos_dynamic_user_group/resource.tf
@@ -1,0 +1,45 @@
+resource "panos_dynamic_user_group" "example" {
+  location = {
+    device_group = {
+      name = panos_device_group.example.name
+    }
+  }
+
+  name        = "developers"
+  description = "Dynamic user group for developers"
+  filter      = "'department-dev' and 'location-hq'"
+  tags = [
+    panos_administrative_tag.dev.name,
+    panos_administrative_tag.hq.name
+  ]
+}
+
+resource "panos_administrative_tag" "dev" {
+  location = {
+    device_group = {
+      name = panos_device_group.example.name
+    }
+  }
+
+  name  = "department-dev"
+  color = "color3"
+}
+
+resource "panos_administrative_tag" "hq" {
+  location = {
+    device_group = {
+      name = panos_device_group.example.name
+    }
+  }
+
+  name  = "location-hq"
+  color = "color5"
+}
+
+resource "panos_device_group" "example" {
+  location = {
+    panorama = {}
+  }
+
+  name = "example-device-group"
+}

--- a/assets/terraform/test/resource_dynamic_user_group_test.go
+++ b/assets/terraform/test/resource_dynamic_user_group_test.go
@@ -1,0 +1,218 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccDynamicUserGroup_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"device_group": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dynamicUserGroup_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_dynamic_user_group.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_dynamic_user_group.example",
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("Test dynamic user group"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_dynamic_user_group.example",
+						tfjsonpath.New("filter"),
+						knownvalue.StringExact("'tag1' or 'tag2'"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_dynamic_user_group.example",
+						tfjsonpath.New("tags"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("tag1"),
+							knownvalue.StringExact("tag2"),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestAccDynamicUserGroup_DisableOverride(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"device_group": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dynamicUserGroup_DisableOverride_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_dynamic_user_group.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_dynamic_user_group.example",
+						tfjsonpath.New("disable_override"),
+						knownvalue.StringExact("yes"),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestAccDynamicUserGroup_Minimal(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"device_group": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dynamicUserGroup_Minimal_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_dynamic_user_group.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_dynamic_user_group.example",
+						tfjsonpath.New("filter"),
+						knownvalue.StringExact("'minimal'"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_dynamic_user_group.example",
+						tfjsonpath.New("description"),
+						knownvalue.Null(),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_dynamic_user_group.example",
+						tfjsonpath.New("tags"),
+						knownvalue.Null(),
+					),
+				},
+			},
+		},
+	})
+}
+
+const dynamicUserGroup_Minimal_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_device_group" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_dynamic_user_group" "example" {
+  location = var.location
+
+  name = var.prefix
+  filter = "'minimal'"
+}
+`
+
+const dynamicUserGroup_DisableOverride_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_device_group" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_dynamic_user_group" "example" {
+  location = var.location
+
+  name = var.prefix
+  filter = "'tag1'"
+  disable_override = "yes"
+}
+`
+
+const dynamicUserGroup_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_device_group" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_administrative_tag" "tag1" {
+  location = var.location
+  name = "tag1"
+}
+
+resource "panos_administrative_tag" "tag2" {
+  location = var.location
+  name = "tag2"
+}
+
+resource "panos_dynamic_user_group" "example" {
+  depends_on = [panos_administrative_tag.tag1, panos_administrative_tag.tag2]
+  location = var.location
+
+  name = var.prefix
+  description = "Test dynamic user group"
+  filter = "'tag1' or 'tag2'"
+  tags = [panos_administrative_tag.tag1.name, panos_administrative_tag.tag2.name]
+}
+`

--- a/specs/device/dynamic-user-groups.yaml
+++ b/specs/device/dynamic-user-groups.yaml
@@ -1,0 +1,166 @@
+name: dynamic-user-group
+terraform_provider_config:
+  description: Dynamic User Group
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants:
+  - singular
+  suffix: dynamic_user_group
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+go_sdk_config:
+  skip: false
+  package:
+  - device
+  - dynamicusergroups
+panos_xpath:
+  path:
+  - dynamic-user-group
+  vars: []
+locations:
+- name: shared
+  xpath:
+    path:
+    - config
+    - shared
+    vars: []
+  description: Panorama shared object
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: device-group
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - device-group
+    - $device_group
+    vars:
+    - name: panorama_device
+      description: Panorama device name
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: device_group
+      description: Device Group name
+      required: true
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The device group name cannot be "shared". Use the "shared" location
+              instead
+      type: entry
+      location_filter: true
+  description: Located in a specific Device Group
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: ngfw_device
+      description: The NGFW device name
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The Virtual System name
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys name cannot be "shared". Use the "shared" location instead
+      type: entry
+  description: Located in a specific Virtual System
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+spec:
+  params:
+  - name: description
+    type: string
+    profiles:
+    - xpath:
+      - description
+    validators:
+    - type: length
+      spec:
+        min: 0
+        max: 1023
+    spec: {}
+    description: ''
+    required: false
+  - name: disable-override
+    type: enum
+    profiles:
+    - xpath:
+      - disable-override
+    validators:
+    - type: values
+      spec:
+        values:
+        - 'yes'
+        - 'no'
+    spec:
+      default: 'no'
+      values:
+      - value: 'yes'
+      - value: 'no'
+    description: disable object override in child device groups
+    required: false
+  - name: filter
+    type: string
+    profiles:
+    - xpath:
+      - filter
+    validators:
+    - type: length
+      spec:
+        max: 2047
+    spec: {}
+    description: tag-based filter
+    required: false
+  - name: tag
+    type: list
+    profiles:
+    - xpath:
+      - tag
+      type: member
+    validators: []
+    spec:
+      type: string
+      items:
+        type: string
+    description: ''
+    required: false
+    codegen_overrides:
+      terraform:
+        name: tags
+  variants: []


### PR DESCRIPTION
  This PR adds support for managing PAN-OS dynamic user groups.

  Terraform Resource Name

  panos_dynamic_user_group

  Parameters with Name Overrides

  | Spec Name | Terraform Name | Type | Description                 |
  |-----------|----------------|------|-----------------------------|
  | tag       | tags           | list | List of administrative tags |

  Standard Parameters

  | Name             | Type   | Description                                                                   |
  |------------------|--------|-------------------------------------------------------------------------------|
  | name             | string | Dynamic user group name                                                       |
  | description      | string | Description (max 1023 characters)                                             |
  | disable-override | enum   | Disable object override in child device groups (values: yes, no, default: no) |
  | filter           | string | Tag-based filter expression (max 2047 characters)                             |

  Locations

  - shared - Panorama shared object (panorama, ngfw)
  - device-group - Located in a specific Device Group (panorama)
  - vsys - Located in a specific Virtual System (ngfw)