### PR TITLE
feat(specs): Add spec, tests and examples for panos_mfa_server_profile

### DIFF
--- a/assets/terraform/examples/resources/panos_mfa_server_profile/import.sh
+++ b/assets/terraform/examples/resources/panos_mfa_server_profile/import.sh
@@ -1,0 +1,12 @@
+# An MFA server profile can be imported by providing the following base64 encoded object as the ID
+# {
+#   location = {
+#     template = {
+#       name            = "mfa-template"
+#       panorama_device = "localhost.localdomain"
+#     }
+#   }
+#
+#   name = "okta-mfa-profile"
+# }
+terraform import panos_mfa_server_profile.example $(echo '{"location":{"template":{"name":"mfa-template","panorama_device":"localhost.localdomain"}},"name":"okta-mfa-profile"}' | base64)

--- a/assets/terraform/examples/resources/panos_mfa_server_profile/resource.tf
+++ b/assets/terraform/examples/resources/panos_mfa_server_profile/resource.tf
@@ -1,0 +1,150 @@
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name     = "mfa-template"
+}
+
+# Certificate profile for MFA server validation
+resource "panos_certificate_profile" "mfa_ca" {
+  location = { template = { name = panos_template.example.name } }
+  name     = "mfa-server-ca"
+}
+
+# Okta Adaptive MFA Profile
+# Okta provides adaptive MFA based on context and risk
+resource "panos_mfa_server_profile" "okta" {
+  location = { template = { name = panos_template.example.name } }
+
+  name = "okta-mfa-profile"
+
+  mfa_cert_profile = panos_certificate_profile.mfa_ca.name
+  mfa_vendor_type  = "okta-adaptive-v1"
+
+  mfa_config = [
+    {
+      name  = "okta-api-host"
+      value = "company.okta.com"
+    },
+    {
+      name  = "okta-baseuri"
+      value = "/api/v1"
+    },
+    {
+      name  = "okta-token"
+      value = "00A1bCdEfGhIjKlMnOpQrStUvWxYz2345678" # Use a variable in production
+    },
+    {
+      name  = "okta-org"
+      value = "company"
+    },
+    {
+      name  = "okta-timeout"
+      value = "30"
+    }
+  ]
+}
+
+# Duo Security MFA Profile
+# Duo provides push notifications, SMS, and phone call verification
+resource "panos_mfa_server_profile" "duo" {
+  location = { template = { name = panos_template.example.name } }
+
+  name = "duo-mfa-profile"
+
+  mfa_cert_profile = panos_certificate_profile.mfa_ca.name
+  mfa_vendor_type  = "duo-security-v2"
+
+  mfa_config = [
+    {
+      name  = "duo-api-host"
+      value = "api-a1b2c3d4.duosecurity.com"
+    },
+    {
+      name  = "duo-integration-key"
+      value = "DIXXXXXXXXXXXXXXXXXX" # Use a variable in production
+    },
+    {
+      name  = "duo-secret-key"
+      value = "deadbeefcafebabe0123456789abcdef01234567" # Use a variable in production
+    },
+    {
+      name  = "duo-timeout"
+      value = "30"
+    },
+    {
+      name  = "duo-baseuri"
+      value = "https://api-a1b2c3d4.duosecurity.com"
+    }
+  ]
+}
+
+# PingIdentity MFA Profile
+# PingIdentity provides enterprise-grade adaptive authentication
+resource "panos_mfa_server_profile" "ping" {
+  location = { template = { name = panos_template.example.name } }
+
+  name = "ping-mfa-profile"
+
+  mfa_cert_profile = panos_certificate_profile.mfa_ca.name
+  mfa_vendor_type  = "ping-identity-v1"
+
+  mfa_config = [
+    {
+      name  = "ping-api-host"
+      value = "idpxnyl3m.pingidentity.com"
+    },
+    {
+      name  = "ping-baseuri"
+      value = "https://tenant.pingone.com"
+    },
+    {
+      name  = "ping-token"
+      value = "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789" # Use a variable in production
+    },
+    {
+      name  = "ping-org-alias"
+      value = "12345678-1234-1234-1234-123456789abc"
+    },
+    {
+      name  = "ping-timeout"
+      value = "30"
+    }
+  ]
+}
+
+# RSA SecurID Access MFA Profile
+# RSA provides hardware token and software token based authentication
+resource "panos_mfa_server_profile" "rsa" {
+  location = { template = { name = panos_template.example.name } }
+
+  name = "rsa-mfa-profile"
+
+  mfa_cert_profile = panos_certificate_profile.mfa_ca.name
+  mfa_vendor_type  = "rsa-securid-access-v1"
+
+  mfa_config = [
+    {
+      name  = "rsa-api-host"
+      value = "cloud.securid.com"
+    },
+    {
+      name  = "rsa-baseuri"
+      value = "https://tenant.rsa.com"
+    },
+    {
+      name  = "rsa-accesskey"
+      value = "abcdef1234567890ABCDEF1234567890" # Use a variable in production
+    },
+    {
+      name  = "rsa-accessid"
+      value = "RSAID123456"
+    },
+    {
+      name  = "rsa-assurancepolicyid"
+      value = "policy-abc-123-def-456"
+    },
+    {
+      name  = "rsa-timeout"
+      value = "90"
+    }
+  ]
+}

--- a/assets/terraform/internal/provider/mfa_server_profile_custom.go
+++ b/assets/terraform/internal/provider/mfa_server_profile_custom.go
@@ -1,0 +1,170 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// vendorConfigs defines the required configuration keys for each MFA vendor type.
+// All keys listed are mandatory when the vendor type is selected.
+var vendorConfigs = map[string][]string{
+	"duo-security-v2": {
+		"duo-api-host",
+		"duo-integration-key",
+		"duo-secret-key",
+		"duo-timeout",
+		"duo-baseuri",
+	},
+	"okta-adaptive-v1": {
+		"okta-api-host",
+		"okta-baseuri",
+		"okta-token",
+		"okta-org",
+		"okta-timeout",
+	},
+	"ping-identity-v1": {
+		"ping-api-host",
+		"ping-baseuri",
+		"ping-token",
+		"ping-org-alias",
+		"ping-timeout",
+	},
+	"rsa-securid-access-v1": {
+		"rsa-api-host",
+		"rsa-baseuri",
+		"rsa-accesskey",
+		"rsa-accessid",
+		"rsa-assurancepolicyid",
+		"rsa-timeout",
+	},
+}
+
+func (o *MfaServerProfileResource) ValidateConfigCustom(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data MfaServerProfileResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Skip validation if values are unknown (computed at plan time)
+	if data.MfaVendorType.IsUnknown() || data.MfaConfig.IsUnknown() {
+		return
+	}
+
+	// Check if mfa_config is provided without mfa_vendor_type
+	vendorTypeEmpty := data.MfaVendorType.IsNull() || data.MfaVendorType.ValueString() == ""
+	configProvided := !data.MfaConfig.IsNull() && len(data.MfaConfig.Elements()) > 0
+
+	if vendorTypeEmpty && configProvided {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("mfa_config"),
+			"Configuration Requires Vendor Type",
+			"The 'mfa_config' attribute cannot be set without specifying 'mfa_vendor_type'. "+
+				"MFA configuration keys are vendor-specific and require a vendor type to be defined.",
+		)
+		return
+	}
+
+	// Skip validation if vendor type is not set (allows certificate-only profiles)
+	if vendorTypeEmpty {
+		return
+	}
+
+	vendorType := data.MfaVendorType.ValueString()
+
+	// Extract config items from the list
+	var configItems []MfaServerProfileResourceMfaConfigObject
+	diags := data.MfaConfig.ElementsAs(ctx, &configItems, false)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Build set of provided configuration keys
+	providedKeys := make(map[string]bool)
+	for _, item := range configItems {
+		if !item.Name.IsNull() && !item.Name.IsUnknown() {
+			providedKeys[item.Name.ValueString()] = true
+		}
+	}
+
+	// Get required keys for this vendor type
+	requiredKeys, vendorExists := vendorConfigs[vendorType]
+	if !vendorExists {
+		// Build list of valid vendor types for error message
+		validVendors := make([]string, 0, len(vendorConfigs))
+		for vendor := range vendorConfigs {
+			validVendors = append(validVendors, vendor)
+		}
+		sort.Strings(validVendors)
+
+		resp.Diagnostics.AddAttributeError(
+			path.Root("mfa_vendor_type"),
+			"Invalid MFA Vendor Type",
+			fmt.Sprintf(
+				"MFA vendor type '%s' is not supported. Valid vendor types are: %s.",
+				vendorType,
+				strings.Join(validVendors, ", "),
+			),
+		)
+		return
+	}
+
+	// Build required keys set for O(1) lookup
+	requiredKeySet := make(map[string]bool)
+	for _, key := range requiredKeys {
+		requiredKeySet[key] = true
+	}
+
+	// Check for missing required keys
+	var missingKeys []string
+	for _, requiredKey := range requiredKeys {
+		if !providedKeys[requiredKey] {
+			missingKeys = append(missingKeys, requiredKey)
+		}
+	}
+
+	if len(missingKeys) > 0 {
+		sort.Strings(missingKeys)
+
+		resp.Diagnostics.AddAttributeError(
+			path.Root("mfa_config"),
+			"Missing Required Configuration Keys",
+			fmt.Sprintf(
+				"MFA vendor type '%s' requires the following configuration keys that are missing: %s. "+
+					"All required keys must be provided for the vendor configuration to be valid.",
+				vendorType,
+				strings.Join(missingKeys, ", "),
+			),
+		)
+	}
+
+	// Check for invalid keys (keys that don't belong to this vendor)
+	var invalidKeys []string
+	for providedKey := range providedKeys {
+		if !requiredKeySet[providedKey] {
+			invalidKeys = append(invalidKeys, providedKey)
+		}
+	}
+
+	if len(invalidKeys) > 0 {
+		sort.Strings(invalidKeys)
+
+		resp.Diagnostics.AddAttributeError(
+			path.Root("mfa_config"),
+			"Invalid Configuration Keys",
+			fmt.Sprintf(
+				"MFA vendor type '%s' does not support the following configuration keys: %s. "+
+					"Only these keys are valid for this vendor: %s.",
+				vendorType,
+				strings.Join(invalidKeys, ", "),
+				strings.Join(requiredKeys, ", "),
+			),
+		)
+	}
+}

--- a/assets/terraform/test/resource_mfa_server_profile_test.go
+++ b/assets/terraform/test/resource_mfa_server_profile_test.go
@@ -1,0 +1,1694 @@
+package provider_test
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccMfaServerProfile_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_Basic,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_cert_profile"),
+						knownvalue.StringExact("test-cert-profile"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("okta-adaptive-v1"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_config"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-api-host"),
+								"value": knownvalue.StringExact("api.okta.example.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-baseuri"),
+								"value": knownvalue.StringExact("/api/v1"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-token"),
+								"value": knownvalue.StringExact("test-token-123"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-org"),
+								"value": knownvalue.StringExact("test-org"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-timeout"),
+								"value": knownvalue.StringExact("30"),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("location").AtMapKey("template").AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tmpl", prefix)),
+					),
+				},
+			},
+		},
+	})
+}
+
+const mfaServerProfile_Basic = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_certificate_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = "test-cert-profile"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_cert_profile = panos_certificate_profile.example.name
+  mfa_vendor_type = "okta-adaptive-v1"
+  mfa_config = [
+    {
+      name = "okta-api-host"
+      value = "api.okta.example.com"
+    },
+    {
+      name = "okta-baseuri"
+      value = "/api/v1"
+    },
+    {
+      name = "okta-token"
+      value = "test-token-123"
+    },
+    {
+      name = "okta-org"
+      value = "test-org"
+    },
+    {
+      name = "okta-timeout"
+      value = "30"
+    }
+  ]
+}
+`
+
+func TestAccMfaServerProfile_Minimal(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_Minimal,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_cert_profile"),
+						knownvalue.Null(),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("okta-adaptive-v1"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("location").AtMapKey("template").AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tmpl", prefix)),
+					),
+				},
+			},
+		},
+	})
+}
+
+const mfaServerProfile_Minimal = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_vendor_type = "okta-adaptive-v1"
+  mfa_config = [
+    {
+      name  = "okta-api-host"
+      value = "api.okta.example.com"
+    },
+    {
+      name  = "okta-baseuri"
+      value = "/api/v1"
+    },
+    {
+      name  = "okta-token"
+      value = "test-token"
+    },
+    {
+      name  = "okta-org"
+      value = "test-org"
+    },
+    {
+      name  = "okta-timeout"
+      value = "30"
+    }
+  ]
+}
+`
+
+func TestAccMfaServerProfile_MultipleConfigurations(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_MultipleConfigurations,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("duo-security-v2"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_config"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-integration-key"),
+								"value": knownvalue.StringExact("DIxxxxxxxxxxxxxxxxxx"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-secret-key"),
+								"value": knownvalue.StringExact("secretxxxxxxxxxxxxxxxxx"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-api-host"),
+								"value": knownvalue.StringExact("api-xxxxxxxx.duosecurity.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-timeout"),
+								"value": knownvalue.StringExact("30"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-baseuri"),
+								"value": knownvalue.StringExact("https://api-xxxxxxxx.duosecurity.com"),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("location").AtMapKey("template").AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tmpl", prefix)),
+					),
+				},
+			},
+		},
+	})
+}
+
+const mfaServerProfile_MultipleConfigurations = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_vendor_type = "duo-security-v2"
+  mfa_config = [
+    {
+      name = "duo-integration-key"
+      value = "DIxxxxxxxxxxxxxxxxxx"
+    },
+    {
+      name = "duo-secret-key"
+      value = "secretxxxxxxxxxxxxxxxxx"
+    },
+    {
+      name = "duo-api-host"
+      value = "api-xxxxxxxx.duosecurity.com"
+    },
+    {
+      name = "duo-timeout"
+      value = "30"
+    },
+    {
+      name = "duo-baseuri"
+      value = "https://api-xxxxxxxx.duosecurity.com"
+    }
+  ]
+}
+`
+
+func TestAccMfaServerProfile_MaxLengthValues(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	// Generate long but valid accesskey value (alphanumeric)
+	maxConfigValue := "abcdef" + strings.Repeat("0123456789ABCDEF", 7) + "xyz"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_MaxLengthValues,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":           config.StringVariable(prefix),
+					"max_config_value": config.StringVariable(maxConfigValue),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("rsa-securid-access-v1"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_config"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-api-host"),
+								"value": knownvalue.StringExact("api.rsa.example.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-baseuri"),
+								"value": knownvalue.StringExact("https://tenant.rsa.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-accesskey"),
+								"value": knownvalue.StringExact(maxConfigValue),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-accessid"),
+								"value": knownvalue.StringExact("RSAID123"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-assurancepolicyid"),
+								"value": knownvalue.StringExact("policy-123"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-timeout"),
+								"value": knownvalue.StringExact("30"),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("location").AtMapKey("template").AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tmpl", prefix)),
+					),
+				},
+			},
+		},
+	})
+}
+
+const mfaServerProfile_MaxLengthValues = `
+variable "prefix" { type = string }
+variable "max_config_value" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_vendor_type = "rsa-securid-access-v1"
+  mfa_config = [
+    {
+      name = "rsa-api-host"
+      value = "api.rsa.example.com"
+    },
+    {
+      name = "rsa-baseuri"
+      value = "https://tenant.rsa.com"
+    },
+    {
+      name = "rsa-accesskey"
+      value = var.max_config_value
+    },
+    {
+      name = "rsa-accessid"
+      value = "RSAID123"
+    },
+    {
+      name = "rsa-assurancepolicyid"
+      value = "policy-123"
+    },
+    {
+      name = "rsa-timeout"
+      value = "30"
+    }
+  ]
+}
+`
+
+func TestAccMfaServerProfile_EmptyConfigurations(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_EmptyConfigurations,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("okta-adaptive-v1"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_config"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-api-host"),
+								"value": knownvalue.StringExact("api.okta.example.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-baseuri"),
+								"value": knownvalue.StringExact("/api/v1"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-token"),
+								"value": knownvalue.StringExact("test-token"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-org"),
+								"value": knownvalue.StringExact("test-org"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-timeout"),
+								"value": knownvalue.StringExact("30"),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("location").AtMapKey("template").AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tmpl", prefix)),
+					),
+				},
+			},
+		},
+	})
+}
+
+const mfaServerProfile_EmptyConfigurations = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_vendor_type = "okta-adaptive-v1"
+  mfa_config = [
+    {
+      name  = "okta-api-host"
+      value = "api.okta.example.com"
+    },
+    {
+      name  = "okta-baseuri"
+      value = "/api/v1"
+    },
+    {
+      name  = "okta-token"
+      value = "test-token"
+    },
+    {
+      name  = "okta-org"
+      value = "test-org"
+    },
+    {
+      name  = "okta-timeout"
+      value = "30"
+    }
+  ]
+}
+`
+
+func TestAccMfaServerProfile_CertificateProfileOnly(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_CertificateProfileOnly,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_cert_profile"),
+						knownvalue.StringExact(fmt.Sprintf("%s-cert", prefix)),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.Null(),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_config"),
+						knownvalue.Null(),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("location").AtMapKey("template").AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tmpl", prefix)),
+					),
+				},
+			},
+		},
+	})
+}
+
+const mfaServerProfile_CertificateProfileOnly = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_certificate_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = "${var.prefix}-cert"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_cert_profile = panos_certificate_profile.example.name
+}
+`
+
+func TestAccMfaServerProfile_AllParameters(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_AllParameters,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_cert_profile"),
+						knownvalue.StringExact("comprehensive-cert-profile"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("ping-identity-v1"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_config"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("ping-api-host"),
+								"value": knownvalue.StringExact("api.pingidentity.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("ping-baseuri"),
+								"value": knownvalue.StringExact("https://tenant.pingone.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("ping-token"),
+								"value": knownvalue.StringExact("secret789xyz"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("ping-org-alias"),
+								"value": knownvalue.StringExact("12345678-1234-1234-1234-123456789abc"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("ping-timeout"),
+								"value": knownvalue.StringExact("30"),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("location").AtMapKey("template").AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tmpl", prefix)),
+					),
+				},
+			},
+		},
+	})
+}
+
+const mfaServerProfile_AllParameters = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_certificate_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = "comprehensive-cert-profile"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_cert_profile = panos_certificate_profile.example.name
+  mfa_vendor_type = "ping-identity-v1"
+  mfa_config = [
+    {
+      name = "ping-api-host"
+      value = "api.pingidentity.com"
+    },
+    {
+      name = "ping-baseuri"
+      value = "https://tenant.pingone.com"
+    },
+    {
+      name = "ping-token"
+      value = "secret789xyz"
+    },
+    {
+      name = "ping-org-alias"
+      value = "12345678-1234-1234-1234-123456789abc"
+    },
+    {
+      name = "ping-timeout"
+      value = "30"
+    }
+  ]
+}
+`
+
+func TestAccMfaServerProfile_ConfigurationEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_ConfigurationEdgeCases,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("duo-security-v2"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_config"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-api-host"),
+								"value": knownvalue.StringExact("api-special.duosecurity.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-integration-key"),
+								"value": knownvalue.StringExact("DI!@#$%^&*()_+-="),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-secret-key"),
+								"value": knownvalue.StringExact("  secret with spaces  "),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-baseuri"),
+								"value": knownvalue.StringExact("https://example.com/path?query=value&other=123"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-timeout"),
+								"value": knownvalue.StringExact("30"),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("location").AtMapKey("template").AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tmpl", prefix)),
+					),
+				},
+			},
+		},
+	})
+}
+
+const mfaServerProfile_ConfigurationEdgeCases = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_vendor_type = "duo-security-v2"
+  mfa_config = [
+    {
+      name = "duo-api-host"
+      value = "api-special.duosecurity.com"
+    },
+    {
+      name = "duo-integration-key"
+      value = "DI!@#$%^&*()_+-="
+    },
+    {
+      name = "duo-secret-key"
+      value = "  secret with spaces  "
+    },
+    {
+      name = "duo-baseuri"
+      value = "https://example.com/path?query=value&other=123"
+    },
+    {
+      name = "duo-timeout"
+      value = "30"
+    }
+  ]
+}
+`
+
+func TestAccMfaServerProfile_AllVendorTypes(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_AllVendorTypes,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.duo",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-duo", prefix)),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.duo",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("duo-security-v2"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.okta",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-okta", prefix)),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.okta",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("okta-adaptive-v1"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.ping",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-ping", prefix)),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.ping",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("ping-identity-v1"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.rsa",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-rsa", prefix)),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.rsa",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("rsa-securid-access-v1"),
+					),
+				},
+			},
+		},
+	})
+}
+
+const mfaServerProfile_AllVendorTypes = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_mfa_server_profile" "duo" {
+  location = { template = { name = panos_template.example.name } }
+  name = "${var.prefix}-duo"
+  mfa_vendor_type = "duo-security-v2"
+  mfa_config = [
+    { name = "duo-api-host", value = "api-a1b2c3d4.duosecurity.com" },
+    { name = "duo-integration-key", value = "DIWXYZ1234567890ABCD" },
+    { name = "duo-secret-key", value = "abcdefghijklmnopqrstuvwxyz0123456789ABCD" },
+    { name = "duo-timeout", value = "60" },
+    { name = "duo-baseuri", value = "https://api-a1b2c3d4.duosecurity.com" }
+  ]
+}
+
+resource "panos_mfa_server_profile" "okta" {
+  location = { template = { name = panos_template.example.name } }
+  name = "${var.prefix}-okta"
+  mfa_vendor_type = "okta-adaptive-v1"
+  mfa_config = [
+    { name = "okta-api-host", value = "api.okta.example.com" },
+    { name = "okta-baseuri", value = "https://tenant.okta.com" },
+    { name = "okta-token", value = "00aaBBccDDeeFFggHHiiJJkkLLmmNNooP" },
+    { name = "okta-org", value = "myorganization" },
+    { name = "okta-timeout", value = "45" }
+  ]
+}
+
+resource "panos_mfa_server_profile" "ping" {
+  location = { template = { name = panos_template.example.name } }
+  name = "${var.prefix}-ping"
+  mfa_vendor_type = "ping-identity-v1"
+  mfa_config = [
+    { name = "ping-api-host", value = "api.pingidentity.com" },
+    { name = "ping-baseuri", value = "https://tenant.pingone.com" },
+    { name = "ping-token", value = "secret789xyz" },
+    { name = "ping-org-alias", value = "12345678-1234-1234-1234-123456789abc" },
+    { name = "ping-timeout", value = "30" }
+  ]
+}
+
+resource "panos_mfa_server_profile" "rsa" {
+  location = { template = { name = panos_template.example.name } }
+  name = "${var.prefix}-rsa"
+  mfa_vendor_type = "rsa-securid-access-v1"
+  mfa_config = [
+    { name = "rsa-api-host", value = "api.rsa.example.com" },
+    { name = "rsa-baseuri", value = "https://tenant.rsa.com" },
+    { name = "rsa-accesskey", value = "abcdef1234567890ABCDEF1234567890" },
+    { name = "rsa-accessid", value = "RSAID123456" },
+    { name = "rsa-assurancepolicyid", value = "policy-abc-123-def-456" },
+    { name = "rsa-timeout", value = "90" }
+  ]
+}
+`
+
+func TestAccMfaServerProfile_LargeConfigurationList(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	// Build expected configuration list for state checks (using Okta valid keys)
+	expectedConfigs := []knownvalue.Check{
+		knownvalue.ObjectExact(map[string]knownvalue.Check{
+			"name":  knownvalue.StringExact("okta-api-host"),
+			"value": knownvalue.StringExact("api1.okta.com"),
+		}),
+		knownvalue.ObjectExact(map[string]knownvalue.Check{
+			"name":  knownvalue.StringExact("okta-baseuri"),
+			"value": knownvalue.StringExact("https://tenant1.okta.com"),
+		}),
+		knownvalue.ObjectExact(map[string]knownvalue.Check{
+			"name":  knownvalue.StringExact("okta-token"),
+			"value": knownvalue.StringExact("token123"),
+		}),
+		knownvalue.ObjectExact(map[string]knownvalue.Check{
+			"name":  knownvalue.StringExact("okta-org"),
+			"value": knownvalue.StringExact("myorg"),
+		}),
+		knownvalue.ObjectExact(map[string]knownvalue.Check{
+			"name":  knownvalue.StringExact("okta-timeout"),
+			"value": knownvalue.StringExact("30"),
+		}),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_LargeConfigurationList,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("okta-adaptive-v1"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_config"),
+						knownvalue.ListExact(expectedConfigs),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("location").AtMapKey("template").AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tmpl", prefix)),
+					),
+				},
+			},
+		},
+	})
+}
+
+const mfaServerProfile_LargeConfigurationList = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_vendor_type = "okta-adaptive-v1"
+  mfa_config = [
+    { name = "okta-api-host", value = "api1.okta.com" },
+    { name = "okta-baseuri", value = "https://tenant1.okta.com" },
+    { name = "okta-token", value = "token123" },
+    { name = "okta-org", value = "myorg" },
+    { name = "okta-timeout", value = "30" }
+  ]
+}
+`
+
+func TestAccMfaServerProfile_ConfigurationNameEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	// Generate a long value (100+ characters)
+	longValue := strings.Repeat("abcdefghij", 10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_ConfigurationNameEdgeCases,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":     config.StringVariable(prefix),
+					"long_value": config.StringVariable(longValue),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("rsa-securid-access-v1"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_config"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-api-host"),
+								"value": knownvalue.StringExact("api.rsa.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-baseuri"),
+								"value": knownvalue.StringExact("https://tenant.rsa.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-accesskey"),
+								"value": knownvalue.StringExact(longValue),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-accessid"),
+								"value": knownvalue.StringExact("accessid123"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-assurancepolicyid"),
+								"value": knownvalue.StringExact("policy456"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-timeout"),
+								"value": knownvalue.StringExact("30"),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("location").AtMapKey("template").AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tmpl", prefix)),
+					),
+				},
+			},
+		},
+	})
+}
+
+const mfaServerProfile_ConfigurationNameEdgeCases = `
+variable "prefix" { type = string }
+variable "long_value" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_vendor_type = "rsa-securid-access-v1"
+  mfa_config = [
+    {
+      name = "rsa-api-host"
+      value = "api.rsa.com"
+    },
+    {
+      name = "rsa-baseuri"
+      value = "https://tenant.rsa.com"
+    },
+    {
+      name = "rsa-accesskey"
+      value = var.long_value
+    },
+    {
+      name = "rsa-accessid"
+      value = "accessid123"
+    },
+    {
+      name = "rsa-assurancepolicyid"
+      value = "policy456"
+    },
+    {
+      name = "rsa-timeout"
+      value = "30"
+    }
+  ]
+}
+`
+
+func TestAccMfaServerProfile_OktaComplete(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_OktaComplete,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_cert_profile"),
+						knownvalue.StringExact(fmt.Sprintf("%s-cert", prefix)),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("okta-adaptive-v1"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_config"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-api-host"),
+								"value": knownvalue.StringExact("api.okta.example.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-baseuri"),
+								"value": knownvalue.StringExact("https://tenant.okta.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-token"),
+								"value": knownvalue.StringExact("00aaBBccDDeeFFggHHiiJJkkLLmmNNooP"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-org"),
+								"value": knownvalue.StringExact("myorganization"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("okta-timeout"),
+								"value": knownvalue.StringExact("45"),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("location").AtMapKey("template").AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tmpl", prefix)),
+					),
+				},
+			},
+		},
+	})
+}
+
+const mfaServerProfile_OktaComplete = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_certificate_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = "${var.prefix}-cert"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_cert_profile = panos_certificate_profile.example.name
+  mfa_vendor_type = "okta-adaptive-v1"
+  mfa_config = [
+    {
+      name = "okta-api-host"
+      value = "api.okta.example.com"
+    },
+    {
+      name = "okta-baseuri"
+      value = "https://tenant.okta.com"
+    },
+    {
+      name = "okta-token"
+      value = "00aaBBccDDeeFFggHHiiJJkkLLmmNNooP"
+    },
+    {
+      name = "okta-org"
+      value = "myorganization"
+    },
+    {
+      name = "okta-timeout"
+      value = "45"
+    }
+  ]
+}
+`
+
+func TestAccMfaServerProfile_DuoComplete(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_DuoComplete,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_cert_profile"),
+						knownvalue.StringExact(fmt.Sprintf("%s-cert", prefix)),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("duo-security-v2"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_config"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-api-host"),
+								"value": knownvalue.StringExact("api-a1b2c3d4.duosecurity.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-integration-key"),
+								"value": knownvalue.StringExact("DIWXYZ1234567890ABCD"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-secret-key"),
+								"value": knownvalue.StringExact("abcdefghijklmnopqrstuvwxyz0123456789ABCD"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-timeout"),
+								"value": knownvalue.StringExact("60"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("duo-baseuri"),
+								"value": knownvalue.StringExact("https://api-a1b2c3d4.duosecurity.com"),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("location").AtMapKey("template").AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tmpl", prefix)),
+					),
+				},
+			},
+		},
+	})
+}
+
+const mfaServerProfile_DuoComplete = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_certificate_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = "${var.prefix}-cert"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_cert_profile = panos_certificate_profile.example.name
+  mfa_vendor_type = "duo-security-v2"
+  mfa_config = [
+    {
+      name = "duo-api-host"
+      value = "api-a1b2c3d4.duosecurity.com"
+    },
+    {
+      name = "duo-integration-key"
+      value = "DIWXYZ1234567890ABCD"
+    },
+    {
+      name = "duo-secret-key"
+      value = "abcdefghijklmnopqrstuvwxyz0123456789ABCD"
+    },
+    {
+      name = "duo-timeout"
+      value = "60"
+    },
+    {
+      name = "duo-baseuri"
+      value = "https://api-a1b2c3d4.duosecurity.com"
+    }
+  ]
+}
+`
+
+func TestAccMfaServerProfile_RSAComplete(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_RSAComplete,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_cert_profile"),
+						knownvalue.StringExact(fmt.Sprintf("%s-cert", prefix)),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_vendor_type"),
+						knownvalue.StringExact("rsa-securid-access-v1"),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("mfa_config"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-api-host"),
+								"value": knownvalue.StringExact("api.rsa.example.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-baseuri"),
+								"value": knownvalue.StringExact("https://tenant.rsa.com"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-accesskey"),
+								"value": knownvalue.StringExact("abcdef1234567890ABCDEF1234567890"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-accessid"),
+								"value": knownvalue.StringExact("RSAID123456"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-assurancepolicyid"),
+								"value": knownvalue.StringExact("policy-abc-123-def-456"),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name":  knownvalue.StringExact("rsa-timeout"),
+								"value": knownvalue.StringExact("90"),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_mfa_server_profile.example",
+						tfjsonpath.New("location").AtMapKey("template").AtMapKey("name"),
+						knownvalue.StringExact(fmt.Sprintf("%s-tmpl", prefix)),
+					),
+				},
+			},
+		},
+	})
+}
+
+const mfaServerProfile_RSAComplete = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_certificate_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = "${var.prefix}-cert"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_cert_profile = panos_certificate_profile.example.name
+  mfa_vendor_type = "rsa-securid-access-v1"
+  mfa_config = [
+    {
+      name = "rsa-api-host"
+      value = "api.rsa.example.com"
+    },
+    {
+      name = "rsa-baseuri"
+      value = "https://tenant.rsa.com"
+    },
+    {
+      name = "rsa-accesskey"
+      value = "abcdef1234567890ABCDEF1234567890"
+    },
+    {
+      name = "rsa-accessid"
+      value = "RSAID123456"
+    },
+    {
+      name = "rsa-assurancepolicyid"
+      value = "policy-abc-123-def-456"
+    },
+    {
+      name = "rsa-timeout"
+      value = "90"
+    }
+  ]
+}
+`
+
+// Negative validation tests
+
+func TestAccMfaServerProfile_InvalidVendorType(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_InvalidVendorType,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ExpectError: regexp.MustCompile(`Invalid MFA Vendor Type`),
+			},
+		},
+	})
+}
+
+const mfaServerProfile_InvalidVendorType = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_vendor_type = "invalid-vendor-v1"
+  mfa_config = [{
+    name  = "some-key"
+    value = "some-value"
+  }]
+}
+`
+
+func TestAccMfaServerProfile_MissingRequiredKeys(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_MissingRequiredKeys,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ExpectError: regexp.MustCompile(`Missing Required Configuration Keys`),
+			},
+		},
+	})
+}
+
+const mfaServerProfile_MissingRequiredKeys = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_vendor_type = "okta-adaptive-v1"
+  mfa_config = [{
+    name  = "okta-api-host"
+    value = "api.okta.example.com"
+  }]
+}
+`
+
+func TestAccMfaServerProfile_InvalidConfigKeys(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_InvalidConfigKeys,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ExpectError: regexp.MustCompile(`Invalid Configuration Keys`),
+			},
+		},
+	})
+}
+
+const mfaServerProfile_InvalidConfigKeys = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_vendor_type = "duo-security-v2"
+  mfa_config = [
+    # All required Duo keys
+    { name = "duo-api-host", value = "api-xxxxxxxx.duosecurity.com" },
+    { name = "duo-integration-key", value = "DIxxxxxxxxxxxxxxxxxx" },
+    { name = "duo-secret-key", value = "secretxxxxxxxxxxxxxxxxx" },
+    { name = "duo-timeout", value = "30" },
+    { name = "duo-baseuri", value = "https://api-xxxxxxxx.duosecurity.com" },
+    # Invalid Okta keys
+    { name = "okta-api-host", value = "api.okta.com" },
+    { name = "okta-baseuri", value = "https://tenant.okta.com" },
+    { name = "okta-org", value = "myorg" }
+  ]
+}
+`
+
+func TestAccMfaServerProfile_MissingAndInvalidKeys(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_MissingAndInvalidKeys,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				// Both errors should be reported
+				ExpectError: regexp.MustCompile(`(Missing Required Configuration Keys|Invalid Configuration Keys)`),
+			},
+		},
+	})
+}
+
+const mfaServerProfile_MissingAndInvalidKeys = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  mfa_vendor_type = "ping-identity-v1"
+  mfa_config = [
+    # Only 1 valid Ping key
+    { name = "ping-api-host", value = "api.pingidentity.com" },
+    # 2 invalid keys from other vendors
+    { name = "duo-integration-key", value = "DIxxxxxxxxxxxxxxxxxx" },
+    { name = "okta-org", value = "myorg" }
+  ]
+}
+`
+
+func TestAccMfaServerProfile_ConfigWithoutVendorType(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: mfaServerProfile_ConfigWithoutVendorType,
+				ConfigVariables: map[string]config.Variable{
+					"prefix": config.StringVariable(prefix),
+				},
+				ExpectError: regexp.MustCompile(`Configuration Requires Vendor Type`),
+			},
+		},
+	})
+}
+
+const mfaServerProfile_ConfigWithoutVendorType = `
+variable "prefix" { type = string }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "${var.prefix}-tmpl"
+}
+
+resource "panos_mfa_server_profile" "example" {
+  location = { template = { name = panos_template.example.name } }
+  name = var.prefix
+
+  # Config provided without vendor type should fail
+  mfa_config = [{
+    name  = "some-key"
+    value = "some-value"
+  }]
+}
+`

--- a/specs/device/profiles/mfa-server-profile.yaml
+++ b/specs/device/profiles/mfa-server-profile.yaml
@@ -1,0 +1,286 @@
+name: mfa-server-profile
+terraform_provider_config:
+  description: MFA Server Profile
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants:
+  - singular
+  suffix: mfa_server_profile
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+  custom_validation: true
+go_sdk_config:
+  skip: false
+  package:
+  - device
+  - profiles
+  - mfa
+panos_xpath:
+  path:
+  - server-profile
+  - mfa-server-profile
+  vars: []
+locations:
+- name: template-vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The vsys.
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys cannot be "shared".
+      type: entry
+  description: Located in a specific template, device and vsys.
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - shared
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+  description: A shared resource located within a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack-vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: The template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The vsys.
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys cannot be "shared".
+      type: entry
+  description: Located in a specific template, device and vsys.
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - shared
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: The template stack
+      required: true
+      validators: []
+      type: entry
+  description: Located in a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: shared
+  xpath:
+    path:
+    - config
+    - shared
+    vars: []
+  description: Panorama shared object
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: ngfw_device
+      description: The NGFW device name
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The Virtual System name
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys name cannot be "shared". Use the "shared" location instead
+      type: entry
+  description: Located in a specific Virtual System
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+spec:
+  params:
+  - name: mfa-cert-profile
+    type: string
+    profiles:
+    - xpath:
+      - mfa-cert-profile
+    validators: []
+    spec: {}
+    description: Certificate profile for verifying the MFA Vendor
+    required: false
+  - name: mfa-config
+    type: list
+    profiles:
+    - xpath:
+      - mfa-config
+      - entry
+      type: entry
+    validators: []
+    spec:
+      type: object
+      items:
+        type: object
+        spec:
+          params:
+          - name: value
+            type: string
+            profiles:
+            - xpath:
+              - value
+            validators:
+            - type: length
+              spec:
+                max: 255
+            spec: {}
+            description: ''
+            required: false
+            codegen_overrides:
+              terraform:
+                sensitive: true
+            hashing:
+              type: solo
+          variants: []
+    description: ''
+    required: false
+  - name: mfa-vendor-type
+    type: string
+    profiles:
+    - xpath:
+      - mfa-vendor-type
+    validators:
+    - type: length
+      spec:
+        max: 128
+    spec: {}
+    description: Vendor and product type
+    required: false
+  variants: []


### PR DESCRIPTION
  MFA Server Profile Resource

  Terraform Resource Name

  panos_mfa_server_profile

  Resource Variants

  - singular (default)

  Supported Locations

  - template-vsys - Located in a specific template, device and vsys
  - template - A shared resource located within a specific template
  - template-stack-vsys - Located in a specific template stack, device and vsys
  - template-stack - Located in a specific template stack
  - shared - Panorama shared object
  - vsys - Located in a specific Virtual System

  Parameters

  Parameters with Codegen Overrides

  | Parameter          | Type   | Description         | Overrides                    | Notes                                                                                       |
  |--------------------|--------|---------------------|------------------------------|---------------------------------------------------------------------------------------------|
  | mfa_config[].value | string | Missing description | sensitive: truehashing: solo | Configuration values are marked sensitive and use solo hashing for PAN-OS encrypted returns |

  Standard Parameters

  | Parameter         | Type         | Description                                      | Required        |
  |-------------------|--------------|--------------------------------------------------|-----------------|
  | name              | string       | Missing description                              | Yes (entry key) |
  | mfa_cert_profile  | string       | Certificate profile for verifying the MFA Vendor | No              |
  | mfa_config        | list(object) | Missing description                              | No              |
  | mfa_config[].name | string       | Entry key                                        | Yes (entry key) |
  | mfa_vendor_type   | string       | Vendor and product type                          | No              |

  Custom Validation

  This resource includes custom validation logic (custom_validation: true) implemented in ValidateConfigCustom:

  Vendor-Specific Configuration Validation

  The custom validator enforces strict vendor-specific configuration requirements for four supported MFA vendors:

  1. duo-security-v2 - Requires 5 configuration keys:
    - duo-api-host
    - duo-integration-key
    - duo-secret-key
    - duo-timeout
    - duo-baseuri
  2. okta-adaptive-v1 - Requires 5 configuration keys:
    - okta-api-host
    - okta-baseuri
    - okta-token
    - okta-org
    - okta-timeout
  3. ping-identity-v1 - Requires 5 configuration keys:
    - ping-api-host
    - ping-baseuri
    - ping-token
    - ping-org-alias
    - ping-timeout
  4. rsa-securid-access-v1 - Requires 6 configuration keys:
    - rsa-api-host
    - rsa-baseuri
    - rsa-accesskey
    - rsa-accessid
    - rsa-assurancepolicyid
    - rsa-timeout

  Validation Rules

  The custom validator performs the following checks at plan time:

  - Invalid vendor type: Returns an error if mfa_vendor_type is not one of the four supported vendors
  - Missing required keys: Returns an error listing all missing configuration keys required by the selected vendor
  - Invalid configuration keys: Returns an error if configuration keys from other vendors are provided
  - Config without vendor type: Returns an error if mfa_config is provided without specifying mfa_vendor_type
  - Certificate-only profiles: Allows profiles with only mfa_cert_profile set (both mfa_vendor_type and mfa_config can be omitted)

  This validation is needed because when valid mfa-vendor-type is used, PAN-OS device will return some of those list values even if they were not sent, creating inconsistency between plan and final value. By creating this validation we are enforcing that all values must be set by the user. This does mean we do not allow any defaults to be set by PAN-OS device, but that probably can't work with the way schema is defined.