### PR TITLE
feat(specs): New spec, tests and examples for panos_netflow_server_profile

### DIFF
--- a/assets/terraform/examples/resources/panos_netflow_server_profile/resource.tf
+++ b/assets/terraform/examples/resources/panos_netflow_server_profile/resource.tf
@@ -1,0 +1,28 @@
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = "example-template"
+}
+
+resource "panos_netflow_server_profile" "example" {
+  depends_on = [panos_template.example]
+  location = {
+    template = {
+      name = panos_template.example.name
+    }
+  }
+
+  name = "example-profile"
+  active_timeout = 10
+  export_enterprise_fields = true
+  servers = [
+    {
+      name = "server1",
+      host = "192.168.1.1",
+      port = 2055
+    }
+  ]
+  template_refresh_rate = {
+    minutes = 20
+    packets = 30
+  }
+}

--- a/assets/terraform/test/resource_netflow_server_profile_test.go
+++ b/assets/terraform/test/resource_netflow_server_profile_test.go
@@ -1,0 +1,256 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccNetflowServerProfile_Basic(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: netflowServerProfile_Basic_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_netflow_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_netflow_server_profile.example",
+						tfjsonpath.New("active_timeout"),
+						knownvalue.Int64Exact(10),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_netflow_server_profile.example",
+						tfjsonpath.New("export_enterprise_fields"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_netflow_server_profile.example",
+						tfjsonpath.New("servers"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name": knownvalue.StringExact("server1"),
+								"host": knownvalue.StringExact("192.168.1.1"),
+								"port": knownvalue.Int64Exact(2055),
+							}),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_netflow_server_profile.example",
+						tfjsonpath.New("template_refresh_rate"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"minutes": knownvalue.Int64Exact(20),
+							"packets": knownvalue.Int64Exact(30),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const netflowServerProfile_Basic_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_netflow_server_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  active_timeout = 10
+  export_enterprise_fields = true
+  servers = [
+    {
+      name = "server1"
+      host = "192.168.1.1"
+      port = 2055
+    }
+  ]
+  template_refresh_rate = {
+    minutes = 20
+    packets = 30
+  }
+}
+`
+
+func TestAccNetflowServerProfile_MultipleServers(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: netflowServerProfile_MultipleServers_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_netflow_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_netflow_server_profile.example",
+						tfjsonpath.New("servers"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name": knownvalue.StringExact("server1"),
+								"host": knownvalue.StringExact("192.168.1.10"),
+								"port": knownvalue.Int64Exact(2055),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"name": knownvalue.StringExact("server2"),
+								"host": knownvalue.StringExact("192.168.1.20"),
+								"port": knownvalue.Int64Exact(9996),
+							}),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const netflowServerProfile_MultipleServers_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_netflow_server_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+  servers = [
+    {
+      name = "server1"
+      host = "192.168.1.10"
+      port = 2055
+    },
+    {
+      name = "server2"
+      host = "192.168.1.20"
+      port = 9996
+    }
+  ]
+}
+`
+
+func TestAccNetflowServerProfile_MinimalConfig(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: netflowServerProfile_MinimalConfig_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":   config.StringVariable(prefix),
+					"location": location,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_netflow_server_profile.example",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(prefix),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_netflow_server_profile.example",
+						tfjsonpath.New("active_timeout"),
+						knownvalue.Int64Exact(5),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_netflow_server_profile.example",
+						tfjsonpath.New("export_enterprise_fields"),
+						knownvalue.Null(),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_netflow_server_profile.example",
+						tfjsonpath.New("servers"),
+						knownvalue.Null(),
+					),
+					statecheck.ExpectKnownValue(
+						"panos_netflow_server_profile.example",
+						tfjsonpath.New("template_refresh_rate"),
+						knownvalue.Null(),
+					),
+				},
+			},
+		},
+	})
+}
+
+const netflowServerProfile_MinimalConfig_Tmpl = `
+variable "prefix" { type = string }
+variable "location" { type = any }
+
+resource "panos_template" "example" {
+  location = { panorama = {} }
+  name = var.prefix
+}
+
+resource "panos_netflow_server_profile" "example" {
+  depends_on = [panos_template.example]
+  location = var.location
+
+  name = var.prefix
+}
+`

--- a/specs/device/profiles/netflow.yaml
+++ b/specs/device/profiles/netflow.yaml
@@ -1,0 +1,323 @@
+name: netflow-profile
+terraform_provider_config:
+  description: Netflow Server Profile
+  skip_resource: false
+  skip_datasource: false
+  resource_type: entry
+  resource_variants:
+  - singular
+  suffix: netflow_server_profile
+  plural_suffix: ''
+  plural_name: ''
+  plural_description: ''
+go_sdk_config:
+  skip: false
+  package:
+  - device
+  - profiles
+  - netflow
+panos_xpath:
+  path:
+  - server-profile
+  - netflow
+  vars: []
+locations:
+- name: vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: ngfw_device
+      description: The NGFW device name
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The Virtual System name
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys name cannot be "shared". Use the "shared" location instead
+      type: entry
+  description: Located in a specific Virtual System
+  devices:
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - shared
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+  description: A shared resource located within a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template
+    - $template
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template
+      description: Specific Panorama template
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The vsys.
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys cannot be "shared".
+      type: entry
+  description: Located in a specific template, device and vsys.
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - shared
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: The template stack
+      required: true
+      validators: []
+      type: entry
+  description: Located in a specific template
+  devices:
+  - panorama
+  validators: []
+  required: false
+  read_only: false
+- name: template-stack-vsys
+  xpath:
+    path:
+    - config
+    - devices
+    - $panorama_device
+    - template-stack
+    - $template_stack
+    - config
+    - devices
+    - $ngfw_device
+    - vsys
+    - $vsys
+    vars:
+    - name: panorama_device
+      description: Specific Panorama device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: template_stack
+      description: The template stack
+      required: true
+      validators: []
+      type: entry
+    - name: ngfw_device
+      description: The NGFW device
+      required: false
+      default: localhost.localdomain
+      validators: []
+      type: entry
+    - name: vsys
+      description: The vsys.
+      required: false
+      default: vsys1
+      validators:
+      - type: not-values
+        spec:
+          values:
+          - value: shared
+            error: The vsys cannot be "shared".
+      type: entry
+  description: Located in a specific template, device and vsys.
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
+entries:
+- name: name
+  description: ''
+  validators: []
+imports: []
+spec:
+  params:
+  - name: active-timeout
+    type: int64
+    profiles:
+    - xpath:
+      - active-timeout
+    validators:
+    - type: length
+      spec:
+        min: 1
+        max: 60
+    spec:
+      default: 5
+    description: Active timeout in minutes
+    required: false
+  - name: export-enterprise-fields
+    type: bool
+    profiles:
+    - xpath:
+      - export-enterprise-fields
+    validators: []
+    spec: {}
+    description: Export PAN-OS Specific Field Types
+    required: false
+  - name: server
+    type: list
+    profiles:
+    - xpath:
+      - server
+      - entry
+      type: entry
+    validators: []
+    spec:
+      type: object
+      items:
+        type: object
+        spec:
+          params:
+          - name: host
+            type: string
+            profiles:
+            - xpath:
+              - host
+            validators: []
+            spec: {}
+            description: Netflow server ip or host name.
+            required: false
+          - name: port
+            type: int64
+            profiles:
+            - xpath:
+              - port
+            validators:
+            - type: length
+              spec:
+                min: 1
+                max: 65535
+            spec:
+              default: 2055
+            description: Netflow server port
+            required: false
+          variants: []
+    description: ''
+    required: false
+    codegen_overrides:
+      terraform:
+        name: servers
+  - name: template-refresh-rate
+    type: object
+    profiles:
+    - xpath:
+      - template-refresh-rate
+    validators: []
+    spec:
+      params:
+      - name: minutes
+        type: int64
+        profiles:
+        - xpath:
+          - minutes
+        validators:
+        - type: length
+          spec:
+            min: 1
+            max: 3600
+        spec:
+          default: 30
+        description: ''
+        required: false
+      - name: packets
+        type: int64
+        profiles:
+        - xpath:
+          - packets
+        validators:
+        - type: length
+          spec:
+            min: 1
+            max: 600
+        spec:
+          default: 20
+        description: ''
+        required: false
+      variants: []
+    description: ''
+    required: false
+  variants: []


### PR DESCRIPTION
Terraform Resource: `panos_netflow_server_profile`

This PR adds support for managing Netflow Server Profiles in PAN-OS.

Stacked on: #638 (feat-specs-lldp-profile)