### PR TITLE
test(terraform): Add more tests and examples for panos_zone

### DIFF
--- a/assets/terraform/examples/resources/panos_zone/resource.tf
+++ b/assets/terraform/examples/resources/panos_zone/resource.tf
@@ -1,9 +1,5 @@
 
 resource "panos_zone" "zone" {
-  depends_on = [
-    panos_ethernet_interface.iface1, panos_ethernet_interface.iface2
-  ]
-
   location = {
     template = {
       name = panos_template.example.name
@@ -22,7 +18,11 @@ resource "panos_zone" "zone" {
   enable_user_identification   = true
 
   network = {
-    layer3 = ["ethernet1/1", "ethernet1/2"]
+    layer3 = [
+      panos_ethernet_interface.iface1.name,
+      panos_ethernet_interface.iface2.name,
+      panos_tunnel_interface.iface3.name,
+    ]
     enable_packet_buffer_protection = true
   }
 }
@@ -49,7 +49,6 @@ resource "panos_ethernet_interface" "iface1" {
 }
 
 resource "panos_ethernet_interface" "iface2" {
-
   location = {
     template = {
       name = panos_template.example.name
@@ -60,4 +59,14 @@ resource "panos_ethernet_interface" "iface2" {
   name = "ethernet1/2"
 
   layer3 = {}
+}
+
+resource "panos_tunnel_interface" "iface3" {
+  location = {
+    template = {
+      name = panos_template.example.name
+    }
+  }
+
+  name = "tunnel.1"
 }


### PR DESCRIPTION
Expands tests and examples for `panos_zone`, adding coverage for zone protection profile binding and additional zone configurations.

Stacked on: #576 (feat-specs-zone-protection-profiles)