### PR TITLE
fix(terraform): add shared location to syslog profile spec

### DIFF
--- a/specs/device/profiles/syslog.yaml
+++ b/specs/device/profiles/syslog.yaml
@@ -33,6 +33,19 @@ locations:
   validators: []
   required: false
   read_only: false
+- name: shared
+  xpath:
+    path:
+    - config
+    - shared
+    vars: []
+  description: Panorama shared object
+  devices:
+  - panorama
+  - ngfw
+  validators: []
+  required: false
+  read_only: false
 - name: vsys
   xpath:
     path:


### PR DESCRIPTION
Closes: PaloAltoNetworks/terraform-provider-panos#524