### PR TITLE
feat: add management setting "Managed By"

### DIFF
--- a/assets/terraform/test/resource_general_settings_test.go
+++ b/assets/terraform/test/resource_general_settings_test.go
@@ -197,6 +197,136 @@ resource "panos_ntp_settings" "example" {
 }
 `
 
+const generalSettings_PanoramaManagedBy_Tmpl = `
+variable "create_template" { type = any }
+variable "location" { type = any }
+variable "prefix" { type = string }
+variable "managed_by" { type = string }
+
+resource "panos_template" "example" {
+  count = var.create_template ? 1 : 0
+  location = { panorama = {} }
+
+  name = format("%s-tmpl", var.prefix)
+}
+
+resource "panos_general_settings" "example" {
+  depends_on = [panos_template.example]
+
+  location = var.location
+
+  panorama = {
+    managed_by = var.managed_by
+  }
+}
+`
+
+func TestAccGeneralSettings_PanoramaManagedBy_System(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"system": config.ObjectVariable(map[string]config.Variable{}),
+	})
+
+	createTemplate := config.BoolVariable(false)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: generalSettings_PanoramaManagedBy_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":          config.StringVariable(prefix),
+					"location":        location,
+					"create_template": createTemplate,
+					"managed_by":      config.StringVariable("panorama"),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_general_settings.example",
+						tfjsonpath.New("panorama").AtMapKey("managed_by"),
+						knownvalue.StringExact("panorama"),
+					),
+				},
+			},
+			{
+				Config: generalSettings_PanoramaManagedBy_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":          config.StringVariable(prefix),
+					"location":        location,
+					"create_template": createTemplate,
+					"managed_by":      config.StringVariable("cloud-service"),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_general_settings.example",
+						tfjsonpath.New("panorama").AtMapKey("managed_by"),
+						knownvalue.StringExact("cloud-service"),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestAccGeneralSettings_PanoramaManagedBy_Template(t *testing.T) {
+	t.Parallel()
+
+	nameSuffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	prefix := fmt.Sprintf("test-acc-%s", nameSuffix)
+
+	location := config.ObjectVariable(map[string]config.Variable{
+		"template": config.ObjectVariable(map[string]config.Variable{
+			"name": config.StringVariable(prefix),
+		}),
+	})
+
+	createTemplate := config.BoolVariable(true)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: generalSettings_PanoramaManagedBy_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":          config.StringVariable(prefix),
+					"location":        location,
+					"create_template": createTemplate,
+					"managed_by":      config.StringVariable("panorama"),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_general_settings.example",
+						tfjsonpath.New("panorama").AtMapKey("managed_by"),
+						knownvalue.StringExact("panorama"),
+					),
+				},
+			},
+			{
+				Config: generalSettings_PanoramaManagedBy_Tmpl,
+				ConfigVariables: map[string]config.Variable{
+					"prefix":          config.StringVariable(prefix),
+					"location":        location,
+					"create_template": createTemplate,
+					"managed_by":      config.StringVariable("cloud-service"),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_general_settings.example",
+						tfjsonpath.New("panorama").AtMapKey("managed_by"),
+						knownvalue.StringExact("cloud-service"),
+					),
+				},
+			},
+		},
+	})
+}
+
 func TestAccGeneralSettings_Sanity_Delete(t *testing.T) {
 	t.Parallel()
 

--- a/specs/device/general.yaml
+++ b/specs/device/general.yaml
@@ -1338,4 +1338,32 @@ spec:
       - value: Zulu
     description: ''
     required: false
+  - name: panorama
+    type: object
+    profiles:
+    - xpath:
+      - panorama
+    validators: []
+    spec:
+      params:
+      - name: managed-by
+        type: enum
+        profiles:
+        - xpath:
+          - managed-by
+        validators:
+        - type: values
+          spec:
+            values:
+            - panorama
+            - cloud-service
+        spec:
+          values:
+          - value: panorama
+          - value: cloud-service
+        description: Select whether device is managed by Panorama or Cloud Service
+        required: false
+      variants: []
+    description: Panorama management settings
+    required: false
   variants: []


### PR DESCRIPTION
## Description

Adding the ability to select Panorama or "Cloud Service" (aka Strata Cloud Manager).

## Motivation and Context
When provisioning a new device, it is useful to be able to pre-set the device to connect to Strata Cloud Manager or Panorama.

## How Has This Been Tested?
I tested the XPath and API queries against a VM Series and PA-440, which both worked. 

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->
- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
