### PR TITLE
feat(terraform): add panos_ip_tag resource and data source

### DIFF
--- a/assets/terraform/examples/data-sources/panos_ip_tag/data-source.tf
+++ b/assets/terraform/examples/data-sources/panos_ip_tag/data-source.tf
@@ -1,0 +1,14 @@
+# Look up every tag currently registered against an IP address.
+data "panos_ip_tag" "example" {
+  location = {
+    panorama = {}
+  }
+
+  ip = "10.0.0.1"
+}
+
+# The data source reports all tags present on the IP, regardless of whether they
+# are managed by a panos_ip_tag resource.
+output "registered_tags" {
+  value = data.panos_ip_tag.example.tags
+}

--- a/assets/terraform/examples/resources/panos_ip_tag/resource.tf
+++ b/assets/terraform/examples/resources/panos_ip_tag/resource.tf
@@ -1,0 +1,34 @@
+# Register tags on an IP directly on a firewall's virtual system.
+resource "panos_ip_tag" "vsys" {
+  location = {
+    vsys = {
+      name = "vsys1"
+    }
+  }
+
+  ip   = "10.0.0.1"
+  tags = ["web", "prod"]
+}
+
+# Register tags directly on Panorama's own User-ID table (no target firewall).
+resource "panos_ip_tag" "panorama" {
+  location = {
+    panorama = {}
+  }
+
+  ip   = "10.0.0.2"
+  tags = ["db"]
+}
+
+# Register tags on a Panorama-managed firewall, targeted by serial number.
+resource "panos_ip_tag" "target_device" {
+  location = {
+    target_device = {
+      serial = "0123456789"
+      vsys   = "vsys1"
+    }
+  }
+
+  ip   = "10.0.0.3"
+  tags = ["dmz"]
+}

--- a/assets/terraform/internal/provider/ip_tag_crud.go
+++ b/assets/terraform/internal/provider/ip_tag_crud.go
@@ -1,0 +1,515 @@
+package provider
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+
+	"github.com/PaloAltoNetworks/pango"
+	"github.com/PaloAltoNetworks/pango/xmlapi"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// ipTagUidMessage is the type=user-id payload that registers or unregisters
+// tags against an IP address. Exactly one of Register/Unregister is set.
+type ipTagUidMessage struct {
+	XMLName    xml.Name      `xml:"uid-message"`
+	Version    string        `xml:"version"`
+	Type       string        `xml:"type"`
+	Register   *ipTagPayload `xml:"payload>register,omitempty"`
+	Unregister *ipTagPayload `xml:"payload>unregister,omitempty"`
+}
+
+type ipTagPayload struct {
+	Entries []ipTagEntry `xml:"entry"`
+}
+
+type ipTagEntry struct {
+	Ip   string   `xml:"ip,attr"`
+	Tags []string `xml:"tag>member"`
+}
+
+// registerIpTagCommand builds a user-id message that registers tags on an IP.
+func registerIpTagCommand(ip string, tags []string) ipTagUidMessage {
+	return ipTagUidMessage{
+		Version:  "1.0",
+		Type:     "update",
+		Register: &ipTagPayload{Entries: []ipTagEntry{{Ip: ip, Tags: tags}}},
+	}
+}
+
+// unregisterIpTagCommand builds a user-id message that removes tags from an IP.
+func unregisterIpTagCommand(ip string, tags []string) ipTagUidMessage {
+	return ipTagUidMessage{
+		Version:    "1.0",
+		Type:       "update",
+		Unregister: &ipTagPayload{Entries: []ipTagEntry{{Ip: ip, Tags: tags}}},
+	}
+}
+
+// registeredIpPageLimit is the maximum number of registered-ip entries PAN-OS
+// returns per page; the read loop pages through results using start-point.
+const registeredIpPageLimit = 500
+
+// ipTagShowRequest is the type=op command that lists registered IP/tag mappings
+// (PAN-OS 8.0+ paginated form).
+type ipTagShowRequest struct {
+	XMLName xml.Name        `xml:"show"`
+	Filter  ipTagShowFilter `xml:"object>registered-ip"`
+}
+
+type ipTagShowFilter struct {
+	Tag   *ipTagShowTagFilter `xml:"tag,omitempty"`
+	Ip    string              `xml:"ip,omitempty"`
+	Limit int                 `xml:"limit"`
+	Start int                 `xml:"start-point"`
+}
+
+type ipTagShowTagFilter struct {
+	Entry ipTagShowTagName `xml:"entry"`
+}
+
+type ipTagShowTagName struct {
+	Name string `xml:"name,attr"`
+}
+
+// registeredIpRequest builds a single page of a registered-ip query. Both
+// ipFilter and tagFilter are optional server-side filters; startPoint is the
+// 1-based index of the first entry to return.
+func registeredIpRequest(ipFilter, tagFilter string, startPoint int) ipTagShowRequest {
+	req := ipTagShowRequest{}
+	req.Filter.Ip = ipFilter
+	req.Filter.Limit = registeredIpPageLimit
+	req.Filter.Start = startPoint
+	if tagFilter != "" {
+		req.Filter.Tag = &ipTagShowTagFilter{Entry: ipTagShowTagName{Name: tagFilter}}
+	}
+	return req
+}
+
+// ipTagShowResponse decodes a registered-ip op response. The outfile path is
+// only populated by pre-8.0 PAN-OS, which dumps results to a file instead of
+// returning them inline; we treat that as an unsupported response shape.
+type ipTagShowResponse struct {
+	Entries []ipTagRespEntry `xml:"result>entry"`
+	Outfile string           `xml:"result>msg>line>outfile"`
+}
+
+type ipTagRespEntry struct {
+	Ip   string   `xml:"ip,attr"`
+	Tags []string `xml:"tag>member"`
+}
+
+// toMap converts a decoded response into an IP→tags map, guarding against the
+// pre-8.0 outfile response shape.
+func (r ipTagShowResponse) toMap() (map[string][]string, error) {
+	if r.Outfile != "" {
+		return nil, fmt.Errorf("PAN-OS returned an outfile (%q) instead of registered-ip entries; PAN-OS 10.1+ is required", r.Outfile)
+	}
+
+	ans := make(map[string][]string, len(r.Entries))
+	for _, entry := range r.Entries {
+		ans[entry.Ip] = entry.Tags
+	}
+	return ans, nil
+}
+
+// parseRegisteredIpResponse decodes raw registered-ip op response bytes into an
+// IP→tags map.
+func parseRegisteredIpResponse(body []byte) (map[string][]string, error) {
+	var resp ipTagShowResponse
+	if err := xml.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+	return resp.toMap()
+}
+
+// pageFetcher returns a single page of registered-ip entries starting at the
+// given 1-based start point. The IO layer backs this with a Communicate call.
+type pageFetcher func(startPoint int) ([]ipTagRespEntry, error)
+
+// collectRegisteredIps pages through registered-ip entries until a page shorter
+// than pageLimit is returned, assembling them into a single IP→tags map.
+func collectRegisteredIps(fetch pageFetcher, pageLimit int) (map[string][]string, error) {
+	ans := make(map[string][]string)
+
+	start := 1
+	for {
+		entries, err := fetch(start)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, entry := range entries {
+			ans[entry.Ip] = entry.Tags
+		}
+
+		if len(entries) < pageLimit {
+			break
+		}
+		start += len(entries)
+	}
+
+	return ans, nil
+}
+
+type IpTagCustom struct{}
+
+// tagSetDiff compares the current set of tags registered against an IP with the
+// desired set, returning the tags that must be registered (in desired but not
+// current) and unregistered (in current but not desired).
+func tagSetDiff(current, desired []string) (toAdd, toRemove []string) {
+	currentSet := make(map[string]struct{}, len(current))
+	for _, tag := range current {
+		currentSet[tag] = struct{}{}
+	}
+
+	desiredSet := make(map[string]struct{}, len(desired))
+	for _, tag := range desired {
+		desiredSet[tag] = struct{}{}
+	}
+
+	for tag := range desiredSet {
+		if _, ok := currentSet[tag]; !ok {
+			toAdd = append(toAdd, tag)
+		}
+	}
+
+	for tag := range currentSet {
+		if _, ok := desiredSet[tag]; !ok {
+			toRemove = append(toRemove, tag)
+		}
+	}
+
+	return toAdd, toRemove
+}
+
+func NewIpTagCustom(provider *ProviderData) (*IpTagCustom, error) {
+	return &IpTagCustom{}, nil
+}
+
+// ReadCustom looks up every tag currently registered against the configured IP
+// at the configured location. Unlike the resource, the data source has no notion
+// of "managed" tags: it reports all tags present on the IP.
+func (o *IpTagDataSource) ReadCustom(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data IpTagDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	vsys, target, diags := resolveIpTagLocation(ctx, data.Location)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ip := data.Ip.ValueString()
+	if ip == "" {
+		resp.Diagnostics.AddError("Invalid configuration", "'ip' must be set to the IP address to look up")
+		return
+	}
+
+	present, err := registeredTagsForIp(ctx, o.client, vsys, target, ip)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read registered IP tags", err.Error())
+		return
+	}
+
+	// Report every tag registered on the IP. An IP with no tags yields an empty
+	// set rather than an error, so callers can detect "nothing registered".
+	tagsValue, diags := types.SetValueFrom(ctx, types.StringType, present)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.Tags = tagsValue
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// reconcileManagedTags returns the subset of managed tags that are still
+// present on the firewall. Tags present on the IP but not managed by this
+// resource are ignored. An empty result means the resource no longer owns any
+// tags on this IP and should be removed from state.
+func reconcileManagedTags(managed, present []string) []string {
+	presentSet := make(map[string]struct{}, len(present))
+	for _, tag := range present {
+		presentSet[tag] = struct{}{}
+	}
+
+	var result []string
+	for _, tag := range managed {
+		if _, ok := presentSet[tag]; ok {
+			result = append(result, tag)
+		}
+	}
+
+	return result
+}
+
+// resolveIpTagLocation maps an ip_tag location into the vsys and target
+// (Panorama-managed firewall serial) used by the user-id/op API calls. The
+// location xpath is vestigial for this runtime resource/data source; only these
+// two values matter. It is shared by both the resource and the data source.
+func resolveIpTagLocation(ctx context.Context, locationObj types.Object) (vsys string, target string, diags diag.Diagnostics) {
+	var loc IpTagLocation
+	diags.Append(locationObj.As(ctx, &loc, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return "", "", diags
+	}
+
+	switch {
+	case !loc.Vsys.IsNull() && !loc.Vsys.IsUnknown():
+		var vsysLoc IpTagVsysLocation
+		diags.Append(loc.Vsys.As(ctx, &vsysLoc, basetypes.ObjectAsOptions{})...)
+		// The vsys name attribute is generated as "name" (provider-wide
+		// convention), not "vsys".
+		vsys = vsysLoc.Name.ValueString()
+	case !loc.Panorama.IsNull() && !loc.Panorama.IsUnknown():
+		// Registered directly on Panorama: no vsys, no target firewall.
+	case !loc.TargetDevice.IsNull() && !loc.TargetDevice.IsUnknown():
+		var targetLoc IpTagTargetDeviceLocation
+		diags.Append(loc.TargetDevice.As(ctx, &targetLoc, basetypes.ObjectAsOptions{})...)
+		vsys = targetLoc.Vsys.ValueString()
+		target = targetLoc.Serial.ValueString()
+		if target == "" {
+			diags.AddError("Invalid location", "'target_device.serial' must be set to the serial number of the managed firewall")
+		}
+	default:
+		diags.AddError("Invalid location", "Exactly one of 'vsys' or 'target_device' must be set")
+	}
+
+	return vsys, target, diags
+}
+
+// tagsFromSet reads a terraform string set into a plain slice.
+func tagsFromSet(ctx context.Context, set types.Set) ([]string, diag.Diagnostics) {
+	var tags []string
+	diags := set.ElementsAs(ctx, &tags, false)
+	return tags, diags
+}
+
+// sendUserId sends a register/unregister user-id message to PAN-OS.
+func (o *IpTagResource) sendUserId(ctx context.Context, vsys, target string, msg ipTagUidMessage) error {
+	cmd := &xmlapi.UserId{
+		Command: msg,
+		Vsys:    vsys,
+		Target:  target,
+	}
+	_, _, err := o.client.Communicate(ctx, cmd, false, nil)
+	return err
+}
+
+// registeredTagsForIp returns the tags currently registered against ip,
+// paging through the registered-ip table as needed. It is shared by both the
+// resource and the data source.
+func registeredTagsForIp(ctx context.Context, client *pango.Client, vsys, target, ip string) ([]string, error) {
+	fetch := func(startPoint int) ([]ipTagRespEntry, error) {
+		cmd := &xmlapi.Op{
+			Command: registeredIpRequest(ip, "", startPoint),
+			Vsys:    vsys,
+			Target:  target,
+		}
+
+		var resp ipTagShowResponse
+		if _, _, err := client.Communicate(ctx, cmd, false, &resp); err != nil {
+			return nil, err
+		}
+		if resp.Outfile != "" {
+			return nil, fmt.Errorf("PAN-OS returned an outfile (%q) instead of registered-ip entries; PAN-OS 10.1+ is required", resp.Outfile)
+		}
+		return resp.Entries, nil
+	}
+
+	all, err := collectRegisteredIps(fetch, registeredIpPageLimit)
+	if err != nil {
+		return nil, err
+	}
+	return all[ip], nil
+}
+
+func (o *IpTagResource) CreateCustom(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data IpTagResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	vsys, target, diags := resolveIpTagLocation(ctx, data.Location)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tags, diags := tagsFromSet(ctx, data.Tags)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if len(tags) == 0 {
+		resp.Diagnostics.AddError("Invalid configuration", "At least one tag must be specified")
+		return
+	}
+
+	// Registering is additive and idempotent: re-registering an existing tag is
+	// a no-op, and tags already on the IP that we don't manage are untouched.
+	ip := data.Ip.ValueString()
+	if err := o.sendUserId(ctx, vsys, target, registerIpTagCommand(ip, tags)); err != nil {
+		resp.Diagnostics.AddError("Failed to register IP tags", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (o *IpTagResource) ReadCustom(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data IpTagResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	vsys, target, diags := resolveIpTagLocation(ctx, data.Location)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	managed, diags := tagsFromSet(ctx, data.Tags)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ip := data.Ip.ValueString()
+	present, err := registeredTagsForIp(ctx, o.client, vsys, target, ip)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read registered IP tags", err.Error())
+		return
+	}
+
+	// State reflects only the managed tags still present on the firewall; tags
+	// we don't manage are ignored. If none remain, the resource is gone.
+	reconciled := reconcileManagedTags(managed, present)
+	if len(reconciled) == 0 {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	tagsValue, diags := types.SetValueFrom(ctx, types.StringType, reconciled)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.Tags = tagsValue
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (o *IpTagResource) UpdateCustom(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan IpTagResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	var state IpTagResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	vsys, target, diags := resolveIpTagLocation(ctx, plan.Location)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	newTags, diags := tagsFromSet(ctx, plan.Tags)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if len(newTags) == 0 {
+		resp.Diagnostics.AddError("Invalid configuration", "At least one tag must be specified")
+		return
+	}
+
+	oldTags, diags := tagsFromSet(ctx, state.Tags)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	newIp := plan.Ip.ValueString()
+	oldIp := state.Ip.ValueString()
+
+	if oldIp != newIp {
+		// The IP cannot be marked RequiresReplace via the spec, so handle a
+		// change here: move all managed tags from the old IP to the new one.
+		if len(oldTags) > 0 {
+			if err := o.sendUserId(ctx, vsys, target, unregisterIpTagCommand(oldIp, oldTags)); err != nil {
+				resp.Diagnostics.AddError("Failed to unregister IP tags from previous IP", err.Error())
+				return
+			}
+		}
+		if err := o.sendUserId(ctx, vsys, target, registerIpTagCommand(newIp, newTags)); err != nil {
+			resp.Diagnostics.AddError("Failed to register IP tags", err.Error())
+			return
+		}
+	} else {
+		toAdd, toRemove := tagSetDiff(oldTags, newTags)
+		if len(toAdd) > 0 {
+			if err := o.sendUserId(ctx, vsys, target, registerIpTagCommand(newIp, toAdd)); err != nil {
+				resp.Diagnostics.AddError("Failed to register IP tags", err.Error())
+				return
+			}
+		}
+		if len(toRemove) > 0 {
+			if err := o.sendUserId(ctx, vsys, target, unregisterIpTagCommand(newIp, toRemove)); err != nil {
+				resp.Diagnostics.AddError("Failed to unregister IP tags", err.Error())
+				return
+			}
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (o *IpTagResource) DeleteCustom(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data IpTagResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	vsys, target, diags := resolveIpTagLocation(ctx, data.Location)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	managed, diags := tagsFromSet(ctx, data.Tags)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ip := data.Ip.ValueString()
+	present, err := registeredTagsForIp(ctx, o.client, vsys, target, ip)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read registered IP tags", err.Error())
+		return
+	}
+
+	// Only unregister the managed tags that are still present, leaving any
+	// tags we don't own (including overlapping ones from other resources) be.
+	stillOurs := reconcileManagedTags(managed, present)
+	if len(stillOurs) > 0 {
+		if err := o.sendUserId(ctx, vsys, target, unregisterIpTagCommand(ip, stillOurs)); err != nil {
+			resp.Diagnostics.AddError("Failed to unregister IP tags", err.Error())
+			return
+		}
+	}
+}

--- a/assets/terraform/internal/provider/ip_tag_crud_test.go
+++ b/assets/terraform/internal/provider/ip_tag_crud_test.go
@@ -1,0 +1,220 @@
+package provider
+
+import (
+	"encoding/xml"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ip_tag tagSetDiff", func() {
+	Context("when the desired set adds and removes tags relative to current", func() {
+		It("returns the additions and removals", func() {
+			toAdd, toRemove := tagSetDiff([]string{"web", "db"}, []string{"web", "prod"})
+
+			Expect(toAdd).To(ConsistOf("prod"))
+			Expect(toRemove).To(ConsistOf("db"))
+		})
+	})
+
+	Context("when the desired set only adds tags", func() {
+		It("returns additions and no removals", func() {
+			toAdd, toRemove := tagSetDiff([]string{"web"}, []string{"web", "prod"})
+
+			Expect(toAdd).To(ConsistOf("prod"))
+			Expect(toRemove).To(BeEmpty())
+		})
+	})
+
+	Context("when the desired set only removes tags", func() {
+		It("returns removals and no additions", func() {
+			toAdd, toRemove := tagSetDiff([]string{"web", "db"}, []string{"web"})
+
+			Expect(toAdd).To(BeEmpty())
+			Expect(toRemove).To(ConsistOf("db"))
+		})
+	})
+
+	Context("when current and desired are identical", func() {
+		It("returns no changes", func() {
+			toAdd, toRemove := tagSetDiff([]string{"web", "db"}, []string{"db", "web"})
+
+			Expect(toAdd).To(BeEmpty())
+			Expect(toRemove).To(BeEmpty())
+		})
+	})
+
+	Context("when inputs contain duplicates", func() {
+		It("treats them as sets and does not emit duplicates", func() {
+			toAdd, toRemove := tagSetDiff([]string{"web", "web"}, []string{"prod", "prod"})
+
+			Expect(toAdd).To(ConsistOf("prod"))
+			Expect(toRemove).To(ConsistOf("web"))
+		})
+	})
+})
+
+var _ = Describe("ip_tag reconcileManagedTags", func() {
+	Context("when some managed tags drifted away and unmanaged tags are present", func() {
+		It("keeps only managed tags still present on the firewall", func() {
+			// Managed {web,prod}; firewall has {web,db}: prod drifted away, db is
+			// unmanaged. State should reconcile to {web}.
+			result := reconcileManagedTags([]string{"web", "prod"}, []string{"web", "db"})
+
+			Expect(result).To(ConsistOf("web"))
+		})
+	})
+
+	Context("when none of the managed tags are present", func() {
+		It("returns an empty set", func() {
+			result := reconcileManagedTags([]string{"web", "prod"}, []string{"db"})
+
+			Expect(result).To(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("ip_tag user-id command marshaling", func() {
+	Context("when registering tags on an IP", func() {
+		It("marshals a uid-message with a register payload", func() {
+			out, err := xml.Marshal(registerIpTagCommand("1.1.1.1", []string{"web", "prod"}))
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(out)).To(Equal(
+				`<uid-message><version>1.0</version><type>update</type>` +
+					`<payload><register><entry ip="1.1.1.1">` +
+					`<tag><member>web</member><member>prod</member></tag>` +
+					`</entry></register></payload></uid-message>`))
+		})
+	})
+
+	Context("when unregistering tags from an IP", func() {
+		It("marshals a uid-message with an unregister payload", func() {
+			out, err := xml.Marshal(unregisterIpTagCommand("1.1.1.1", []string{"db"}))
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(out)).To(Equal(
+				`<uid-message><version>1.0</version><type>update</type>` +
+					`<payload><unregister><entry ip="1.1.1.1">` +
+					`<tag><member>db</member></tag>` +
+					`</entry></unregister></payload></uid-message>`))
+		})
+	})
+})
+
+var _ = Describe("ip_tag registered-ip request marshaling", func() {
+	Context("when filtering by IP only", func() {
+		It("marshals a paginated show request with a 500 page limit", func() {
+			out, err := xml.Marshal(registeredIpRequest("1.1.1.1", "", 1))
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(out)).To(Equal(
+				`<show><object><registered-ip>` +
+					`<ip>1.1.1.1</ip><limit>500</limit><start-point>1</start-point>` +
+					`</registered-ip></object></show>`))
+		})
+	})
+
+	Context("when filtering by both IP and tag", func() {
+		It("includes a tag entry filter and the requested start point", func() {
+			out, err := xml.Marshal(registeredIpRequest("1.1.1.1", "web", 501))
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(out)).To(Equal(
+				`<show><object><registered-ip>` +
+					`<tag><entry name="web"></entry></tag>` +
+					`<ip>1.1.1.1</ip><limit>500</limit><start-point>501</start-point>` +
+					`</registered-ip></object></show>`))
+		})
+	})
+})
+
+var _ = Describe("ip_tag parseRegisteredIpResponse", func() {
+	Context("when PAN-OS returns registered IP entries", func() {
+		It("parses each IP with its members into a map", func() {
+			body := []byte(`<response status="success"><result>` +
+				`<entry ip="1.1.1.1"><tag><member>web</member><member>db</member></tag></entry>` +
+				`<entry ip="2.2.2.2"><tag><member>prod</member></tag></entry>` +
+				`</result></response>`)
+
+			result, err := parseRegisteredIpResponse(body)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(2))
+			Expect(result["1.1.1.1"]).To(ConsistOf("web", "db"))
+			Expect(result["2.2.2.2"]).To(ConsistOf("prod"))
+		})
+	})
+
+	Context("when PAN-OS returns an outfile instead of entries", func() {
+		It("returns an error pointing at the unsupported response shape", func() {
+			body := []byte(`<response status="success"><result>` +
+				`<msg><line><outfile>regip.txt</outfile></line></msg>` +
+				`</result></response>`)
+
+			_, err := parseRegisteredIpResponse(body)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("outfile"))
+		})
+	})
+})
+
+var _ = Describe("ip_tag collectRegisteredIps pagination", func() {
+	Context("when the first page is already shorter than the page limit", func() {
+		It("returns that page and stops after one fetch", func() {
+			var starts []int
+			fetch := func(startPoint int) ([]ipTagRespEntry, error) {
+				starts = append(starts, startPoint)
+				return []ipTagRespEntry{{Ip: "1.1.1.1", Tags: []string{"web"}}}, nil
+			}
+
+			result, err := collectRegisteredIps(fetch, 2)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(starts).To(Equal([]int{1}))
+			Expect(result["1.1.1.1"]).To(ConsistOf("web"))
+		})
+	})
+
+	Context("when a full page is followed by a short page", func() {
+		It("assembles entries across pages and advances the start point", func() {
+			pages := map[int][]ipTagRespEntry{
+				1: {{Ip: "1.1.1.1", Tags: []string{"a"}}, {Ip: "2.2.2.2", Tags: []string{"b"}}},
+				3: {{Ip: "3.3.3.3", Tags: []string{"c"}}},
+			}
+			var starts []int
+			fetch := func(startPoint int) ([]ipTagRespEntry, error) {
+				starts = append(starts, startPoint)
+				return pages[startPoint], nil
+			}
+
+			result, err := collectRegisteredIps(fetch, 2)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(starts).To(Equal([]int{1, 3}))
+			Expect(result).To(HaveLen(3))
+			Expect(result["3.3.3.3"]).To(ConsistOf("c"))
+		})
+	})
+
+	Context("when a full page is followed by an empty page", func() {
+		It("stops after the empty page without losing earlier entries", func() {
+			pages := map[int][]ipTagRespEntry{
+				1: {{Ip: "1.1.1.1", Tags: []string{"a"}}, {Ip: "2.2.2.2", Tags: []string{"b"}}},
+				3: {},
+			}
+			var starts []int
+			fetch := func(startPoint int) ([]ipTagRespEntry, error) {
+				starts = append(starts, startPoint)
+				return pages[startPoint], nil
+			}
+
+			result, err := collectRegisteredIps(fetch, 2)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(starts).To(Equal([]int{1, 3}))
+			Expect(result).To(HaveLen(2))
+		})
+	})
+})

--- a/assets/terraform/templates/data-sources/ip_tag.md.tmpl
+++ b/assets/terraform/templates/data-sources/ip_tag.md.tmpl
@@ -1,0 +1,23 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
+subcategory: "Objects"
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# {{.Name}} ({{.Type}})
+
+{{ .Description | trimspace }}
+
+This data source returns **every** tag currently registered against the given IP
+address in the firewall's User-ID table — both tags managed by a `panos_ip_tag`
+resource and tags registered by any other means. An IP with no registered tags
+yields an empty set.
+
+{{ if .HasExample -}}
+## Example Usage
+
+{{ tffile .ExampleFile }}
+{{- end }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/assets/terraform/templates/resources/ip_tag.md.tmpl
+++ b/assets/terraform/templates/resources/ip_tag.md.tmpl
@@ -1,0 +1,52 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
+subcategory: "Objects"
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# {{.Name}} ({{.Type}})
+
+{{ .Description | trimspace }}
+
+This resource registers a set of dynamic tags against an IP address through the
+PAN-OS User-ID API. It manages *only* the tags it declares: tags registered on
+the same IP by other means (other resources, the User-ID agent, scripts) are
+left untouched. Registration is non-destructive and idempotent.
+
+~> **Runtime, not configuration.** Dynamic IP-to-tag registrations live in the
+firewall's User-ID table, not in the candidate config, so this resource does
+**not** require a commit and is **not** importable. Adopt an existing
+registration simply by declaring it and running `terraform apply` — re-registering
+tags that are already present is a no-op.
+
+{{ if .HasExample -}}
+## Example Usage
+
+{{ tffile .ExampleFile }}
+{{- end }}
+
+## Drift Reconciliation
+
+On every read the provider intersects the tags it manages with the tags actually
+present on the firewall, and stores only that intersection in state. Tags it does
+not manage are ignored entirely.
+
+For example, if this resource manages `{web, prod}` but the firewall reports
+`{web, db}` for the IP:
+
+* `web` is kept — it is managed and present.
+* `prod` drifted away (someone unregistered it) — it is dropped from state and
+  re-registered on the next `terraform apply`.
+* `db` is unmanaged — it is ignored, never added to state, and never removed.
+
+If none of the managed tags remain on the IP, the resource is removed from state.
+
+## Limitations
+
+-> **Overlapping ownership.** The firewall has no reference counting for
+registered tags. If two `panos_ip_tag` resources (or two configurations) register
+the *same* tag on the *same* IP, deleting either one unregisters that shared tag,
+affecting the other. Avoid declaring the same IP+tag pair from more than one place.
+
+{{ .SchemaMarkdown | trimspace }}

--- a/assets/terraform/test/resource_ip_tag_test.go
+++ b/assets/terraform/test/resource_ip_tag_test.go
@@ -1,0 +1,214 @@
+package provider_test
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/PaloAltoNetworks/pango/xmlapi"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+// The IPs we register tags against. 192.0.2.0/24 is TEST-NET-1 (RFC 5737),
+// reserved for documentation/testing, so it is safe to use on a live device.
+// Each test uses a distinct address so the parallel suites don't collide: the
+// data source reports every tag present on an IP, so a shared address would let
+// one test observe another's registrations.
+const (
+	testAccIpTagAddress           = "192.0.2.1"
+	testAccIpTagDataSourceAddress = "192.0.2.2"
+)
+
+func testAccIpTagPreCheck(t *testing.T) {
+	if os.Getenv("PANOS_HOSTNAME") == "" {
+		t.Fatal("PANOS_HOSTNAME must be set for acceptance tests")
+	}
+}
+
+// TestAccIpTag exercises the panorama location: tags registered directly on
+// Panorama's own User-ID table (no target firewall).
+func TestAccIpTag(t *testing.T) {
+	t.Parallel()
+
+	suffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	webTag := fmt.Sprintf("test-acc-%s-web", suffix)
+	dbTag := fmt.Sprintf("test-acc-%s-db", suffix)
+	prodTag := fmt.Sprintf("test-acc-%s-prod", suffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccIpTagPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccIpTagCheckDestroy(testAccIpTagAddress, []string{webTag, dbTag, prodTag}),
+		Steps: []resource.TestStep{
+			{
+				// Create: register {web, db}.
+				Config: testAccIpTagTmpl,
+				ConfigVariables: config.Variables{
+					"ip": config.StringVariable(testAccIpTagAddress),
+					"tags": config.SetVariable(
+						config.StringVariable(webTag),
+						config.StringVariable(dbTag),
+					),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_ip_tag.test",
+						tfjsonpath.New("tags"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact(webTag),
+							knownvalue.StringExact(dbTag),
+						}),
+					),
+				},
+			},
+			{
+				// Update: {web, db} -> {web, prod}. Registers prod, unregisters db.
+				Config: testAccIpTagTmpl,
+				ConfigVariables: config.Variables{
+					"ip": config.StringVariable(testAccIpTagAddress),
+					"tags": config.SetVariable(
+						config.StringVariable(webTag),
+						config.StringVariable(prodTag),
+					),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"panos_ip_tag.test",
+						tfjsonpath.New("tags"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact(webTag),
+							knownvalue.StringExact(prodTag),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const testAccIpTagTmpl = `
+variable "ip" { type = string }
+variable "tags" { type = set(string) }
+
+resource "panos_ip_tag" "test" {
+  location = { panorama = {} }
+
+  ip   = var.ip
+  tags = var.tags
+}
+`
+
+// TestAccIpTagDataSource registers tags via the resource and reads them back
+// through the data source, asserting the data source reports every tag present
+// on the IP.
+func TestAccIpTagDataSource(t *testing.T) {
+	t.Parallel()
+
+	suffix := acctest.RandStringFromCharSet(6, acctest.CharSetAlphaNum)
+	webTag := fmt.Sprintf("test-acc-%s-web", suffix)
+	dbTag := fmt.Sprintf("test-acc-%s-db", suffix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccIpTagPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders,
+		CheckDestroy:             testAccIpTagCheckDestroy(testAccIpTagDataSourceAddress, []string{webTag, dbTag}),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIpTagDataSourceTmpl,
+				ConfigVariables: config.Variables{
+					"ip": config.StringVariable(testAccIpTagDataSourceAddress),
+					"tags": config.SetVariable(
+						config.StringVariable(webTag),
+						config.StringVariable(dbTag),
+					),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"data.panos_ip_tag.test",
+						tfjsonpath.New("tags"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact(webTag),
+							knownvalue.StringExact(dbTag),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+const testAccIpTagDataSourceTmpl = `
+variable "ip" { type = string }
+variable "tags" { type = set(string) }
+
+resource "panos_ip_tag" "test" {
+  location = { panorama = {} }
+
+  ip   = var.ip
+  tags = var.tags
+}
+
+data "panos_ip_tag" "test" {
+  location = { panorama = {} }
+
+  ip = panos_ip_tag.test.ip
+}
+`
+
+// testAccIpTagCheckDestroy queries Panorama's registered-ip table and fails if
+// any of the test's managed tags are still present on the given IP.
+func testAccIpTagCheckDestroy(ip string, managedTags []string) func(*terraform.State) error {
+	return func(_ *terraform.State) error {
+		type respEntry struct {
+			Ip   string   `xml:"ip,attr"`
+			Tags []string `xml:"tag>member"`
+		}
+		type showFilter struct {
+			Ip    string `xml:"ip,omitempty"`
+			Limit int    `xml:"limit"`
+			Start int    `xml:"start-point"`
+		}
+		type showReq struct {
+			XMLName xml.Name   `xml:"show"`
+			Filter  showFilter `xml:"object>registered-ip"`
+		}
+		type showResp struct {
+			Entries []respEntry `xml:"result>entry"`
+		}
+
+		cmd := &xmlapi.Op{
+			Command: showReq{Filter: showFilter{Ip: ip, Limit: 500, Start: 1}},
+		}
+
+		var resp showResp
+		if _, _, err := sdkClient.Communicate(context.TODO(), cmd, false, &resp); err != nil {
+			return fmt.Errorf("failed to query registered-ip table: %w", err)
+		}
+
+		managed := make(map[string]struct{}, len(managedTags))
+		for _, tag := range managedTags {
+			managed[tag] = struct{}{}
+		}
+
+		for _, entry := range resp.Entries {
+			if entry.Ip != ip {
+				continue
+			}
+			for _, tag := range entry.Tags {
+				if _, ok := managed[tag]; ok {
+					return fmt.Errorf("tag %q is still registered on %s after destroy", tag, ip)
+				}
+			}
+		}
+
+		return nil
+	}
+}

--- a/specs/objects/ip-tag.yaml
+++ b/specs/objects/ip-tag.yaml
@@ -1,0 +1,93 @@
+name: "IP Tag"
+terraform_provider_config:
+  description: "Dynamic IP-to-tag registration"
+  resource_type: custom
+  suffix: "ip_tag"
+  custom_functions:
+    Create: true
+    Read: true
+    Update: true
+    Delete: true
+go_sdk_config:
+  skip: true
+  package: ["ip_tag"]
+panos_xpath:
+  path:
+    - registered-ip
+locations:
+  - name: "vsys"
+    description: "Located in a specific Virtual System on an NGFW."
+    devices:
+      - ngfw
+    xpath:
+      path:
+        - "config"
+        - "devices"
+        - "$ngfw_device"
+        - "vsys"
+        - "$vsys"
+      vars:
+        - name: "ngfw_device"
+          description: "The NGFW device name."
+          required: false
+          default: "localhost.localdomain"
+          type: entry
+        - name: "vsys"
+          description: "The Virtual System name."
+          required: false
+          default: "vsys1"
+          type: entry
+  - name: "panorama"
+    description: "Registered directly on Panorama's own User-ID table (no target firewall)."
+    devices:
+      - panorama
+    xpath:
+      path:
+        - "config"
+        - "shared"
+      vars: []
+  - name: "target-device"
+    description: "A firewall managed by Panorama, targeted by serial number."
+    devices:
+      - panorama
+    xpath:
+      path:
+        - "config"
+        - "devices"
+        - "$serial"
+        - "vsys"
+        - "$vsys"
+      vars:
+        - name: "serial"
+          description: "The serial number of the Panorama-managed firewall."
+          required: true
+          type: entry
+        - name: "vsys"
+          description: "The Virtual System name."
+          required: false
+          default: "vsys1"
+          type: entry
+version: "10.1.0"
+spec:
+  params:
+    - name: ip
+      type: string
+      description: "The IP address to register tags against."
+      required: true
+      profiles:
+        - xpath: ["ip"]
+    - name: tags
+      type: list
+      description: "The set of tags to register against the IP address."
+      required: true
+      profiles:
+        - xpath: ["tag", "member"]
+          type: member
+      spec:
+        type: string
+        items:
+          type: string
+      codegen_overrides:
+        terraform:
+          type: set
+          name: tags


### PR DESCRIPTION
## Summary

Adds a custom **resource** and **data source** for PAN-OS dynamic IP-to-tag registration via the User-ID API. These registrations live in the firewall's User-ID table (runtime state), not the candidate config — so there is **no commit** and the resource is **not importable** (adopt by declaring and applying; registration is idempotent).

### `panos_ip_tag` resource
- Registers a managed set of tags against an IP. Non-destructive and idempotent — re-registering existing tags is a no-op, and tags it does not manage are never touched.
- Real Update: registers added tags, unregisters removed tags; an IP change moves the managed tags from old to new.
- Drift reconciliation: state holds only managed tags still present on the firewall; the resource is removed from state when none remain.
- Three locations: `vsys` (NGFW), `panorama` (Panorama's own User-ID table), `target_device` (Panorama-managed firewall by serial).

### `panos_ip_tag` data source
- Single-IP lookup: given a `location` and `ip`, returns **every** tag currently registered on that IP (empty set if none).

### Docs
- Custom tfplugindocs templates carrying the drift-reconciliation walkthrough and the overlap-ownership limitation (the firewall has no refcount, so two resources owning the same IP+tag will interfere on delete).
- Examples for all three resource locations and the data source.

## Design note
The data source is a single-IP lookup rather than a filtered listing (ip/tag filters → entries + total). A listing shape isn't expressible in this codegen: a custom data source's model is fixed to the spec params, a fully hand-written data source can't be registered (the provider's `DataSources()` list is generated), and there's no datasource-only param override. The single-IP lookup is the codegen-native shape.

## Testing
- **Unit** (white-box Ginkgo): tag-set diff, register/unregister XML marshaling, paginated registered-ip response parsing + multi-page assembly.
- **Acceptance** (`TF_ACC`, live-verified against Panorama): resource create → update-tags → delete with `CheckDestroy`, and the data-source read. Both passing live.

## Notes for reviewers
A self-review surfaced several non-blocking cleanup/test-quality items to revisit in follow-ups (e.g. the live read path bypasses the unit-tested `toMap`/`parseRegisteredIpResponse` decode path; `CheckDestroy` doesn't paginate; dead `tagFilter` param; concrete `*pango.Client` vs the `util.PangoClient` convention). None affect correctness of the shipped behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)